### PR TITLE
fix(file-share): run benchmark workflow snippets as commonjs

### DIFF
--- a/.github/workflows/file-share-two-runner-benchmarks.yml
+++ b/.github/workflows/file-share-two-runner-benchmarks.yml
@@ -40,7 +40,7 @@ jobs:
                   GITHUB_TOKEN: ${{ github.token }}
                   GITHUB_REPOSITORY: ${{ github.repository }}
               run: |
-                  node <<'NODE'
+                  node --input-type=commonjs <<'NODE'
                   const fs = require("node:fs");
 
                   const token = process.env.GITHUB_TOKEN;
@@ -212,7 +212,7 @@ jobs:
                   BENCH_MIN_UPLOAD_MBPS: ${{ inputs.min_upload_mbps }}
                   BENCH_MIN_DOWNLOAD_MBPS: ${{ inputs.min_download_mbps }}
               run: |
-                  node <<'NODE'
+                  node --input-type=commonjs <<'NODE'
                   const fs = require("node:fs");
                   const path = require("node:path");
 


### PR DESCRIPTION
## Summary
- fix the new two-runner workflow's inline Node snippets to run in CommonJS mode inside the ESM repo

## Why
The first live run of `File Share Two-Runner Benchmarks` failed in the coordinator job before the transfer started because `node <<'NODE'` was evaluated as an ES module and rejected `require(...)`.
