### PR TITLE
chore(examples): refresh document release line

### DIFF
--- a/packages/blog-platform/library/package.json
+++ b/packages/blog-platform/library/package.json
@@ -36,8 +36,8 @@
         "typescript": "^5.6.3"
     },
     "dependencies": {
-        "@peerbit/document": "13.0.23",
-        "@peerbit/trusted-network": "^6.0.23",
+        "@peerbit/document": "13.0.24",
+        "@peerbit/trusted-network": "^6.0.24",
         "peerbit": "^5.2.6",
         "uuid": "^10.0.0"
     }

--- a/packages/chess/frontend/package.json
+++ b/packages/chess/frontend/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@giga-app/sdk": "workspace:*",
-        "@peerbit/document-react": "^1.0.23",
+        "@peerbit/document-react": "^1.0.24",
         "@peerbit/react": "^1.1.9",
         "@radix-ui/react-popover": "^1.0.7",
         "@radix-ui/react-progress": "^1.0.3",

--- a/packages/collaborative-learning/frontend/package.json
+++ b/packages/collaborative-learning/frontend/package.json
@@ -17,7 +17,7 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^7.0.2",
         "@mui/material": "^5.15.7",
-        "@peerbit/document": "13.0.23",
+        "@peerbit/document": "13.0.24",
         "@peerbit/react": "^1.1.9",
         "@tensorflow/tfjs": "^4.2.0",
         "events": "^3.3.0",

--- a/packages/file-share/frontend/package.json
+++ b/packages/file-share/frontend/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "@dao-xyz/borsh": "^6.0.0",
         "@peerbit/crypto": "^3.1.0",
-        "@peerbit/document": "13.0.23",
+        "@peerbit/document": "13.0.24",
         "@peerbit/please-lib": "workspace:*",
         "@peerbit/react": "^1.1.9",
         "@peerbit/shared-log": "13.0.23",

--- a/packages/file-share/library/package.json
+++ b/packages/file-share/library/package.json
@@ -41,10 +41,10 @@
     "dependencies": {
         "@dao-xyz/borsh": "^6.0.0",
         "@peerbit/crypto": "^3.1.0",
-        "@peerbit/document": "13.0.23",
+        "@peerbit/document": "13.0.24",
         "@peerbit/program": "6.0.17",
         "@peerbit/shared-log": "13.0.23",
-        "@peerbit/trusted-network": "^6.0.23",
+        "@peerbit/trusted-network": "^6.0.24",
         "@stablelib/sha256": "^2.0.1",
         "peerbit": "^5.2.6",
         "uint8arrays": "^5.1.0",

--- a/packages/many-chat-rooms/frontend/package.json
+++ b/packages/many-chat-rooms/frontend/package.json
@@ -17,7 +17,7 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^7.0.2",
         "@mui/material": "^5.15.7",
-        "@peerbit/document": "13.0.23",
+        "@peerbit/document": "13.0.24",
         "@peerbit/example-many-chat-rooms": "workspace:*",
         "@peerbit/peer-names": "workspace:*",
         "@peerbit/react": "^1.1.9",

--- a/packages/media-streaming/music-library/frontend/package.json
+++ b/packages/media-streaming/music-library/frontend/package.json
@@ -19,8 +19,8 @@
     },
     "dependencies": {
         "@giga-app/sdk": "workspace:*",
-        "@peerbit/document": "13.0.23",
-        "@peerbit/document-react": "^1.0.23",
+        "@peerbit/document": "13.0.24",
+        "@peerbit/document-react": "^1.0.24",
         "@peerbit/media-streaming": "workspace:*",
         "@peerbit/media-streaming-web": "workspace:*",
         "@peerbit/music-library-utils": "workspace:*",

--- a/packages/media-streaming/music-library/music-library-utils/package.json
+++ b/packages/media-streaming/music-library/music-library-utils/package.json
@@ -41,7 +41,7 @@
         "typescript": "^5.6.3"
     },
     "dependencies": {
-        "@peerbit/document": "13.0.23",
+        "@peerbit/document": "13.0.24",
         "@peerbit/media-streaming": "workspace:*",
         "peerbit": "^5.2.6",
         "uuid": "^10.0.0"

--- a/packages/media-streaming/playback-utils/package.json
+++ b/packages/media-streaming/playback-utils/package.json
@@ -44,7 +44,7 @@
         "typescript": "^5.6.3"
     },
     "dependencies": {
-        "@peerbit/document": "13.0.23",
+        "@peerbit/document": "13.0.24",
         "@peerbit/media-streaming": "workspace:*",
         "peerbit": "^5.2.6",
         "uuid": "^10.0.0"

--- a/packages/media-streaming/streaming-utils/package.json
+++ b/packages/media-streaming/streaming-utils/package.json
@@ -40,7 +40,7 @@
         "typescript": "^5.6.3"
     },
     "dependencies": {
-        "@peerbit/document": "13.0.23",
+        "@peerbit/document": "13.0.24",
         "peerbit": "^5.2.6",
         "uuid": "^10.0.0"
     }

