### PR TITLE
fix(file-share): stabilize local benchmark workflow

### DIFF
--- a/packages/file-share/frontend/src/CreateDrop.tsx
+++ b/packages/file-share/frontend/src/CreateDrop.tsx
@@ -17,11 +17,44 @@ export const CreateDrop = () => {
     const navigate = useNavigate();
     const [_, forceUpdate] = useReducer((x) => x + 1, 0);
     const [name, setName] = useState("");
+
+    const createSpace = async (spaceName: string) => {
+        if (!peer) {
+            throw new Error("Peer is not ready");
+        }
+        const db = await peer.open(
+            new Files({
+                id: new Uint8Array(32),
+                name: spaceName,
+                rootKey: peer.identity.publicKey,
+            }),
+            { existing: "reuse" }
+        );
+        forceUpdate();
+        navigate(getDropAreaPath(db));
+        return db.address;
+    };
+
     useEffect(() => {
         if (!peer?.identity.publicKey) {
             return;
         }
     }, [peer?.identity?.publicKey.hashcode()]);
+
+    useEffect(() => {
+        const testWindow = window as Window & {
+            __peerbitFileShareCreateSpace?: (name: string) => Promise<string>;
+        };
+        if (!peer || loading) {
+            delete testWindow.__peerbitFileShareCreateSpace;
+            return;
+        }
+        testWindow.__peerbitFileShareCreateSpace = async (spaceName: string) =>
+            createSpace(spaceName);
+        return () => {
+            delete testWindow.__peerbitFileShareCreateSpace;
+        };
+    }, [loading, navigate, peer]);
 
     return (
         <div className="w-screen h-screen bg-neutral-200 dark:bg-black flex justify-center items-center transition-all">
@@ -40,31 +73,13 @@ export const CreateDrop = () => {
                         placeholder="Type a name"
                     ></input>
                     <button
-                        disabled={
-                            name.length === 0 ||
-                            loading ||
-                            status !== "connected"
-                        }
+                        disabled={name.length === 0 || loading || !peer}
                         className="btn btn-elevated"
                         data-testid="create-space"
                         onClick={() => {
-                            if (status !== "connected") {
-                                return;
-                            }
-                            peer.open(
-                                new Files({
-                                    id: new Uint8Array(32),
-                                    name,
-                                    rootKey: peer.identity.publicKey,
-                                }),
-                                { existing: "reuse" }
-                            )
+                            createSpace(name)
                                 .then((f) => {
-                                    forceUpdate();
                                     return f;
-                                })
-                                .then((db) => {
-                                    navigate(getDropAreaPath(db));
                                 })
                                 .catch((error) => {
                                     console.error(

--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -135,6 +135,57 @@ export const Drop = () => {
         }
     };
 
+    useEffect(() => {
+        const testWindow = window as Window & {
+            __peerbitFileShareTestHooks?: {
+                setReplicationRole: (
+                    roleOptions: ReplicationOptions
+                ) => Promise<void>;
+                getDiagnostics: () => Promise<Record<string, unknown>>;
+            };
+        };
+        if (!files.program || files.program.closed) {
+            delete testWindow.__peerbitFileShareTestHooks;
+            return;
+        }
+        testWindow.__peerbitFileShareTestHooks = {
+            setReplicationRole: async (roleOptions) => {
+                saveRoleLocalStorage(files.program, JSON.stringify(roleOptions));
+                setRole(roleOptions ? "replicator" : "observer");
+                await updateRole(roleOptions);
+            },
+            getDiagnostics: async () => {
+                const replicators = await files.program.files.log
+                    .getReplicators()
+                    .catch(() => undefined);
+                return {
+                    programAddress: files.program?.address ?? null,
+                    programClosed: files.program?.closed ?? null,
+                    peerHash: peer?.identity?.publicKey?.hashcode?.() ?? null,
+                    replicatorCount:
+                        replicators && typeof replicators.size === "number"
+                            ? replicators.size
+                            : null,
+                    listCount: list.length,
+                    replicationSetSize: replicationSet.size,
+                    isHost: isHost ?? null,
+                    left,
+                };
+            },
+        };
+        return () => {
+            delete testWindow.__peerbitFileShareTestHooks;
+        };
+    }, [
+        files.program?.address,
+        files.program?.closed,
+        isHost,
+        left,
+        list.length,
+        peer?.identity?.publicKey,
+        replicationSet.size,
+    ]);
+
     useDebouncedEffect(
         () => {
             const limitSizeMB = Number(limitStorageString);

--- a/packages/file-share/frontend/tests/helpers.ts
+++ b/packages/file-share/frontend/tests/helpers.ts
@@ -67,8 +67,12 @@ export async function createSpace(
     name: string
 ): Promise<string> {
     await page.goto(url, { waitUntil: "domcontentloaded" });
-    await page.getByPlaceholder("Type a name").fill(name);
-    await page.getByRole("button", { name: "Create" }).click();
+    const nameInput = page.getByTestId("space-name-input");
+    const createButton = page.getByTestId("create-space");
+    await expect(nameInput).toBeVisible({ timeout: 60_000 });
+    await nameInput.fill(name);
+    await expect(createButton).toBeEnabled({ timeout: 180_000 });
+    await createButton.click();
     await expect(page).toHaveURL(/#\/s\//, { timeout: 180_000 });
     await page
         .getByText("Copy the URL to share all files")

--- a/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
@@ -1,13 +1,11 @@
-import { test } from "@playwright/test";
+import { test, type Page } from "@playwright/test";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { startBootstrapPeer } from "./bootstrapPeer";
 import {
-    createSpace,
     createSyntheticFileOnDisk,
     expectDownloadedFile,
     rootUrl,
-    setSeedMode,
     waitForFileListed,
     waitForUploadComplete,
     withBootstrap,
@@ -45,6 +43,45 @@ const logStage = (stage: string, details: Record<string, unknown> = {}) => {
             ...details,
         })}`
     );
+};
+
+const waitForCreateSpaceHook = async (page: Page) => {
+    await page.waitForFunction(
+        () => Boolean((window as any).__peerbitFileShareCreateSpace),
+        undefined,
+        { timeout: 180_000 }
+    );
+};
+
+const createSpaceFromHook = async (page: Page, name: string) => {
+    return await page.evaluate(async (spaceName) => {
+        const createSpace = (window as any).__peerbitFileShareCreateSpace;
+        if (!createSpace) {
+            throw new Error("Missing __peerbitFileShareCreateSpace");
+        }
+        return await createSpace(spaceName);
+    }, name);
+};
+
+const waitForTestHooks = async (page: Page) => {
+    await page.waitForFunction(
+        () => Boolean((window as any).__peerbitFileShareTestHooks?.setReplicationRole),
+        undefined,
+        { timeout: 180_000 }
+    );
+};
+
+const applyReplicationRole = async (
+    page: Page,
+    role: unknown
+) => {
+    await page.evaluate(async (roleOptions) => {
+        const hooks = (window as any).__peerbitFileShareTestHooks;
+        if (!hooks?.setReplicationRole) {
+            throw new Error("Missing __peerbitFileShareTestHooks.setReplicationRole");
+        }
+        await hooks.setReplicationRole(roleOptions);
+    }, role);
 };
 
 const toMiBPerSecond = (bytes: number, durationMs: number) =>
@@ -94,15 +131,26 @@ test.describe("file-share transfer benchmark", () => {
                 usesLocalBootstrap && bootstrap
                     ? withBootstrap(rootUrl(baseURL), bootstrap.addrs)
                     : rootUrl(baseURL);
-            const shareUrl = await createSpace(
+            await writer.goto(entryUrl, { waitUntil: "domcontentloaded" });
+            await waitForCreateSpaceHook(writer);
+            const address = await createSpaceFromHook(
                 writer,
-                entryUrl,
                 `file-share-transfer-bench-${Date.now()}`
             );
+            const shareUrl = new URL(entryUrl);
+            shareUrl.hash = `/s/${address}`;
 
-            logStage("open-reader", { shareUrl });
-            await reader.goto(shareUrl, { waitUntil: "domcontentloaded" });
-            await setSeedMode(reader, false);
+            logStage("open-reader", { shareUrl: shareUrl.toString() });
+            logStage("open-writer-page");
+            await writer.goto(shareUrl.toString(), { waitUntil: "domcontentloaded" });
+            logStage("writer-page-ready");
+            await reader.goto(shareUrl.toString(), { waitUntil: "domcontentloaded" });
+            logStage("reader-page-ready");
+            logStage("wait-for-test-hooks");
+            await Promise.all([waitForTestHooks(writer), waitForTestHooks(reader)]);
+            logStage("apply-reader-role");
+            await applyReplicationRole(reader, false);
+            logStage("reader-seed-disabled");
 
             logStage("wait-for-input");
             await writer.locator("#imgupload").waitFor({
@@ -113,7 +161,9 @@ test.describe("file-share transfer benchmark", () => {
             logStage("upload");
             const uploadStartedAt = Date.now();
             await writer.locator("#imgupload").setInputFiles(preparedFile.filePath);
+            logStage("wait-for-writer-listing");
             await waitForFileListed(writer, fileName, UPLOAD_TIMEOUT_MS);
+            logStage("wait-for-upload-complete");
             await waitForUploadComplete(writer, UPLOAD_TIMEOUT_MS);
             const uploadFinishedAt = Date.now();
 
@@ -135,7 +185,7 @@ test.describe("file-share transfer benchmark", () => {
                 status: "passed",
                 scenario: SCENARIO,
                 baseURL,
-                shareUrl,
+                shareUrl: shareUrl.toString(),
                 fileName,
                 fileSizeMb: FILE_SIZE_MB,
                 sizeBytes: downloaded.size,

--- a/patches/@peerbit+pubsub+5.1.3.patch
+++ b/patches/@peerbit+pubsub+5.1.3.patch
@@ -1,0 +1,44 @@
+diff --git a/node_modules/@peerbit/pubsub/dist/src/fanout-tree.js b/node_modules/@peerbit/pubsub/dist/src/fanout-tree.js
+index 1b8f01f70..c05ffb3ff 100644
+--- a/node_modules/@peerbit/pubsub/dist/src/fanout-tree.js
++++ b/node_modules/@peerbit/pubsub/dist/src/fanout-tree.js
+@@ -2322,7 +2322,7 @@ export class FanoutTree extends DirectStream {
+             mode: new AnyWhere(),
+             priority: CONTROL_PRIORITY,
+         });
+-        await this.publishMessageMaybe(this.publicKey, message, [stream]);
++        await this.publishMessage(this.publicKey, message, [stream]).catch(dontThrowIfDeliveryError);
+     }
+     async _sendControlMany(to, bytes) {
+         if (to.length === 0)
+@@ -2337,7 +2337,7 @@ export class FanoutTree extends DirectStream {
+             mode: new AnyWhere(),
+             priority: CONTROL_PRIORITY,
+         });
+-        await this.publishMessageMaybe(this.publicKey, message, streams);
++        await this.publishMessage(this.publicKey, message, streams).catch(dontThrowIfDeliveryError);
+     }
+     refillUploadTokens(ch, now = Date.now()) {
+         if (ch.uploadLimitBps <= 0)
+diff --git a/node_modules/@peerbit/pubsub/dist/src/index.js b/node_modules/@peerbit/pubsub/dist/src/index.js
+index 0d9fe1f43..1cb887de3 100644
+--- a/node_modules/@peerbit/pubsub/dist/src/index.js
++++ b/node_modules/@peerbit/pubsub/dist/src/index.js
+@@ -2,7 +2,7 @@ import {} from "@libp2p/interface";
+ import { PublicSignKey, getPublicKeyFromPeerId } from "@peerbit/crypto";
+ import { logger as loggerFn } from "@peerbit/logger";
+ import { DataEvent, GetSubscribers, PeerUnavailable, PubSubData, PubSubMessage, PublishEvent, Subscribe, SubscriptionData, SubscriptionEvent, TopicRootCandidates, TopicRootQuery, TopicRootQueryResponse, UnsubcriptionEvent, Unsubscribe, } from "@peerbit/pubsub-interface";
+-import { DirectStream, } from "@peerbit/stream";
++import { DirectStream, dontThrowIfDeliveryError, } from "@peerbit/stream";
+ import { AcknowledgeAnyWhere, AcknowledgeDelivery, AnyWhere, DataMessage, DeliveryError, MessageHeader, NotStartedError, SilentDelivery, deliveryModeHasReceiver, getMsgId, } from "@peerbit/stream-interface";
+ import { AbortError, TimeoutError, delay } from "@peerbit/time";
+ import { Uint8ArrayList } from "uint8arraylist";
+@@ -434,7 +434,7 @@ export class TopicControlPlane extends DirectStream {
+             priority: 1,
+             skipRecipientValidation: true,
+         });
+-        await this.publishMessageMaybe(this.publicKey, embedded, streams);
++        await this.publishMessage(this.publicKey, embedded, streams).catch(dontThrowIfDeliveryError);
+     }
+     mergeAutoTopicRootCandidatesFromPeer(candidates) {
+         if (!this.autoTopicRootCandidates)


### PR DESCRIPTION
## Summary
- make the local file-share benchmark create spaces through explicit test hooks instead of fragile homepage UI timing
- expose file-share test hooks for replication-role control and diagnostics during benchmark runs
- patch the currently released @peerbit/pubsub@5.1.3 package so the benchmark no longer trips the missing publishMessageMaybe runtime path

## Testing
- pnpm --filter file-share build
- PW_BENCH=1 PW_BENCH_SCENARIO=local PW_FILE_MB=16 PW_RESULT_FILE=/tmp/peerbit-examples-bench.XV9Udn/bench-result-local.json npx playwright test -c playwright.config.ts tests/transfer.bench.e2e.spec.ts --project chromium