### PR TITLE
chore(bench): default file-share benchmarks to 512 MiB

### DIFF
--- a/.github/workflows/file-share-benchmarks.yml
+++ b/.github/workflows/file-share-benchmarks.yml
@@ -15,7 +15,7 @@ on:
                 description: File size in MiB
                 required: true
                 type: number
-                default: 1024
+                default: 512
             runs:
                 description: Number of benchmark runs
                 required: true


### PR DESCRIPTION
## Summary
- change the file-share benchmark workflow default file size from `1024` to `512`

## Why
`512 MiB` is a more practical default for on-demand transfer benchmarking than `1 GiB`, while still being large enough to be meaningful.
