### PR TITLE
chore(release): publish file-share 2.0.4

### DIFF
--- a/packages/file-share/cli/CHANGELOG.md
+++ b/packages/file-share/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @peerbit/please
 
+## 2.0.4
+
+### Patch Changes
+
+- Refresh file-share packages to the latest Peerbit release line and stabilize the monorepo install layout used by the CLI and frontend.
+- Updated dependencies
+    - @peerbit/please-lib@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/file-share/cli/package.json
+++ b/packages/file-share/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@peerbit/please",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "author": "dao.xyz",
     "repository": "https://github.com/@dao-xyz/peerbit-examples",
     "license": "Apache-2.0",

--- a/packages/file-share/frontend/CHANGELOG.md
+++ b/packages/file-share/frontend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # file-share
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies
+    - @peerbit/please-lib@2.0.4
+
 ## 0.0.6
 
 ### Patch Changes

--- a/packages/file-share/frontend/package.json
+++ b/packages/file-share/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "file-share",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "private": true,
     "homepage": "https://dao-xyz.github.io/peerbit-examples",
     "type": "module",

--- a/packages/file-share/library/CHANGELOG.md
+++ b/packages/file-share/library/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @peerbit/please-lib
 
+## 2.0.4
+
+### Patch Changes
+
+- Refresh file-share packages to the latest Peerbit release line and stabilize the monorepo install layout used by the CLI and frontend.
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/file-share/library/package.json
+++ b/packages/file-share/library/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@peerbit/please-lib",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "author": "dao.xyz",
     "repository": "https://github.com/@dao-xyz/peerbit-examples",
     "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- publish the refreshed file-share packages after the peerbit 5.2.3 roll forward
- bump , , and the frontend package via changesets
- keep the repo state aligned with the already-merged dependency refresh on master

## Verification
- pnpm run build