### PR TITLE
feat(file-share): add two-runner benchmark workflow

### DIFF
--- a/.github/workflows/file-share-two-runner-benchmarks.yml
+++ b/.github/workflows/file-share-two-runner-benchmarks.yml
@@ -1,0 +1,274 @@
+name: File Share Two-Runner Benchmarks
+
+on:
+    workflow_dispatch:
+        inputs:
+            file_mb:
+                description: File size in MiB
+                required: true
+                type: number
+                default: 512
+            base_url:
+                description: Target file-share deployment
+                required: true
+                type: string
+                default: https://files.dao.xyz
+            min_upload_mbps:
+                description: Fail if upload throughput is below this value (0 disables)
+                required: true
+                type: number
+                default: 0
+            min_download_mbps:
+                description: Fail if download throughput is below this value (0 disables)
+                required: true
+                type: number
+                default: 0
+
+permissions:
+    contents: read
+    issues: write
+
+jobs:
+    coordinator:
+        runs-on: ubuntu-22.04
+        outputs:
+            issue_number: ${{ steps.issue.outputs.issue_number }}
+        steps:
+            - name: Ensure coordination issue
+              id: issue
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  GITHUB_REPOSITORY: ${{ github.repository }}
+              run: |
+                  node <<'NODE'
+                  const fs = require("node:fs");
+
+                  const token = process.env.GITHUB_TOKEN;
+                  const repo = process.env.GITHUB_REPOSITORY;
+                  const title = "File Share Benchmark Coordination";
+
+                  const request = async (url, init = {}) => {
+                    const response = await fetch(url, {
+                      ...init,
+                      headers: {
+                        Accept: "application/vnd.github+json",
+                        Authorization: `Bearer ${token}`,
+                        "X-GitHub-Api-Version": "2022-11-28",
+                        ...(init.headers || {}),
+                      },
+                    });
+                    if (!response.ok) {
+                      throw new Error(`GitHub API ${response.status}: ${await response.text()}`);
+                    }
+                    return await response.json();
+                  };
+
+                  const search = await request(
+                    `https://api.github.com/search/issues?q=${encodeURIComponent(`repo:${repo} is:issue "${title}" in:title`)}`
+                  );
+                  const existing = search.items.find((item) => item.title === title);
+                  let issueNumber = existing?.number;
+
+                  if (!issueNumber) {
+                    const created = await request(
+                      `https://api.github.com/repos/${repo}/issues`,
+                      {
+                        method: "POST",
+                        body: JSON.stringify({
+                          title,
+                          body:
+                            "This issue is used by the on-demand two-runner file-share benchmark workflow as a coordination channel. Each benchmark run posts run-id scoped comments here.",
+                        }),
+                      }
+                    );
+                    issueNumber = created.number;
+                  }
+
+                  fs.appendFileSync(process.env.GITHUB_OUTPUT, `issue_number=${issueNumber}\n`);
+                  NODE
+
+    writer:
+        runs-on: ubuntu-22.04
+        needs: coordinator
+        timeout-minutes: 90
+        concurrency:
+            group: file-share-two-runner-writer-${{ github.ref_name }}-${{ inputs.file_mb }}
+            cancel-in-progress: false
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  run_install: false
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: pnpm
+                  cache-dependency-path: pnpm-lock.yaml
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Install Playwright Chromium
+              run: pnpm exec playwright install --with-deps chromium
+
+            - name: Run writer benchmark
+              working-directory: packages/file-share/frontend
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  GITHUB_REPOSITORY: ${{ github.repository }}
+                  COORDINATION_ISSUE: ${{ needs.coordinator.outputs.issue_number }}
+                  PW_BASE_URL: ${{ inputs.base_url }}
+                  PW_FILE_MB: ${{ inputs.file_mb }}
+                  PW_RESULT_FILE: ${{ github.workspace }}/bench-results/writer.json
+              run: |
+                  mkdir -p "$GITHUB_WORKSPACE/bench-results"
+                  node tests/two-runner.bench.mjs writer
+
+            - name: Upload writer artifacts
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: file-share-two-runner-writer-${{ github.run_id }}
+                  path: bench-results
+
+    reader:
+        runs-on: ubuntu-22.04
+        needs: coordinator
+        timeout-minutes: 90
+        concurrency:
+            group: file-share-two-runner-reader-${{ github.ref_name }}-${{ inputs.file_mb }}
+            cancel-in-progress: false
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  run_install: false
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: pnpm
+                  cache-dependency-path: pnpm-lock.yaml
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Install Playwright Chromium
+              run: pnpm exec playwright install --with-deps chromium
+
+            - name: Run reader benchmark
+              working-directory: packages/file-share/frontend
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  GITHUB_REPOSITORY: ${{ github.repository }}
+                  COORDINATION_ISSUE: ${{ needs.coordinator.outputs.issue_number }}
+                  PW_BASE_URL: ${{ inputs.base_url }}
+                  PW_FILE_MB: ${{ inputs.file_mb }}
+                  PW_RESULT_FILE: ${{ github.workspace }}/bench-results/reader.json
+              run: |
+                  mkdir -p "$GITHUB_WORKSPACE/bench-results"
+                  node tests/two-runner.bench.mjs reader
+
+            - name: Upload reader artifacts
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: file-share-two-runner-reader-${{ github.run_id }}
+                  path: bench-results
+
+    summarize:
+        runs-on: ubuntu-22.04
+        needs:
+            - coordinator
+            - writer
+            - reader
+        if: always()
+        steps:
+            - name: Download writer artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: file-share-two-runner-writer-${{ github.run_id }}
+                  path: writer-results
+
+            - name: Download reader artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: file-share-two-runner-reader-${{ github.run_id }}
+                  path: reader-results
+
+            - name: Summarize results
+              env:
+                  BENCH_FILE_MB: ${{ inputs.file_mb }}
+                  BENCH_BASE_URL: ${{ inputs.base_url }}
+                  BENCH_MIN_UPLOAD_MBPS: ${{ inputs.min_upload_mbps }}
+                  BENCH_MIN_DOWNLOAD_MBPS: ${{ inputs.min_download_mbps }}
+              run: |
+                  node <<'NODE'
+                  const fs = require("node:fs");
+                  const path = require("node:path");
+
+                  const load = (dir, file) =>
+                    JSON.parse(fs.readFileSync(path.join(dir, file), "utf8"));
+
+                  const writer = load("writer-results", "writer.json");
+                  const reader = load("reader-results", "reader.json");
+
+                  const lines = [
+                    "# File-share two-runner benchmark",
+                    "",
+                    `- Base URL: \`${process.env.BENCH_BASE_URL}\``,
+                    `- File size: \`${process.env.BENCH_FILE_MB} MiB\``,
+                    `- Writer status: \`${writer.status}\``,
+                    `- Reader status: \`${reader.status}\``,
+                  ];
+
+                  if (writer.status === "passed") {
+                    lines.push(
+                      `- Upload: \`${(Number(writer.uploadDurationMs) / 1000).toFixed(2)}s\` at \`${Number(writer.uploadMbps).toFixed(2)} Mbps\``
+                    );
+                  } else {
+                    lines.push(`- Writer failure: \`${writer.failure?.message || "unknown"}\``);
+                  }
+
+                  if (reader.status === "passed") {
+                    lines.push(
+                      `- Reader listing wait: \`${(Number(reader.listingWaitMs) / 1000).toFixed(2)}s\``,
+                      `- Download: \`${(Number(reader.downloadDurationMs) / 1000).toFixed(2)}s\` at \`${Number(reader.downloadMbps).toFixed(2)} Mbps\``
+                    );
+                  } else {
+                    lines.push(`- Reader failure: \`${reader.failure?.message || "unknown"}\``);
+                  }
+
+                  if (process.env.GITHUB_STEP_SUMMARY) {
+                    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join("\n") + "\n");
+                  } else {
+                    console.log(lines.join("\n"));
+                  }
+
+                  if (writer.status !== "passed" || reader.status !== "passed") {
+                    throw new Error("Two-runner benchmark did not complete successfully");
+                  }
+
+                  const minUpload = Number(process.env.BENCH_MIN_UPLOAD_MBPS || "0");
+                  const minDownload = Number(process.env.BENCH_MIN_DOWNLOAD_MBPS || "0");
+
+                  if (minUpload > 0 && Number(writer.uploadMbps) < minUpload) {
+                    throw new Error(
+                      `Upload throughput ${Number(writer.uploadMbps).toFixed(2)} Mbps is below threshold ${minUpload} Mbps`
+                    );
+                  }
+                  if (minDownload > 0 && Number(reader.downloadMbps) < minDownload) {
+                    throw new Error(
+                      `Download throughput ${Number(reader.downloadMbps).toFixed(2)} Mbps is below threshold ${minDownload} Mbps`
+                    );
+                  }
+                  NODE