--- a/packages/media-streaming/video-streaming/frontend/package.json
+++ b/packages/media-streaming/video-streaming/frontend/package.json
@@ -19,8 +19,8 @@
     },
     "dependencies": {
         "@giga-app/sdk": "workspace:*",
-        "@peerbit/document": "13.0.23",
-        "@peerbit/document-react": "^1.0.23",
+        "@peerbit/document": "13.0.24",
+        "@peerbit/document-react": "^1.0.24",
         "@peerbit/media-streaming": "workspace:*",
         "@peerbit/media-streaming-web": "workspace:*",
         "@peerbit/react": "^1.1.9",

--- a/packages/one-chat-room/frontend/package.json
+++ b/packages/one-chat-room/frontend/package.json
@@ -17,7 +17,7 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^7.0.2",
         "@mui/material": "^5.15.7",
-        "@peerbit/document": "13.0.23",
+        "@peerbit/document": "13.0.24",
         "@peerbit/peer-names": "workspace:*",
         "@peerbit/program-react": "^0.4.20",
         "@peerbit/react": "^1.1.9",

--- a/packages/sharedworker-todo/frontend/package.json
+++ b/packages/sharedworker-todo/frontend/package.json
@@ -14,9 +14,9 @@
         "@libp2p/circuit-relay-v2": "^4.1.0",
         "@libp2p/websockets": "^10.1.0",
         "@peerbit/canonical-host": "^1.0.26",
-        "@peerbit/document": "13.0.23",
-        "@peerbit/document-proxy": "^2.0.23",
-        "@peerbit/document-react": "^1.0.23",
+        "@peerbit/document": "13.0.24",
+        "@peerbit/document-proxy": "^2.0.24",
+        "@peerbit/document-react": "^1.0.24",
         "@peerbit/react": "^1.1.9",
         "react": "^19.2.0",
         "react-dom": "^19.1.0"

--- a/packages/social-media-app/ai/library/package.json
+++ b/packages/social-media-app/ai/library/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@giga-app/interface": "workspace:*",
-        "@peerbit/document": "13.0.23",
+        "@peerbit/document": "13.0.24",
         "ollama": "^0.5.14",
         "peerbit": "^5.2.6",
         "uuid": "^10.0.0"

--- a/packages/social-media-app/app-service/package.json
+++ b/packages/social-media-app/app-service/package.json
@@ -37,7 +37,7 @@
         "typescript": "^5.6.3"
     },
     "dependencies": {
-        "@peerbit/document": "13.0.23",
+        "@peerbit/document": "13.0.24",
         "parse5": "^7.1.2",
         "peerbit": "^5.2.6",
         "uuid": "^10.0.0"

--- a/packages/social-media-app/frontend/package.json
+++ b/packages/social-media-app/frontend/package.json
@@ -31,7 +31,7 @@
         "@giga-app/network": "workspace:*",
         "@giga-app/sdk": "workspace:*",
         "@headlessui/react": "^2.2.0",
-        "@peerbit/document-react": "^1.0.23",
+        "@peerbit/document-react": "^1.0.24",
         "@peerbit/identity-supabase": "workspace:*",
         "@peerbit/peer-names": "workspace:*",
         "@peerbit/program-react": "^0.4.20",

--- a/packages/social-media-app/library/package.json
+++ b/packages/social-media-app/library/package.json
@@ -41,7 +41,7 @@
         "vitest": "^3.2.4"
     },
     "dependencies": {
-        "@peerbit/document": "13.0.23",
+        "@peerbit/document": "13.0.24",
         "peerbit": "^5.2.6",
         "qrcode": "^1.5.4",
         "uuid": "^10.0.0"

--- a/packages/svelte-example/package.json
+++ b/packages/svelte-example/package.json
@@ -10,7 +10,7 @@
         "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
     },
     "dependencies": {
-        "@peerbit/document": "13.0.23",
+        "@peerbit/document": "13.0.24",
         "peerbit": "^5.2.6",
         "uuid": "^10"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,11 +187,11 @@ importers:
         specifier: workspace:*
         version: link:../../social-media-app/app-sdk
       '@peerbit/document-react':
-        specifier: ^1.0.23
-        version: 1.0.23(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        specifier: ^1.0.24
+        version: 1.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@peerbit/react':
         specifier: ^1.1.9
-        version: 1.1.9(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.9(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-popover':
         specifier: ^1.0.7
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -218,7 +218,7 @@ importers:
         version: 1.4.0
       peerbit:
         specifier: 5.2.6
-        version: 5.2.6(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.2.6(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -285,10 +285,10 @@ importers:
         version: 5.18.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@peerbit/document':
         specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        version: 13.0.23(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/react':
         specifier: ^1.1.9
-        version: 1.1.9(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.9(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@tensorflow/tfjs':
         specifier: ^4.2.0
         version: 4.22.0(seedrandom@3.0.5)
@@ -297,7 +297,7 @@ importers:
         version: 3.3.0
       peerbit:
         specifier: 5.2.6
-        version: 5.2.6(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.2.6(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -609,8 +609,8 @@ importers:
         specifier: 13.0.23
         version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/document-react':
-        specifier: ^1.0.23
-        version: 1.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        specifier: ^1.0.24
+        version: 1.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@peerbit/media-streaming':
         specifier: workspace:*
         version: link:../../streaming-utils
@@ -806,8 +806,8 @@ importers:
         specifier: 13.0.23
         version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/document-react':
-        specifier: ^1.0.23
-        version: 1.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        specifier: ^1.0.24
+        version: 1.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@peerbit/media-streaming':
         specifier: workspace:*
         version: link:../../streaming-utils
@@ -994,11 +994,11 @@ importers:
         specifier: 13.0.23
         version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/document-proxy':
-        specifier: ^2.0.23
-        version: 2.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: ^2.0.24
+        version: 2.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/document-react':
-        specifier: ^1.0.23
-        version: 1.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        specifier: ^1.0.24
+        version: 1.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@peerbit/react':
         specifier: ^1.1.9
         version: 1.1.9(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
@@ -1252,8 +1252,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@peerbit/document-react':
-        specifier: ^1.0.23
-        version: 1.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        specifier: ^1.0.24
+        version: 1.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@peerbit/identity-supabase':
         specifier: workspace:*
         version: link:../../identity/supabase
@@ -3159,12 +3159,12 @@ packages:
   '@peerbit/document-interface@3.2.26':
     resolution: {integrity: sha512-yv3feNd4DYmAOaG/Mt3wrTTKYUHEn3psbgiv3osj+Ijd6X8e0WVCy1DQF34fN2wHB0o49dODurOUtsEof7gRjQ==}
 
-  '@peerbit/document-proxy@2.0.23':
-    resolution: {integrity: sha512-tFuapc0tSjn24M9KQAejpOwfRlnxZFDEHgYheeZpdeYm6vwyXUu74GFMvWl9hB3DLECoOqU4QmF8f/N92uaxKg==}
+  '@peerbit/document-proxy@2.0.24':
+    resolution: {integrity: sha512-LgtKGiUR36oZx981QKBkHTaellWQ0C+VosJlizIglachSc73sc3J9gvdfc3bD1WTXdQgNJtryFpPilvs4/R6SQ==}
     engines: {node: '>=18'}
 
-  '@peerbit/document-react@1.0.23':
-    resolution: {integrity: sha512-lrFNZfh/txORcl//EgHfOozT4ejqf9H3Yo3qzYpiUSJEaZIH00yW3Nzc2IgOKjEkENu5aV/bFXZsKsbLExtjDw==}
+  '@peerbit/document-react@1.0.24':
+    resolution: {integrity: sha512-N5sruHkhMfAY2Jo0TVIcNxBHwpT+/QM8wq1e6lV5S2TIMfrl3hnq9i5Ehnnwb9PsgmlzvdR7jL5/Go2+MJt3xg==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
@@ -12043,7 +12043,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@peerbit/document-proxy@2.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))':
+  '@peerbit/document-proxy@2.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
       '@dao-xyz/borsh-rpc': 2.0.5
@@ -12061,21 +12061,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@peerbit/document-react@1.0.23(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@peerbit/document': 13.0.23(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))
-      '@peerbit/indexer-interface': 3.0.3
-      '@peerbit/logger': 2.0.1
-      '@peerbit/react': 1.1.9(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
-      react: 19.2.4
-      uuid: 10.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - react-native
-      - supports-color
-      - utf-8-validate
-
-  '@peerbit/document-react@1.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)':
+  '@peerbit/document-react@1.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@peerbit/document': 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/indexer-interface': 3.0.3


### PR DESCRIPTION
## Summary
- bump the examples repo to the newly released document/trusted-network line
- refresh pnpm lockfile against the published Peerbit packages
- validate the refreshed graph with a full build

## Verification
- pnpm install
- pnpm run build