### PR TITLE
test(file-share): seed observer role before benchmark navigation

### DIFF
--- a/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
@@ -66,25 +66,20 @@ const createSpaceFromHook = async (page: Page, name: string) => {
     }, name);
 };
 
-const waitForTestHooks = async (page: Page) => {
-    await page.waitForFunction(
-        () => Boolean((window as any).__peerbitFileShareTestHooks?.setReplicationRole),
-        undefined,
-        { timeout: 180_000 }
-    );
-};
-
-const applyReplicationRole = async (
+const seedReplicationRole = async (
     page: Page,
+    address: string,
     role: unknown
 ) => {
-    await page.evaluate(async (roleOptions) => {
-        const hooks = (window as any).__peerbitFileShareTestHooks;
-        if (!hooks?.setReplicationRole) {
-            throw new Error("Missing __peerbitFileShareTestHooks.setReplicationRole");
-        }
-        await hooks.setReplicationRole(roleOptions);
-    }, role);
+    await page.addInitScript(
+        ({ shareAddress, roleOptions }) => {
+            window.localStorage.setItem(
+                `${shareAddress}-role`,
+                JSON.stringify(roleOptions)
+            );
+        },
+        { shareAddress: address, roleOptions: role }
+    );
 };
 
 const toMiBPerSecond = (bytes: number, durationMs: number) =>
@@ -148,6 +143,8 @@ test.describe("file-share transfer benchmark", () => {
             );
             const shareUrl = new URL(entryUrl);
             shareUrl.hash = `/s/${address}`;
+            logStage("seed-reader-role");
+            await seedReplicationRole(reader, address, false);
 
             logStage("open-reader", { shareUrl: shareUrl.toString() });
             logStage("open-writer-page");
@@ -155,11 +152,6 @@ test.describe("file-share transfer benchmark", () => {
             logStage("writer-page-ready");
             await reader.goto(shareUrl.toString(), { waitUntil: "domcontentloaded" });
             logStage("reader-page-ready");
-            logStage("wait-for-test-hooks");
-            await Promise.all([waitForTestHooks(writer), waitForTestHooks(reader)]);
-            logStage("apply-reader-role");
-            await applyReplicationRole(reader, false);
-            logStage("reader-seed-disabled");
 
             logStage("wait-for-input");
             await writer.locator("#imgupload").waitFor({


### PR DESCRIPTION
## Summary
- seed the reader's observer role through local storage before navigating to the share page
- remove the benchmark's dependency on runtime test hooks for role switching

## Validation
- `cd packages/file-share/frontend && PW_BENCH=1 PW_BENCH_SCENARIO=local PW_FILE_MB=16 PW_RESULT_FILE=/tmp/peerbit-examples-bump.HkBNCF/local-16-role-seed.json npx playwright test -c playwright.config.ts tests/transfer.bench.e2e.spec.ts --project chromium`

## Why
The prod 512 MiB benchmark still had a separate source of flakiness: it could fail before upload if one page never exposed `__peerbitFileShareTestHooks`. The benchmark only needs the reader to open in observer mode, and the app already persists that role in local storage on startup, so seeding the role directly is a simpler and more stable harness path.
