### PR TITLE
chore(release): publish file-share 2.0.2

### DIFF
--- a/.changeset/direct-peer-dialing.md
+++ b/.changeset/direct-peer-dialing.md
@@ -1,6 +1,0 @@
----
-"@peerbit/please": patch
-"@peerbit/please-lib": patch
----
-
-Prefer direct peer dialing for file sharing, improve large streamed transfer reliability, and update file-share examples for the released Peerbit 5.2.0 graph.

--- a/packages/file-share/cli/CHANGELOG.md
+++ b/packages/file-share/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @peerbit/please
 
+## 2.0.2
+
+### Patch Changes
+
+- af6fcb4: Prefer direct peer dialing for file sharing, improve large streamed transfer reliability, and update file-share examples for the released Peerbit 5.2.0 graph.
+- Updated dependencies [af6fcb4]
+    - @peerbit/please-lib@2.0.2
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/file-share/cli/package.json
+++ b/packages/file-share/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@peerbit/please",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "author": "dao.xyz",
     "repository": "https://github.com/@dao-xyz/peerbit-examples",
     "license": "Apache-2.0",

--- a/packages/file-share/frontend/CHANGELOG.md
+++ b/packages/file-share/frontend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # file-share
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies [af6fcb4]
+    - @peerbit/please-lib@2.0.2
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/file-share/frontend/package.json
+++ b/packages/file-share/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "file-share",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "private": true,
     "homepage": "https://dao-xyz.github.io/peerbit-examples",
     "type": "module",

--- a/packages/file-share/library/CHANGELOG.md
+++ b/packages/file-share/library/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @peerbit/please-lib
 
+## 2.0.2
+
+### Patch Changes
+
+- af6fcb4: Prefer direct peer dialing for file sharing, improve large streamed transfer reliability, and update file-share examples for the released Peerbit 5.2.0 graph.
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/file-share/library/package.json
+++ b/packages/file-share/library/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@peerbit/please-lib",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "author": "dao.xyz",
     "repository": "https://github.com/@dao-xyz/peerbit-examples",
     "license": "Apache-2.0",

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -124,6 +124,7 @@ const LARGE_FILE_SEGMENT_SIZE = TINY_FILE_SIZE_LIMIT / 10;
 const LARGE_FILE_TARGET_CHUNK_COUNT = 1024;
 const CHUNK_SIZE_GRANULARITY = 64 * 1024;
 const MAX_LARGE_FILE_SEGMENT_SIZE = TINY_FILE_SIZE_LIMIT - 256 * 1024;
+const LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS = 5 * 60 * 1000;
 const TINY_FILE_SIZE_LIMIT_BIGINT = BigInt(TINY_FILE_SIZE_LIMIT);
 
 const roundUpTo = (value: number, multiple: number) =>
@@ -339,7 +340,8 @@ export class LargeFile extends AbstractFile {
             timeout?: number;
         }
     ): Promise<TinyFile> {
-        const totalTimeout = properties?.timeout ?? 30_000;
+        const totalTimeout =
+            properties?.timeout ?? LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS;
         const deadline = Date.now() + totalTimeout;
         const attemptTimeout = Math.min(totalTimeout, 5_000);
         const chunkId = getChunkId(this.id, index);


### PR DESCRIPTION
## Summary
- version and changelog the file-share packages for release 2.0.2
- include the direct-peer dialing work and the public 5GB chunk-lookup timeout fix
- prepare npm publish for `@peerbit/please` and `@peerbit/please-lib`

## Validation
- `pnpm --filter @peerbit/please-lib build`
- `pnpm --filter @peerbit/please build`
- `pnpm vitest run packages/file-share/library/src/__tests__/index.integration.test.ts packages/file-share/library/src/__tests__/late-join.integration.test.ts --project node`
- `pnpm vitest run packages/file-share/cli/src/__tests__ --project node`
