### PR TITLE
fix(file-share): disable persistent chunk reads for observers

### DIFF
--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -127,6 +127,8 @@ export const Drop = () => {
             return;
         }
 
+        files.program.persistChunkReads = roleOptions !== false;
+
         // console.log("X", files.program.files.log["_roleOptions"]?.["limits"]?.["cpu"]?.max)
         saveRoleLocalStorage(files.program, JSON.stringify(roleOptions)); // Save role in localstorage for next time
         await files.program.files.log.replicate(false);
@@ -161,6 +163,7 @@ export const Drop = () => {
                 return {
                     programAddress: files.program?.address ?? null,
                     programClosed: files.program?.closed ?? null,
+                    persistChunkReads: files.program?.persistChunkReads ?? null,
                     peerHash: peer?.identity?.publicKey?.hashcode?.() ?? null,
                     replicatorCount:
                         replicators && typeof replicators.size === "number"

--- a/packages/file-share/frontend/tests/observer-role.local.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/observer-role.local.e2e.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test, type Page } from "@playwright/test";
+import { startBootstrapPeer } from "./bootstrapPeer";
+import { createSpace, rootUrl, withBootstrap } from "./helpers";
+
+const waitForTestHooks = async (page: Page) => {
+    await page.waitForFunction(
+        () =>
+            Boolean(
+                (window as any).__peerbitFileShareTestHooks?.setReplicationRole
+            ),
+        undefined,
+        { timeout: 180_000 }
+    );
+};
+
+const setReplicationRole = async (page: Page, role: unknown) => {
+    await page.evaluate(async (roleOptions) => {
+        const hooks = (window as any).__peerbitFileShareTestHooks;
+        if (!hooks?.setReplicationRole) {
+            throw new Error("Missing __peerbitFileShareTestHooks.setReplicationRole");
+        }
+        await hooks.setReplicationRole(roleOptions);
+    }, role);
+};
+
+const getDiagnostics = async (page: Page) => {
+    return await page.evaluate(async () => {
+        const hooks = (window as any).__peerbitFileShareTestHooks;
+        if (!hooks?.getDiagnostics) {
+            throw new Error("Missing __peerbitFileShareTestHooks.getDiagnostics");
+        }
+        return await hooks.getDiagnostics();
+    });
+};
+
+test.describe("file-share observer role", () => {
+    test("observer mode disables persistent chunk reads", async ({
+        browser,
+        baseURL,
+    }) => {
+        test.setTimeout(10 * 60 * 1000);
+        if (!baseURL) {
+            throw new Error("Missing baseURL");
+        }
+
+        const bootstrap = await startBootstrapPeer();
+        const writerContext = await browser.newContext();
+        const readerContext = await browser.newContext();
+        const writer = await writerContext.newPage();
+        const reader = await readerContext.newPage();
+
+        try {
+            const entryUrl = withBootstrap(rootUrl(baseURL), bootstrap.addrs);
+            const shareUrl = await createSpace(
+                writer,
+                entryUrl,
+                `observer-role-space-${Date.now()}`
+            );
+
+            await reader.goto(shareUrl, { waitUntil: "domcontentloaded" });
+            await waitForTestHooks(reader);
+
+            await setReplicationRole(reader, false);
+
+            await expect
+                .poll(async () => {
+                    const diagnostics = await getDiagnostics(reader);
+                    return diagnostics.persistChunkReads;
+                })
+                .toBe(false);
+        } finally {
+            await writerContext.close().catch(() => {});
+            await readerContext.close().catch(() => {});
+            await bootstrap.stop().catch(() => {});
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- keep `persistChunkReads` in sync when the file-share UI switches between seeding and observer roles
- expose `persistChunkReads` in the test diagnostics hook
- add a Playwright regression that proves observer mode disables persistent chunk reads

## Validation
- `cd packages/file-share/frontend && npx playwright test -c playwright.config.ts tests/observer-role.local.e2e.spec.ts --project chromium`
- `cd packages/file-share/frontend && PW_BENCH=1 PW_BENCH_SCENARIO=local PW_FILE_MB=512 PW_RESULT_FILE=/tmp/peerbit-examples-bump.HkBNCF/local-512-observer-fix.json npx playwright test -c playwright.config.ts tests/transfer.bench.e2e.spec.ts --project chromium`

## Why
The benchmark toggles the reader into observer mode, but the app was leaving `persistChunkReads` enabled. Large files then kept using the persistent per-chunk read path instead of the streamed observer path, which is a plausible cause of the intermittent `prod` 512 MiB stall.
