### PR TITLE
fix: add cryptographic validation to deserializeEd25519Keypair

### DIFF
--- a/packages/identity/supabase/src/__tests__/keypair-validation.test.ts
+++ b/packages/identity/supabase/src/__tests__/keypair-validation.test.ts
@@ -1,0 +1,99 @@
+/**
+ * deserializeEd25519Keypair validation tests
+ *
+ * Tests that the function properly validates keypair data and rejects
+ * invalid or corrupted keypairs.
+ *
+ * File: packages/identity/supabase/src/keypair.ts
+ */
+
+import { describe, expect, it } from "vitest";
+import { Ed25519Keypair } from "@peerbit/crypto";
+import {
+    deserializeEd25519Keypair,
+    serializeEd25519Keypair,
+} from "../keypair.js";
+
+describe("deserializeEd25519Keypair validation", () => {
+    describe("rejects invalid keypairs", () => {
+        it("rejects randomly generated 64-byte data", async () => {
+            const randomBytes = new Uint8Array(64);
+            for (let i = 0; i < 64; i++) {
+                randomBytes[i] = Math.floor(Math.random() * 256);
+            }
+            const randomBase64 = Buffer.from(randomBytes).toString("base64");
+
+            await expect(
+                deserializeEd25519Keypair(randomBase64)
+            ).rejects.toThrow("Invalid keypair encoding");
+        });
+
+        it("rejects keypair with mismatched components", async () => {
+            const keypair1 = await Ed25519Keypair.create();
+            const keypair2 = await Ed25519Keypair.create();
+
+            const bytes1 = keypair1.privateKeyPublicKey;
+            const bytes2 = keypair2.privateKeyPublicKey;
+
+            // Create keypair with private key from keypair1 and public key from keypair2
+            const mixedBytes = new Uint8Array(64);
+            mixedBytes.set(bytes1.slice(0, 32));  // private key from keypair1
+            mixedBytes.set(bytes2.slice(32, 64), 32);  // public key from keypair2
+
+            const mixedBase64 = Buffer.from(mixedBytes).toString("base64");
+
+            await expect(
+                deserializeEd25519Keypair(mixedBase64)
+            ).rejects.toThrow("Invalid keypair encoding");
+        });
+
+        it("rejects corrupted key data", async () => {
+            const keypair = await Ed25519Keypair.create();
+            const serialized = serializeEd25519Keypair(keypair);
+
+            // Corrupt the data while keeping valid Base64 and 64-byte length
+            const bytes = Buffer.from(serialized, "base64");
+            const corruptedBytes = new Uint8Array(bytes);
+            for (let i = 0; i < 64; i++) {
+                corruptedBytes[i] = (corruptedBytes[i] + 1) % 256;
+            }
+            const corrupted = Buffer.from(corruptedBytes).toString("base64");
+
+            await expect(
+                deserializeEd25519Keypair(corrupted)
+            ).rejects.toThrow("Invalid keypair encoding");
+        });
+    });
+
+    describe("accepts valid keypairs", () => {
+        it("serializes and deserializes correctly", async () => {
+            const original = await Ed25519Keypair.create();
+            const serialized = serializeEd25519Keypair(original);
+            const restored = await deserializeEd25519Keypair(serialized);
+
+            expect(restored.equals(original)).toBe(true);
+        });
+
+        it("produces consistent signatures after round-trip", async () => {
+            const original = await Ed25519Keypair.create();
+            const serialized = serializeEd25519Keypair(original);
+            const restored = await deserializeEd25519Keypair(serialized);
+
+            const message = new Uint8Array([1, 2, 3, 4, 5]);
+            const signature1 = await original.sign(message);
+            const signature2 = await restored.sign(message);
+
+            expect(signature1.signature).toEqual(signature2.signature);
+        });
+
+        it("maintains peer identity across operations", async () => {
+            const original = await Ed25519Keypair.create();
+            const serialized = serializeEd25519Keypair(original);
+            const restored = await deserializeEd25519Keypair(serialized);
+
+            expect(original.toPeerId().toString()).toBe(
+                restored.toPeerId().toString()
+            );
+        });
+    });
+});

