### PR TITLE
fix(file-share): pipeline persisted chunk downloads

### DIFF
--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -176,11 +176,11 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
-        it("streams large downloads without parentId chunk searches when chunk reads are persisted", async () => {
+        it("pipelines persisted chunk reads without using parentId searches", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
             const fileId = await filestore.add(
-                "streamed download without parentId search",
+                "streamed download with persisted read-ahead",
                 largeFile
             );
 
@@ -194,7 +194,12 @@ describe("index", () => {
 
             const originalSearch =
                 filestoreReader.files.index.search.bind(filestoreReader.files.index);
+            const originalGet =
+                filestoreReader.files.index.get.bind(filestoreReader.files.index);
             let parentIdSearches = 0;
+            let directChunkGets = 0;
+            let inflightChunkGets = 0;
+            let maxInflightChunkGets = 0;
 
             (filestoreReader.files.index as any).search = async (
                 request: { query: unknown | unknown[] },
@@ -216,6 +221,23 @@ describe("index", () => {
                 return originalSearch(request as never, options as never);
             };
 
+            (filestoreReader.files.index as any).get = async (
+                id: string,
+                options: unknown
+            ) => {
+                if (id.startsWith(`${fileId}:`)) {
+                    directChunkGets++;
+                    inflightChunkGets++;
+                    maxInflightChunkGets = Math.max(
+                        maxInflightChunkGets,
+                        inflightChunkGets
+                    );
+                    await delay(25);
+                    inflightChunkGets--;
+                }
+                return originalGet(id as never, options as never);
+            };
+
             const streamedChunks: Uint8Array[] = [];
 
             await file!.writeFile(filestoreReader, {
@@ -225,6 +247,8 @@ describe("index", () => {
             });
 
             expect(parentIdSearches).to.eq(0);
+            expect(directChunkGets).to.be.greaterThan(1);
+            expect(maxInflightChunkGets).to.be.greaterThan(1);
             expect(streamedChunks.length).to.be.greaterThan(1);
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -125,6 +125,7 @@ const LARGE_FILE_TARGET_CHUNK_COUNT = 1024;
 const CHUNK_SIZE_GRANULARITY = 64 * 1024;
 const MAX_LARGE_FILE_SEGMENT_SIZE = TINY_FILE_SIZE_LIMIT - 256 * 1024;
 const LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS = 5 * 60 * 1000;
+const LARGE_FILE_PERSISTED_READ_AHEAD = 16;
 const TINY_FILE_SIZE_LIMIT_BIGINT = BigInt(TINY_FILE_SIZE_LIMIT);
 
 const roundUpTo = (value: number, multiple: number) =>
@@ -413,13 +414,39 @@ export class LargeFile extends AbstractFile {
                       })
                   ).map((chunk) => [chunk.index || 0, chunk])
               );
+        const inFlightChunks = new Map<number, Promise<TinyFile>>();
+        const resolveChunkWithReadAhead = (index: number) => {
+            const cached = inFlightChunks.get(index);
+            if (cached) {
+                return cached;
+            }
+            const pending = this.resolveChunk(files, index, knownChunks, {
+                timeout: properties?.timeout,
+            });
+            inFlightChunks.set(index, pending);
+            return pending;
+        };
+
+        if (files.persistChunkReads) {
+            for (
+                let index = 0;
+                index <
+                Math.min(this.chunkCount, LARGE_FILE_PERSISTED_READ_AHEAD);
+                index++
+            ) {
+                void resolveChunkWithReadAhead(index);
+            }
+        }
 
         for (let index = 0; index < this.chunkCount; index++) {
+            const nextIndex = index + LARGE_FILE_PERSISTED_READ_AHEAD;
+            if (files.persistChunkReads && nextIndex < this.chunkCount) {
+                void resolveChunkWithReadAhead(nextIndex);
+            }
             const chunkFile = files.persistChunkReads
-                ? await this.resolveChunk(files, index, knownChunks, {
-                      timeout: properties?.timeout,
-                  })
+                ? await resolveChunkWithReadAhead(index)
                 : knownChunks.get(index);
+            inFlightChunks.delete(index);
             if (!chunkFile) {
                 throw new Error(
                     `Failed to resolve chunk ${index + 1}/${this.chunkCount} for file ${this.id}`


### PR DESCRIPTION
## Summary
- pipeline persisted chunk downloads with read-ahead instead of resolving every chunk strictly serially
- keep observer reads on the existing bulk-fetch path and keep persisted reads off the parentId search path
- cover the new behavior with a focused file-share integration test

## Validation
- pnpm --filter @peerbit/please-lib build
- pnpm --filter @peerbit/please build
- pnpm exec vitest run packages/file-share/library/src/__tests__/index.integration.test.ts -t "pipelines persisted chunk reads without using parentId searches"