### PR TITLE
chore(release): publish file-share 2.0.5

### DIFF
--- a/.changeset/quick-coins-juggle.md
+++ b/.changeset/quick-coins-juggle.md
@@ -1,6 +1,0 @@
----
-"@peerbit/please": patch
-"@peerbit/please-lib": patch
----
-
-Wait for the full chunk set before streaming large files in observer downloads, so CLI reads do not fail after a file becomes discoverable but before all chunks are fetchable.

--- a/packages/file-share/cli/CHANGELOG.md
+++ b/packages/file-share/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @peerbit/please
 
+## 2.0.5
+
+### Patch Changes
+
+- d1ca154: Wait for the full chunk set before streaming large files in observer downloads, so CLI reads do not fail after a file becomes discoverable but before all chunks are fetchable.
+- Updated dependencies [d1ca154]
+    - @peerbit/please-lib@2.0.5
+
 ## 2.0.4
 
 ### Patch Changes

--- a/packages/file-share/cli/package.json
+++ b/packages/file-share/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@peerbit/please",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "author": "dao.xyz",
     "repository": "https://github.com/@dao-xyz/peerbit-examples",
     "license": "Apache-2.0",

--- a/packages/file-share/frontend/CHANGELOG.md
+++ b/packages/file-share/frontend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # file-share
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [d1ca154]
+    - @peerbit/please-lib@2.0.5
+
 ## 0.0.7
 
 ### Patch Changes

--- a/packages/file-share/frontend/package.json
+++ b/packages/file-share/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "file-share",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "private": true,
     "homepage": "https://dao-xyz.github.io/peerbit-examples",
     "type": "module",

--- a/packages/file-share/library/CHANGELOG.md
+++ b/packages/file-share/library/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @peerbit/please-lib
 
+## 2.0.5
+
+### Patch Changes
+
+- d1ca154: Wait for the full chunk set before streaming large files in observer downloads, so CLI reads do not fail after a file becomes discoverable but before all chunks are fetchable.
+
 ## 2.0.4
 
 ### Patch Changes

--- a/packages/file-share/library/package.json
+++ b/packages/file-share/library/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@peerbit/please-lib",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "author": "dao.xyz",
     "repository": "https://github.com/@dao-xyz/peerbit-examples",
     "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- publish the file-share observer-read fix
- bump , , and the frontend package via changesets
- keep the published CLI aligned with the merged chunk-readability fix on master

## Verification
- pnpm --filter @peerbit/please-lib build
- pnpm --filter @peerbit/please build