--- a/packages/identity/supabase/src/__tests__/keypair.test.ts
+++ b/packages/identity/supabase/src/__tests__/keypair.test.ts
@@ -9,7 +9,7 @@ describe("identity-supabase keypair codec", () => {
     it("roundtrips an Ed25519 keypair", async () => {
         const keypair = await Ed25519Keypair.create();
         const encoded = serializeEd25519Keypair(keypair);
-        const decoded = deserializeEd25519Keypair(encoded);
+        const decoded = await deserializeEd25519Keypair(encoded);
         expect(decoded.equals(keypair)).to.equal(true);
     });
 });

--- a/packages/identity/supabase/src/keypair.ts
+++ b/packages/identity/supabase/src/keypair.ts
@@ -4,13 +4,17 @@ import {
     Ed25519PublicKey,
 } from "@peerbit/crypto";
 import { decodeBase64, encodeBase64 } from "./base64.js";
+import sodium from "libsodium-wrappers";
+import { equals } from "uint8arrays";
 
 export const serializeEd25519Keypair = (keypair: Ed25519Keypair): string => {
     const bytes = keypair.privateKeyPublicKey; // 32 (priv) + 32 (pub)
     return encodeBase64(bytes);
 };
 
-export const deserializeEd25519Keypair = (value: string): Ed25519Keypair => {
+export const deserializeEd25519Keypair = async (
+    value: string
+): Promise<Ed25519Keypair> => {
     const bytes = decodeBase64(value.trim());
     if (bytes.length !== 64) {
         throw new Error(
@@ -20,6 +24,17 @@ export const deserializeEd25519Keypair = (value: string): Ed25519Keypair => {
 
     const privateKeyBytes = bytes.slice(0, 32);
     const publicKeyBytes = bytes.slice(32, 64);
+
+    // Validate that the public key matches the private key
+    await sodium.ready;
+    const derivedKeypair = sodium.crypto_sign_seed_keypair(privateKeyBytes);
+    const derivedPublicKey = derivedKeypair.publicKey;
+
+    if (!equals(derivedPublicKey, publicKeyBytes)) {
+        throw new Error(
+            "Invalid keypair encoding: public key does not match private key"
+        );
+    }
 
     return new Ed25519Keypair({
         publicKey: new Ed25519PublicKey({ publicKey: publicKeyBytes }),


### PR DESCRIPTION
## Summary
- Add cryptographic validation to `deserializeEd25519Keypair` function
- Previously only validated data length (64 bytes), not content validity
- Now uses libsodium to verify public key matches private key

## Problem
The `deserializeEd25519Keypair` function in `packages/identity/supabase/src/keypair.ts` only validated that input data decodes to 64 bytes, but did not verify cryptographic validity. This allowed:
- Random 64-byte data to be accepted as valid keypairs
- Mismatched private/public key combinations
- Corrupted data to pass through silently

## Impact
Without proper validation:
- **Silent authentication failures** - User's stored key becomes corrupted, auth fails with no clear error
- **Identity confusion** - PeerId changes unexpectedly, breaking permissions and audit logs
- **Data verification failures** - Valid data appears tampered when verified with corrupted key
- **Multi-device sync failures** - Different devices produce conflicting signatures

## Solution
Added validation using libsodium:
```typescript
// Derive public key from private key
const derivedKeypair = sodium.crypto_sign_seed_keypair(privateKeyBytes);
const derivedPublicKey = derivedKeypair.publicKey;

// Verify it matches the stored public key
if (!equals(derivedPublicKey, publicKeyBytes)) {
    throw new Error("Invalid keypair encoding: public key does not match private key");
}
```

## Changes
- `packages/identity/supabase/src/keypair.ts`: Added validation, function now async
- `packages/identity/supabase/src/__tests__/keypair.test.ts`: Updated for async
- `packages/identity/supabase/src/__tests__/keypair-validation.test.ts`: New test file with validation tests

## Tests
All 7 tests pass:
- 3 tests verify invalid keypairs are rejected (random data, mismatched keys, corrupted data)
- 3 tests verify valid keypairs work correctly (round-trip, signatures, identity)
- 1 existing test updated for async compatibility

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>