### PR TITLE
fix(bench): support streamed large-file downloads

### DIFF
--- a/packages/file-share/frontend/tests/helpers.ts
+++ b/packages/file-share/frontend/tests/helpers.ts
@@ -177,22 +177,7 @@ export async function expectDownloadedFile(
     expectedSizeMb: number,
     timeout = 8 * 60 * 1000
 ) {
-    const row = page.locator("li", { hasText: fileName }).first();
-    await expect(row).toBeVisible({ timeout: 60_000 });
-    const byTestId = row.getByTestId("download-file");
-    const button =
-        (await byTestId.count()) > 0 ? byTestId : row.locator("button").first();
-
-    const ignoreTimeout = <T>(promise: Promise<T>) =>
-        promise.catch((error: any) => {
-            if (
-                error?.name === "TimeoutError" ||
-                /Timeout .* exceeded/i.test(String(error?.message || ""))
-            ) {
-                return new Promise<T>(() => {});
-            }
-            throw error;
-        });
+    const { button } = await getDownloadButton(page, fileName);
 
     const downloadPromise = page.waitForEvent("download", { timeout });
     const dialogFailure = ignoreTimeout(
@@ -228,6 +213,26 @@ export async function expectDownloadedFile(
         size: details.size,
     };
 }
+
+const ignoreTimeout = <T>(promise: Promise<T>) =>
+    promise.catch((error: any) => {
+        if (
+            error?.name === "TimeoutError" ||
+            /Timeout .* exceeded/i.test(String(error?.message || ""))
+        ) {
+            return new Promise<T>(() => {});
+        }
+        throw error;
+    });
+
+const getDownloadButton = async (page: Page, fileName: string) => {
+    const row = page.locator("li", { hasText: fileName }).first();
+    await expect(row).toBeVisible({ timeout: 60_000 });
+    const byTestId = row.getByTestId("download-file");
+    const button =
+        (await byTestId.count()) > 0 ? byTestId : row.locator("button").first();
+    return { row, button };
+};
 
 export async function installMockSaveFilePicker(page: Page) {
     await page.addInitScript(() => {
@@ -276,14 +281,31 @@ export async function expectSavedViaPicker(
     timeout = 8 * 60 * 1000
 ) {
     const expectedBytes = expectedSizeMb * 1024 * 1024;
-    await expect
+    const { button } = await getDownloadButton(page, fileName);
+    const dialogFailure = ignoreTimeout(
+        page.waitForEvent("dialog", { timeout }).then(async (dialog) => {
+            const message = dialog.message();
+            await dialog.dismiss().catch(() => {});
+            throw new Error(`Download failed dialog: ${message}`);
+        })
+    );
+    const pageErrorFailure = ignoreTimeout(
+        page.waitForEvent("pageerror", { timeout }).then((error) => {
+            throw error;
+        })
+    );
+    const streamedSave = expect
         .poll(
             async () =>
                 page.evaluate((expectedName) => {
                     const savedFiles =
-                        ((window as unknown as { __mockSavedFiles?: Array<{ name: string; size: number }> })
-                            .__mockSavedFiles ?? []);
-                    return savedFiles.find((file) => file.name === expectedName) ?? null;
+                        ((window as unknown as {
+                            __mockSavedFiles?: Array<{ name: string; size: number }>;
+                        }).__mockSavedFiles ?? []);
+                    return (
+                        savedFiles.find((file) => file.name === expectedName) ??
+                        null
+                    );
                 }, fileName),
             {
                 timeout,
@@ -291,4 +313,7 @@ export async function expectSavedViaPicker(
             }
         )
         .toEqual({ name: fileName, size: expectedBytes });
+
+    await button.click();
+    await Promise.race([streamedSave, dialogFailure, pageErrorFailure]);
 }

--- a/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
@@ -5,6 +5,8 @@ import { startBootstrapPeer } from "./bootstrapPeer";
 import {
     createSyntheticFileOnDisk,
     expectDownloadedFile,
+    expectSavedViaPicker,
+    installMockSaveFilePicker,
     rootUrl,
     waitForFileListed,
     waitForUploadComplete,
@@ -21,6 +23,7 @@ const UPLOAD_TIMEOUT_MS = Number(
 const DOWNLOAD_TIMEOUT_MS = Number(
     process.env.PW_DOWNLOAD_TIMEOUT_MS || "1800000"
 );
+const STREAMING_DOWNLOAD_THRESHOLD_BYTES = 250_000_000;
 
 if (!["local", "prod"].includes(SCENARIO)) {
     throw new Error(`Unsupported PW_BENCH_SCENARIO='${SCENARIO}'`);
@@ -124,8 +127,14 @@ test.describe("file-share transfer benchmark", () => {
             fileName,
             FILE_SIZE_MB
         );
+        const usesStreamingDownload =
+            preparedFile != null &&
+            FILE_SIZE_MB * 1024 * 1024 >= STREAMING_DOWNLOAD_THRESHOLD_BYTES;
 
         try {
+            if (usesStreamingDownload) {
+                await installMockSaveFilePicker(reader);
+            }
             logStage("create-space");
             const entryUrl =
                 usesLocalBootstrap && bootstrap
@@ -173,12 +182,21 @@ test.describe("file-share transfer benchmark", () => {
 
             logStage("download");
             const downloadStartedAt = Date.now();
-            const downloaded = await expectDownloadedFile(
-                reader,
-                fileName,
-                FILE_SIZE_MB,
-                DOWNLOAD_TIMEOUT_MS
-            );
+            const downloaded = usesStreamingDownload
+                ? await expectSavedViaPicker(
+                      reader,
+                      fileName,
+                      FILE_SIZE_MB,
+                      DOWNLOAD_TIMEOUT_MS
+                  ).then(() => ({
+                      size: preparedFile ? FILE_SIZE_MB * 1024 * 1024 : 0,
+                  }))
+                : await expectDownloadedFile(
+                      reader,
+                      fileName,
+                      FILE_SIZE_MB,
+                      DOWNLOAD_TIMEOUT_MS
+                  );
             const downloadFinishedAt = Date.now();
 
             const result = {
@@ -188,6 +206,9 @@ test.describe("file-share transfer benchmark", () => {
                 shareUrl: shareUrl.toString(),
                 fileName,
                 fileSizeMb: FILE_SIZE_MB,
+                downloadMode: usesStreamingDownload
+                    ? "save-picker-stream"
+                    : "browser-download",
                 sizeBytes: downloaded.size,
                 uploadDurationMs: uploadFinishedAt - uploadStartedAt,
                 discoveryLagMs: readerVisibleAt - uploadFinishedAt,


### PR DESCRIPTION
## Summary
- update the transfer benchmark to handle large downloads through the save picker path
- use the normal browser download assertion for small files and mocked streamed saves for large files

## Why
In secure Chromium contexts, large file-share downloads use `showSaveFilePicker` instead of the browser `download` event. The benchmark was still waiting only for `download`, so prod `512 MiB` runs timed out even though the app had switched to the streamed path.