--- a/packages/file-share/frontend/tests/two-runner.bench.mjs
+++ b/packages/file-share/frontend/tests/two-runner.bench.mjs
@@ -1,0 +1,587 @@
+import fs from "node:fs";
+import { mkdir, open, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { chromium } from "@playwright/test";
+
+const MODE = process.argv[2];
+const BASE_URL = (process.env.PW_BASE_URL || "https://files.dao.xyz").replace(
+    /\/$/,
+    ""
+);
+const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "512");
+const RESULT_FILE = process.env.PW_RESULT_FILE;
+const STREAMING_DOWNLOAD_THRESHOLD_BYTES = 250_000_000;
+const UPLOAD_TIMEOUT_MS = Number(
+    process.env.PW_UPLOAD_TIMEOUT_MS || "1800000"
+);
+const DOWNLOAD_TIMEOUT_MS = Number(
+    process.env.PW_DOWNLOAD_TIMEOUT_MS || "1800000"
+);
+const COORDINATION_TIMEOUT_MS = Number(
+    process.env.PW_COORDINATION_TIMEOUT_MS || "2700000"
+);
+const POLL_INTERVAL_MS = Number(process.env.PW_COORDINATION_POLL_MS || "10000");
+const RUN_ID = process.env.GITHUB_RUN_ID || `local-${Date.now()}`;
+const COORDINATION_FILE = process.env.COORDINATION_FILE;
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY;
+const COORDINATION_ISSUE = process.env.COORDINATION_ISSUE;
+
+const rootUrl = (baseURL) => `${baseURL.replace(/\/$/, "")}/#/`;
+
+const persistResult = async (result) => {
+    if (!RESULT_FILE) {
+        return;
+    }
+    await mkdir(path.dirname(RESULT_FILE), { recursive: true });
+    await writeFile(RESULT_FILE, `${JSON.stringify(result, null, 2)}\n`);
+};
+
+const toMiBPerSecond = (bytes, durationMs) =>
+    durationMs > 0 ? bytes / (1024 * 1024) / (durationMs / 1000) : null;
+
+const toMbps = (bytes, durationMs) =>
+    durationMs > 0 ? (bytes * 8) / 1_000_000 / (durationMs / 1000) : null;
+
+const createSyntheticFileOnDisk = async (fileName, sizeMb) => {
+    const dir = await fs.promises.mkdtemp(
+        path.join(tmpdir(), "peerbit-file-share-")
+    );
+    const filePath = path.join(dir, fileName);
+    const file = await open(filePath, "w");
+    try {
+        await file.truncate(sizeMb * 1024 * 1024);
+    } finally {
+        await file.close();
+    }
+    return { dir, filePath, fileName };
+};
+
+const waitForCreateSpaceHook = async (page) => {
+    await page.waitForFunction(
+        () => Boolean(window.__peerbitFileShareCreateSpace),
+        undefined,
+        { timeout: 180_000 }
+    );
+};
+
+const createSpaceFromHook = async (page, name) =>
+    page.evaluate(async (spaceName) => {
+        const createSpace = window.__peerbitFileShareCreateSpace;
+        if (!createSpace) {
+            throw new Error("Missing __peerbitFileShareCreateSpace");
+        }
+        return await createSpace(spaceName);
+    }, name);
+
+const seedReplicationRole = async (page, address, roleOptions) => {
+    await page.addInitScript(
+        ({ shareAddress, role }) => {
+            window.localStorage.setItem(
+                `${shareAddress}-role`,
+                JSON.stringify(role)
+            );
+        },
+        { shareAddress: address, role: roleOptions }
+    );
+};
+
+const waitForFileListed = async (page, fileName, timeout = 180_000) => {
+    await page.locator("li", { hasText: fileName }).first().waitFor({ timeout });
+};
+
+const waitForUploadComplete = async (page, timeout = 600_000) => {
+    const progress = page.locator(
+        '[data-testid="upload-progress"], .progress-root'
+    );
+    if ((await progress.count()) === 0) {
+        return;
+    }
+    await progress.first().waitFor({ state: "hidden", timeout });
+};
+
+const ignoreTimeout = (promise) =>
+    promise.catch((error) => {
+        if (
+            error?.name === "TimeoutError" ||
+            /Timeout .* exceeded/i.test(String(error?.message || ""))
+        ) {
+            return new Promise(() => {});
+        }
+        throw error;
+    });
+
+const getDownloadButton = async (page, fileName) => {
+    const row = page.locator("li", { hasText: fileName }).first();
+    await row.waitFor({ timeout: 60_000 });
+    const byTestId = row.getByTestId("download-file");
+    const button =
+        (await byTestId.count()) > 0 ? byTestId : row.locator("button").first();
+    return { row, button };
+};
+
+const installMockSaveFilePicker = async (page) => {
+    await page.addInitScript(() => {
+        const savedFiles = [];
+        Object.defineProperty(window, "__peerbitStreamingDownloadThresholdBytes", {
+            value: 1,
+            configurable: true,
+            enumerable: false,
+            writable: true,
+        });
+        Object.defineProperty(window, "__mockSavedFiles", {
+            value: savedFiles,
+            configurable: true,
+            enumerable: false,
+            writable: false,
+        });
+        Object.defineProperty(window, "showSaveFilePicker", {
+            configurable: true,
+            enumerable: false,
+            writable: true,
+            value: async (options) => {
+                let written = 0;
+                return {
+                    createWritable: async () => ({
+                        write: async (data) => {
+                            written += data.byteLength ?? 0;
+                        },
+                        close: async () => {
+                            savedFiles.push({
+                                name: options?.suggestedName ?? "download.bin",
+                                size: written,
+                            });
+                        },
+                        abort: async () => {},
+                    }),
+                };
+            },
+        });
+    });
+};
+
+const expectDownloadedFile = async (
+    page,
+    fileName,
+    expectedSizeMb,
+    timeout = 8 * 60 * 1000
+) => {
+    const { button } = await getDownloadButton(page, fileName);
+
+    const downloadPromise = page.waitForEvent("download", { timeout });
+    const dialogFailure = ignoreTimeout(
+        page.waitForEvent("dialog", { timeout }).then(async (dialog) => {
+            const message = dialog.message();
+            await dialog.dismiss().catch(() => {});
+            throw new Error(`Download failed dialog: ${message}`);
+        })
+    );
+    const pageErrorFailure = ignoreTimeout(
+        page.waitForEvent("pageerror", { timeout }).then((error) => {
+            throw error;
+        })
+    );
+
+    await button.click();
+    const download = await Promise.race([
+        downloadPromise,
+        dialogFailure,
+        pageErrorFailure,
+    ]);
+
+    const dir = await fs.promises.mkdtemp(
+        path.join(tmpdir(), "peerbit-file-download-")
+    );
+    const downloadPath = path.join(dir, fileName);
+    await download.saveAs(downloadPath);
+    const details = await stat(downloadPath);
+    if (details.size !== expectedSizeMb * 1024 * 1024) {
+        throw new Error(
+            `Unexpected downloaded file size ${details.size} for ${fileName}`
+        );
+    }
+    return { downloadPath, size: details.size };
+};
+
+const expectSavedViaPicker = async (
+    page,
+    fileName,
+    expectedSizeMb,
+    timeout = 8 * 60 * 1000
+) => {
+    const expectedBytes = expectedSizeMb * 1024 * 1024;
+    const { button } = await getDownloadButton(page, fileName);
+    const dialogFailure = ignoreTimeout(
+        page.waitForEvent("dialog", { timeout }).then(async (dialog) => {
+            const message = dialog.message();
+            await dialog.dismiss().catch(() => {});
+            throw new Error(`Download failed dialog: ${message}`);
+        })
+    );
+    const pageErrorFailure = ignoreTimeout(
+        page.waitForEvent("pageerror", { timeout }).then((error) => {
+            throw error;
+        })
+    );
+    const streamedSave = page
+        .waitForFunction(
+            ({ expectedName, expectedSize }) => {
+                const savedFiles = window.__mockSavedFiles ?? [];
+                return (
+                    savedFiles.find(
+                        (file) =>
+                            file.name === expectedName &&
+                            file.size === expectedSize
+                    ) ?? null
+                );
+            },
+            {
+                expectedName: fileName,
+                expectedSize: expectedBytes,
+            },
+            { timeout }
+        )
+        .then(() => ({ size: expectedBytes }));
+
+    await button.click();
+    return await Promise.race([streamedSave, dialogFailure, pageErrorFailure]);
+};
+
+const marker = (kind) =>
+    `<!-- file-share-two-runner run:${RUN_ID} kind:${kind} -->`;
+
+const parseEventBody = (body) => {
+    const match = body.match(
+        /^<!-- file-share-two-runner run:(.+?) kind:(.+?) -->\n```json\n([\s\S]*?)\n```$/m
+    );
+    if (!match) {
+        return null;
+    }
+    try {
+        return {
+            runId: match[1],
+            kind: match[2],
+            payload: JSON.parse(match[3]),
+        };
+    } catch {
+        return null;
+    }
+};
+
+const createFileCoordinator = (filePath) => ({
+    async publish(kind, payload) {
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await fs.promises.appendFile(
+            filePath,
+            `${JSON.stringify({ runId: RUN_ID, kind, payload })}\n`
+        );
+    },
+    async waitForAny(kinds, timeoutMs) {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            if (fs.existsSync(filePath)) {
+                const text = await readFile(filePath, "utf8");
+                const events = text
+                    .split("\n")
+                    .filter(Boolean)
+                    .map((line) => JSON.parse(line))
+                    .filter((event) => event.runId === RUN_ID);
+                const match = events.find((event) => kinds.includes(event.kind));
+                if (match) {
+                    return match;
+                }
+            }
+            await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+        }
+        throw new Error(
+            `Timed out waiting for coordination event ${kinds.join(", ")}`
+        );
+    },
+});
+
+const githubRequest = async (url, init = {}) => {
+    if (!GITHUB_TOKEN || !GITHUB_REPOSITORY || !COORDINATION_ISSUE) {
+        throw new Error("Missing GitHub coordination environment");
+    }
+    const response = await fetch(url, {
+        ...init,
+        headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${GITHUB_TOKEN}`,
+            "X-GitHub-Api-Version": "2022-11-28",
+            ...(init.headers || {}),
+        },
+    });
+    if (!response.ok) {
+        throw new Error(
+            `GitHub coordination request failed (${response.status}): ${await response.text()}`
+        );
+    }
+    if (response.status === 204) {
+        return null;
+    }
+    return await response.json();
+};
+
+const createGithubCoordinator = () => {
+    const issueUrl = `https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${COORDINATION_ISSUE}/comments?per_page=100`;
+    return {
+        async publish(kind, payload) {
+            const body = `${marker(kind)}\n\`\`\`json\n${JSON.stringify(
+                payload,
+                null,
+                2
+            )}\n\`\`\``;
+            await githubRequest(issueUrl, {
+                method: "POST",
+                body: JSON.stringify({ body }),
+            });
+        },
+        async waitForAny(kinds, timeoutMs) {
+            const deadline = Date.now() + timeoutMs;
+            while (Date.now() < deadline) {
+                const comments = await githubRequest(issueUrl);
+                const parsed = comments
+                    .map((comment) => parseEventBody(comment.body))
+                    .filter(Boolean)
+                    .filter((event) => event.runId === RUN_ID)
+                    .filter((event) => kinds.includes(event.kind));
+                if (parsed.length > 0) {
+                    return parsed[parsed.length - 1];
+                }
+                await new Promise((resolve) =>
+                    setTimeout(resolve, POLL_INTERVAL_MS)
+                );
+            }
+            throw new Error(
+                `Timed out waiting for coordination event ${kinds.join(", ")}`
+            );
+        },
+    };
+};
+
+const createCoordinator = () => {
+    if (COORDINATION_FILE) {
+        return createFileCoordinator(COORDINATION_FILE);
+    }
+    return createGithubCoordinator();
+};
+
+const createFailure = (error) => ({
+    message: typeof error?.message === "string" ? error.message : String(error),
+    stack: typeof error?.stack === "string" ? error.stack : undefined,
+});
+
+const runWriter = async (coordinator) => {
+    const browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({ acceptDownloads: true });
+    const page = await context.newPage();
+    const fileName = `file-share-two-runner-${Date.now()}.bin`;
+    const preparedFile = await createSyntheticFileOnDisk(fileName, FILE_SIZE_MB);
+
+    try {
+        const entryUrl = rootUrl(BASE_URL);
+        await page.goto(entryUrl, { waitUntil: "domcontentloaded" });
+        await waitForCreateSpaceHook(page);
+        const address = await createSpaceFromHook(
+            page,
+            `file-share-two-runner-${Date.now()}`
+        );
+        const shareUrl = new URL(entryUrl);
+        shareUrl.hash = `/s/${address}`;
+
+        await page.goto(shareUrl.toString(), { waitUntil: "domcontentloaded" });
+        await page.locator("#imgupload").waitFor({
+            state: "attached",
+            timeout: 60_000,
+        });
+
+        const uploadStartedAt = Date.now();
+        await page.locator("#imgupload").setInputFiles(preparedFile.filePath);
+        await waitForFileListed(page, fileName, UPLOAD_TIMEOUT_MS);
+        await waitForUploadComplete(page, UPLOAD_TIMEOUT_MS);
+        const uploadFinishedAt = Date.now();
+
+        const result = {
+            status: "passed",
+            role: "writer",
+            scenario: "prod",
+            baseURL: BASE_URL,
+            shareUrl: shareUrl.toString(),
+            address,
+            fileName,
+            fileSizeMb: FILE_SIZE_MB,
+            sizeBytes: FILE_SIZE_MB * 1024 * 1024,
+            uploadDurationMs: uploadFinishedAt - uploadStartedAt,
+            uploadMiBps: toMiBPerSecond(
+                FILE_SIZE_MB * 1024 * 1024,
+                uploadFinishedAt - uploadStartedAt
+            ),
+            uploadMbps: toMbps(
+                FILE_SIZE_MB * 1024 * 1024,
+                uploadFinishedAt - uploadStartedAt
+            ),
+            startedAt: uploadStartedAt,
+            finishedAt: uploadFinishedAt,
+        };
+
+        await coordinator.publish("writer-ready", result);
+        const readerEvent = await coordinator.waitForAny(
+            ["reader-complete", "reader-failed"],
+            COORDINATION_TIMEOUT_MS
+        );
+        if (readerEvent.kind === "reader-failed") {
+            throw new Error(
+                `Reader failed: ${readerEvent.payload?.message || "unknown error"}`
+            );
+        }
+        await persistResult({
+            ...result,
+            reader: readerEvent.payload,
+        });
+    } catch (error) {
+        const failure = createFailure(error);
+        await persistResult({
+            status: "failed",
+            role: "writer",
+            scenario: "prod",
+            fileName,
+            fileSizeMb: FILE_SIZE_MB,
+            failure,
+        });
+        await coordinator.publish("writer-failed", failure).catch(() => {});
+        throw error;
+    } finally {
+        await context.close().catch(() => {});
+        await browser.close().catch(() => {});
+        await rm(preparedFile.dir, {
+            recursive: true,
+            force: true,
+        }).catch(() => {});
+    }
+};
+
+const runReader = async (coordinator) => {
+    const readyEvent = await coordinator.waitForAny(
+        ["writer-ready", "writer-failed"],
+        COORDINATION_TIMEOUT_MS
+    );
+    if (readyEvent.kind === "writer-failed") {
+        throw new Error(
+            `Writer failed before reader started: ${readyEvent.payload?.message || "unknown error"}`
+        );
+    }
+
+    const writer = readyEvent.payload;
+    const browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({ acceptDownloads: true });
+    const page = await context.newPage();
+    const usesStreamingDownload =
+        FILE_SIZE_MB * 1024 * 1024 >= STREAMING_DOWNLOAD_THRESHOLD_BYTES;
+
+    try {
+        if (usesStreamingDownload) {
+            await installMockSaveFilePicker(page);
+        }
+        await seedReplicationRole(page, writer.address, false);
+        await page.goto(writer.shareUrl, { waitUntil: "domcontentloaded" });
+        const readerReadyAt = Date.now();
+        await waitForFileListed(page, writer.fileName, UPLOAD_TIMEOUT_MS);
+        const listedAt = Date.now();
+
+        const downloadStartedAt = Date.now();
+        const downloaded = usesStreamingDownload
+            ? await expectSavedViaPicker(
+                  page,
+                  writer.fileName,
+                  FILE_SIZE_MB,
+                  DOWNLOAD_TIMEOUT_MS
+              ).then(() => ({ size: FILE_SIZE_MB * 1024 * 1024 }))
+            : await expectDownloadedFile(
+                  page,
+                  writer.fileName,
+                  FILE_SIZE_MB,
+                  DOWNLOAD_TIMEOUT_MS
+              );
+        const downloadFinishedAt = Date.now();
+
+        const result = {
+            status: "passed",
+            role: "reader",
+            scenario: "prod",
+            baseURL: BASE_URL,
+            shareUrl: writer.shareUrl,
+            fileName: writer.fileName,
+            fileSizeMb: FILE_SIZE_MB,
+            downloadMode: usesStreamingDownload
+                ? "save-picker-stream"
+                : "browser-download",
+            sizeBytes: downloaded.size,
+            listingWaitMs: listedAt - readerReadyAt,
+            downloadDurationMs: downloadFinishedAt - downloadStartedAt,
+            downloadMiBps: toMiBPerSecond(
+                downloaded.size,
+                downloadFinishedAt - downloadStartedAt
+            ),
+            downloadMbps: toMbps(
+                downloaded.size,
+                downloadFinishedAt - downloadStartedAt
+            ),
+            startedAt: readerReadyAt,
+            finishedAt: downloadFinishedAt,
+        };
+
+        await persistResult(result);
+        await coordinator.publish("reader-complete", result);
+    } catch (error) {
+        const failure = createFailure(error);
+        await persistResult({
+            status: "failed",
+            role: "reader",
+            scenario: "prod",
+            fileName: writer.fileName,
+            fileSizeMb: FILE_SIZE_MB,
+            failure,
+        });
+        await coordinator.publish("reader-failed", failure).catch(() => {});
+        throw error;
+    } finally {
+        await context.close().catch(() => {});
+        await browser.close().catch(() => {});
+    }
+};
+
+const runSmoke = async (coordinator) => {
+    const payload = { ok: true, at: Date.now() };
+    await coordinator.publish("smoke", payload);
+    const event = await coordinator.waitForAny(["smoke"], 5_000);
+    await persistResult({
+        status: "passed",
+        role: "smoke",
+        payload: event.payload,
+    });
+};
+
+const main = async () => {
+    if (!["writer", "reader", "smoke"].includes(MODE)) {
+        throw new Error(
+            `Usage: node tests/two-runner.bench.mjs <writer|reader|smoke>`
+        );
+    }
+    const coordinator = createCoordinator();
+    if (MODE === "writer") {
+        await runWriter(coordinator);
+        return;
+    }
+    if (MODE === "reader") {
+        await runReader(coordinator);
+        return;
+    }
+    await runSmoke(coordinator);
+};
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a dedicated two-runner file-share benchmark workflow for GitHub Actions
- add a Playwright-based two-runner benchmark script that coordinates a writer runner and a reader runner through a reusable GitHub coordination issue
- keep the existing single-runner workflow intact for the fast local/prod smoke path

## Validation
- `node --check packages/file-share/frontend/tests/two-runner.bench.mjs`
- `cd packages/file-share/frontend && COORDINATION_FILE=/tmp/peerbit-two-runner-smoke.jsonl PW_RESULT_FILE=/tmp/peerbit-two-runner-smoke-result.json node tests/two-runner.bench.mjs smoke`
- `pnpm --filter @peerbit/please-lib build`
- `pnpm --filter file-share build`

## Notes
- this workflow is intentionally `workflow_dispatch` only
- it uses one persistent coordination issue instead of opening a new issue for every run
- the first version is focused on the real deployed `prod` path rather than trying to force a two-runner `local` mode
