### PR TITLE
fix(file-share): allow slower public large-file chunk lookup

### DIFF
--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -124,6 +124,7 @@ const LARGE_FILE_SEGMENT_SIZE = TINY_FILE_SIZE_LIMIT / 10;
 const LARGE_FILE_TARGET_CHUNK_COUNT = 1024;
 const CHUNK_SIZE_GRANULARITY = 64 * 1024;
 const MAX_LARGE_FILE_SEGMENT_SIZE = TINY_FILE_SIZE_LIMIT - 256 * 1024;
+const LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS = 5 * 60 * 1000;
 const TINY_FILE_SIZE_LIMIT_BIGINT = BigInt(TINY_FILE_SIZE_LIMIT);
 
 const roundUpTo = (value: number, multiple: number) =>
@@ -339,7 +340,8 @@ export class LargeFile extends AbstractFile {
             timeout?: number;
         }
     ): Promise<TinyFile> {
-        const totalTimeout = properties?.timeout ?? 30_000;
+        const totalTimeout =
+            properties?.timeout ?? LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS;
         const deadline = Date.now() + totalTimeout;
         const attemptTimeout = Math.min(totalTimeout, 5_000);
         const chunkId = getChunkId(this.id, index);


### PR DESCRIPTION
## Summary
- increase the default large-file chunk lookup timeout from 30s to 5m
- keep the existing retry loop but allow slower public-network chunk discovery to complete
- preserve the current direct/local behavior while unblocking public bootstrap-only downloads

## Why
A real public-network 5GB CLI transfer against the live bootstrap fleet was still failing mid-download with:
- Failed to resolve chunk 253/1134 for file ...

The same flow already worked locally/direct, which pointed to a public-overlay latency issue rather than a correctness issue in the chunk path itself. The per-chunk default timeout was still only 30000ms.

## Validation
- pnpm vitest run packages/file-share/library/src/__tests__/index.integration.test.ts packages/file-share/library/src/__tests__/late-join.integration.test.ts --project node
- public bootstrap-only CLI 5GB upload/download re-test on the built branch

### Public-network result
- upload succeeded and produced an id after about 7m31s
- download completed successfully in 847.09s
- downloader maximum resident set size: 301367296 bytes
- source size: 5368709120
- destination size: 5368709120
- SHA-256 matched exactly

This replaces the previous public failure mode where the same shape stalled and died around chunk 253/1134 after about 303s.
