### PR TITLE
fix(file-share): measure and unblock initial listing

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,11 +62,11 @@
             "@peerbit/canonical-client": "1.1.20",
             "@peerbit/canonical-host": "1.0.26",
             "@peerbit/crypto": "3.1.0",
-            "@peerbit/document": "13.0.23",
+            "@peerbit/document": "13.0.24",
             "@peerbit/program": "6.0.17",
             "@peerbit/shared-log": "13.0.23",
             "@peerbit/stream-interface": "6.0.7",
-            "@peerbit/trusted-network": "6.0.23",
+            "@peerbit/trusted-network": "6.0.24",
             "peerbit": "5.2.6",
             "libsodium": "0.7.15",
             "libsodium-wrappers": "0.7.15"

--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -1,6 +1,6 @@
 import { usePeer, useProgram } from "@peerbit/react";
 import { useNavigate, useParams } from "react-router";
-import { useEffect, useReducer, useState } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
 import { Files, AbstractFile, LargeFile } from "@peerbit/please-lib";
 import * as Toggle from "@radix-ui/react-toggle";
 import { MdArrowBack, MdUploadFile, MdClose, MdSettings } from "react-icons/md";
@@ -41,6 +41,25 @@ type BrowserFileWriter = {
     abort?(reason?: unknown): Promise<void>;
 };
 
+type ListingDiagnostics = {
+    mountedAt: number;
+    shareAddress: string | null;
+    initialRole: "replicator" | "replicator-default" | "observer";
+    onOpenStartedAt: number | null;
+    trustCheckStartedAt: number | null;
+    trustCheckFinishedAt: number | null;
+    firstListSource: string | null;
+    firstListStartedAt: number | null;
+    firstListFinishedAt: number | null;
+    firstListDurationMs: number | null;
+    firstMetadataRefreshFinishedAt: number | null;
+    updateRoleCount: number;
+    lastUpdateRoleStartedAt: number | null;
+    lastUpdateRoleFinishedAt: number | null;
+    lastAppliedRole: "replicator" | "observer" | null;
+    listCallCount: number;
+};
+
 type SaveFilePickerWindow = Window & {
     showSaveFilePicker?: (options?: {
         suggestedName?: string;
@@ -65,6 +84,33 @@ const getStreamingDownloadThresholdBytes = () => {
 
 const getFileSizeBigInt = (file: AbstractFile) =>
     typeof file.size === "bigint" ? file.size : BigInt(file.size);
+
+const createListingDiagnostics = (
+    shareAddress: string | undefined,
+    storedRole: ReplicationOptions | undefined
+): ListingDiagnostics => ({
+    mountedAt: Date.now(),
+    shareAddress: shareAddress ?? null,
+    initialRole:
+        storedRole === false
+            ? "observer"
+            : storedRole
+              ? "replicator"
+              : "replicator-default",
+    onOpenStartedAt: null,
+    trustCheckStartedAt: null,
+    trustCheckFinishedAt: null,
+    firstListSource: null,
+    firstListStartedAt: null,
+    firstListFinishedAt: null,
+    firstListDurationMs: null,
+    firstMetadataRefreshFinishedAt: null,
+    updateRoleCount: 0,
+    lastUpdateRoleStartedAt: null,
+    lastUpdateRoleFinishedAt: null,
+    lastAppliedRole: null,
+    listCallCount: 0,
+});
 
 export const useDebouncedEffect = (effect, deps, delay) => {
     useEffect(() => {
@@ -113,6 +159,16 @@ export const Drop = () => {
             ? null
             : window.localStorage.getItem(`${shareAddress}-role`)
     );
+    const diagnosticsRef = useRef<ListingDiagnostics>(
+        createListingDiagnostics(shareAddress, storedRole)
+    );
+
+    useEffect(() => {
+        diagnosticsRef.current = createListingDiagnostics(shareAddress, storedRole);
+        // Reset diagnostics only when we enter a different share. Role changes
+        // inside the same share are part of the same session we want to measure.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [shareAddress]);
 
     const files = useProgram<Files>(
         peer,
@@ -142,6 +198,11 @@ export const Drop = () => {
             return;
         }
 
+        diagnosticsRef.current.updateRoleCount += 1;
+        diagnosticsRef.current.lastAppliedRole =
+            roleOptions === false ? "observer" : "replicator";
+        diagnosticsRef.current.lastUpdateRoleStartedAt = Date.now();
+
         files.program.persistChunkReads = roleOptions !== false;
 
         // console.log("X", files.program.files.log["_roleOptions"]?.["limits"]?.["cpu"]?.max)
@@ -150,6 +211,7 @@ export const Drop = () => {
         if (roleOptions !== false) {
             await files.program.files.log.replicate(roleOptions);
         }
+        diagnosticsRef.current.lastUpdateRoleFinishedAt = Date.now();
     };
 
     useEffect(() => {
@@ -180,6 +242,8 @@ export const Drop = () => {
                     programClosed: files.program?.closed ?? null,
                     persistChunkReads: files.program?.persistChunkReads ?? null,
                     peerHash: peer?.identity?.publicKey?.hashcode?.() ?? null,
+                    programOpenDiagnostics:
+                        files.program?.openDiagnostics ?? null,
                     replicatorCount:
                         replicators && typeof replicators.size === "number"
                             ? replicators.size
@@ -188,6 +252,7 @@ export const Drop = () => {
                     replicationSetSize: replicationSet.size,
                     isHost: isHost ?? null,
                     left,
+                    timings: diagnosticsRef.current,
                 };
             },
         };
@@ -261,16 +326,8 @@ export const Drop = () => {
         );
 
         let onOpen = async () => {
-            const isTrusted =
-                !files.program.trustGraph ||
-                (await files.program.trustGraph.isTrusted(
-                    peer.identity.publicKey
-                ));
-            setIsHost(isTrusted);
+            diagnosticsRef.current.onOpenStartedAt = Date.now();
 
-            files.program = files.program;
-
-            // Second condition is for when we last time did use this files address, and if we where replicator at that time, be a replicator this time again
             const serializedRoleFromStorage = getRoleFromLocalStorage(
                 files.program
             );
@@ -278,8 +335,28 @@ export const Drop = () => {
             const roleFromLocalstore = parseStoredRole(
                 serializedRoleFromStorage
             );
+            const desiredRole =
+                hasStoredRole
+                    ? roleFromLocalstore
+                    : role === "replicator"
+                      ? DEFAULT_REPLICATION_ROLE
+                      : false;
+
+            files.program.persistChunkReads = desiredRole !== false;
+            setRole(desiredRole === false ? "observer" : "replicator");
+            void updateList("initial-open");
+
+            diagnosticsRef.current.trustCheckStartedAt = Date.now();
+            const isTrusted =
+                !files.program.trustGraph ||
+                (await files.program.trustGraph.isTrusted(
+                    peer.identity.publicKey
+                ));
+            diagnosticsRef.current.trustCheckFinishedAt = Date.now();
+            setIsHost(isTrusted);
+
+            files.program = files.program;
             if (isTrusted && hasStoredRole) {
-                // by default open as replicator
                 setLimitCPU(
                     files.program.files.log["_roleOptions"]?.["limits"]?.["cpu"]
                         ?.max
@@ -292,22 +369,10 @@ export const Drop = () => {
                         ? String(limitStorageLoaded)
                         : "0"
                 ); // TODO export types
-                setRole(roleFromLocalstore ? "replicator" : "observer");
-                await updateRole(roleFromLocalstore);
-            } else {
-                if (isTrusted) {
-                    // I am the owner
-                }
-                await updateRole(
-                    role === "replicator"
-                        ? DEFAULT_REPLICATION_ROLE
-                        : false
-                );
             }
-            void updateList();
-            setReplicatorCount(
-                (await files.program.files.log.getReplicators()).size
-            );
+
+            const replicators = await files.program.files.log.getReplicators();
+            setReplicatorCount(replicators.size);
         };
 
         onOpen();
@@ -335,14 +400,29 @@ export const Drop = () => {
         };
     }, [files.program?.address, files.program?.closed]);
 
-    const updateList = async () => {
+    const updateList = async (sourceOrEvent: string | Event = "refresh") => {
         if (files.program.files.log.closed) {
             return;
         }
 
+        const source =
+            typeof sourceOrEvent === "string" ? sourceOrEvent : "event";
+
         // TODO don't reload the whole list, just add the new elements..
         try {
+            diagnosticsRef.current.listCallCount += 1;
+            const startedAt = Date.now();
+            if (diagnosticsRef.current.firstListStartedAt == null) {
+                diagnosticsRef.current.firstListStartedAt = startedAt;
+                diagnosticsRef.current.firstListSource = source;
+            }
             const list = await files.program.list();
+            const finishedAt = Date.now();
+            if (diagnosticsRef.current.firstListFinishedAt == null) {
+                diagnosticsRef.current.firstListFinishedAt = finishedAt;
+                diagnosticsRef.current.firstListDurationMs =
+                    finishedAt - startedAt;
+            }
             setList(
                 list
                     .filter((x) => !x.parentId)
@@ -357,6 +437,13 @@ export const Drop = () => {
                     ]);
                     setReplicationSet(new Set(allFiles.map((x) => x.id)));
                     setReplicatorCount(replicators.size);
+                    if (
+                        diagnosticsRef.current.firstMetadataRefreshFinishedAt ==
+                        null
+                    ) {
+                        diagnosticsRef.current.firstMetadataRefreshFinishedAt =
+                            Date.now();
+                    }
                     forceUpdate();
                 } catch (error) {
                     console.warn(

--- a/packages/file-share/frontend/tests/observer-role.local.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/observer-role.local.e2e.spec.ts
@@ -88,6 +88,11 @@ test.describe("file-share observer role", () => {
                 })
                 .toBe(false);
 
+            const initialDiagnostics = await getDiagnostics(reader);
+            expect(initialDiagnostics.timings?.updateRoleCount).toBe(0);
+            expect(initialDiagnostics.timings?.firstListStartedAt).not.toBeNull();
+            expect(initialDiagnostics.timings?.firstListFinishedAt).not.toBeNull();
+
             await setReplicationRole(reader, {
                 limits: { cpu: { max: 1 } },
             });
@@ -97,6 +102,9 @@ test.describe("file-share observer role", () => {
                     return diagnostics.persistChunkReads;
                 })
                 .toBe(true);
+
+            const updatedDiagnostics = await getDiagnostics(reader);
+            expect(updatedDiagnostics.timings?.updateRoleCount).toBeGreaterThan(0);
         } finally {
             await writerContext.close().catch(() => {});
             await readerContext.close().catch(() => {});

--- a/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
@@ -66,6 +66,16 @@ const createSpaceFromHook = async (page: Page, name: string) => {
     }, name);
 };
 
+const getDiagnostics = async (page: Page) => {
+    return await page.evaluate(async () => {
+        const hooks = (window as any).__peerbitFileShareTestHooks;
+        if (!hooks?.getDiagnostics) {
+            throw new Error("Missing __peerbitFileShareTestHooks.getDiagnostics");
+        }
+        return await hooks.getDiagnostics();
+    });
+};
+
 const seedReplicationRole = async (
     page: Page,
     address: string,
@@ -167,10 +177,12 @@ test.describe("file-share transfer benchmark", () => {
             logStage("wait-for-upload-complete");
             await waitForUploadComplete(writer, UPLOAD_TIMEOUT_MS);
             const uploadFinishedAt = Date.now();
+            const writerDiagnostics = await getDiagnostics(writer);
 
             logStage("wait-for-reader-listing");
             await waitForFileListed(reader, fileName, UPLOAD_TIMEOUT_MS);
             const readerVisibleAt = Date.now();
+            const readerDiagnostics = await getDiagnostics(reader);
 
             logStage("download");
             const downloadStartedAt = Date.now();
@@ -205,6 +217,8 @@ test.describe("file-share transfer benchmark", () => {
                 uploadDurationMs: uploadFinishedAt - uploadStartedAt,
                 discoveryLagMs: readerVisibleAt - uploadFinishedAt,
                 downloadDurationMs: downloadFinishedAt - downloadStartedAt,
+                writerDiagnostics,
+                readerDiagnostics,
                 uploadMiBps: toMiBPerSecond(
                     downloaded.size,
                     uploadFinishedAt - uploadStartedAt

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -512,6 +512,15 @@ export class LargeFile extends AbstractFile {
 
 type Args = { replicate: ReplicationOptions };
 
+type OpenDiagnostics = {
+    startedAt: number;
+    trustGraphOpenStartedAt: number | null;
+    trustGraphOpenFinishedAt: number | null;
+    filesOpenStartedAt: number | null;
+    filesOpenFinishedAt: number | null;
+    finishedAt: number | null;
+};
+
 @variant("files")
 export class Files extends Program<Args> {
     @field({ type: Uint8Array })
@@ -527,6 +536,7 @@ export class Files extends Program<Args> {
     files: Documents<AbstractFile, IndexableFile>;
 
     persistChunkReads: boolean;
+    openDiagnostics?: OpenDiagnostics;
 
     constructor(
         properties: {
@@ -960,11 +970,22 @@ export class Files extends Program<Args> {
 
     // Setup lifecycle, will be invoked on 'open'
     async open(args?: Args): Promise<void> {
+        this.openDiagnostics = {
+            startedAt: Date.now(),
+            trustGraphOpenStartedAt: null,
+            trustGraphOpenFinishedAt: null,
+            filesOpenStartedAt: null,
+            filesOpenFinishedAt: null,
+            finishedAt: null,
+        };
         this.persistChunkReads = args?.replicate !== false;
+        this.openDiagnostics.trustGraphOpenStartedAt = Date.now();
         await this.trustGraph?.open({
             replicate: args?.replicate,
         });
+        this.openDiagnostics.trustGraphOpenFinishedAt = Date.now();
 
+        this.openDiagnostics.filesOpenStartedAt = Date.now();
         await this.files.open({
             type: AbstractFile,
             // TODO add ACL
@@ -985,5 +1006,7 @@ export class Files extends Program<Args> {
                 type: IndexableFile,
             },
         });
+        this.openDiagnostics.filesOpenFinishedAt = Date.now();
+        this.openDiagnostics.finishedAt = Date.now();
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,11 +8,11 @@ overrides:
   '@peerbit/canonical-client': 1.1.20
   '@peerbit/canonical-host': 1.0.26
   '@peerbit/crypto': 3.1.0
-  '@peerbit/document': 13.0.23
+  '@peerbit/document': 13.0.24
   '@peerbit/program': 6.0.17
   '@peerbit/shared-log': 13.0.23
   '@peerbit/stream-interface': 6.0.7
-  '@peerbit/trusted-network': 6.0.23
+  '@peerbit/trusted-network': 6.0.24
   peerbit: 5.2.6
   libsodium: 0.7.15
   libsodium-wrappers: 0.7.15
@@ -134,11 +134,11 @@ importers:
   packages/blog-platform/library:
     dependencies:
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/trusted-network':
-        specifier: 6.0.23
-        version: 6.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 6.0.24
+        version: 6.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       peerbit:
         specifier: 5.2.6
         version: 5.2.6(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
@@ -188,10 +188,10 @@ importers:
         version: link:../../social-media-app/app-sdk
       '@peerbit/document-react':
         specifier: ^1.0.24
-        version: 1.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.0.24(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@peerbit/react':
         specifier: ^1.1.9
-        version: 1.1.9(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.9(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-popover':
         specifier: ^1.0.7
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -218,7 +218,7 @@ importers:
         version: 1.4.0
       peerbit:
         specifier: 5.2.6
-        version: 5.2.6(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.2.6(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -284,11 +284,11 @@ importers:
         specifier: ^5.15.7
         version: 5.18.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/react':
         specifier: ^1.1.9
-        version: 1.1.9(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.9(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@tensorflow/tfjs':
         specifier: ^4.2.0
         version: 4.22.0(seedrandom@3.0.5)
@@ -297,7 +297,7 @@ importers:
         version: 3.3.0
       peerbit:
         specifier: 5.2.6
-        version: 5.2.6(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.2.6(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -361,8 +361,8 @@ importers:
         specifier: 3.1.0
         version: 3.1.0
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/please-lib':
         specifier: workspace:*
         version: link:../library
@@ -470,8 +470,8 @@ importers:
         specifier: 3.1.0
         version: 3.1.0
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/program':
         specifier: 6.0.17
         version: 6.0.17(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
@@ -479,8 +479,8 @@ importers:
         specifier: 13.0.23
         version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/trusted-network':
-        specifier: 6.0.23
-        version: 6.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 6.0.24
+        version: 6.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@stablelib/sha256':
         specifier: ^2.0.1
         version: 2.0.1
@@ -542,8 +542,8 @@ importers:
         specifier: ^5.15.7
         version: 5.18.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/example-many-chat-rooms':
         specifier: workspace:*
         version: link:../library
@@ -606,8 +606,8 @@ importers:
         specifier: workspace:*
         version: link:../../../social-media-app/app-sdk
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/document-react':
         specifier: ^1.0.24
         version: 1.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
@@ -715,8 +715,8 @@ importers:
   packages/media-streaming/music-library/music-library-utils:
     dependencies:
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/media-streaming':
         specifier: workspace:*
         version: link:../../streaming-utils
@@ -737,8 +737,8 @@ importers:
   packages/media-streaming/playback-utils:
     dependencies:
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/media-streaming':
         specifier: workspace:*
         version: link:../streaming-utils
@@ -759,8 +759,8 @@ importers:
   packages/media-streaming/streaming-utils:
     dependencies:
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       peerbit:
         specifier: 5.2.6
         version: 5.2.6(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
@@ -803,8 +803,8 @@ importers:
         specifier: workspace:*
         version: link:../../../social-media-app/app-sdk
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/document-react':
         specifier: ^1.0.24
         version: 1.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
@@ -930,8 +930,8 @@ importers:
         specifier: ^5.15.7
         version: 5.18.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/peer-names':
         specifier: workspace:*
         version: link:../../name-service/library
@@ -991,8 +991,8 @@ importers:
         specifier: 1.0.26
         version: 1.0.26(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/document-proxy':
         specifier: ^2.0.24
         version: 2.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
@@ -1059,8 +1059,8 @@ importers:
         specifier: workspace:*
         version: link:../../library
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       ollama:
         specifier: ^0.5.14
         version: 0.5.18
@@ -1114,8 +1114,8 @@ importers:
   packages/social-media-app/app-service:
     dependencies:
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       parse5:
         specifier: ^7.1.2
         version: 7.3.0
@@ -1379,8 +1379,8 @@ importers:
   packages/social-media-app/library:
     dependencies:
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       peerbit:
         specifier: 5.2.6
         version: 5.2.6(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
@@ -1413,8 +1413,8 @@ importers:
   packages/svelte-example:
     dependencies:
       '@peerbit/document':
-        specifier: 13.0.23
-        version: 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        specifier: 13.0.24
+        version: 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       peerbit:
         specifier: 5.2.6
         version: 5.2.6(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
@@ -3168,8 +3168,8 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
-  '@peerbit/document@13.0.23':
-    resolution: {integrity: sha512-K2NzB5sl5Gld9lYvF9uOYLDMxhNHAJpjEISDeRrvzGtRS8bCZVMQoqza4N3wUBVUYPAC6dv1Oq79mDkMYjBQIA==}
+  '@peerbit/document@13.0.24':
+    resolution: {integrity: sha512-L1gK4ICPlUT1UuHJzt89A8KeV+drt4ZE59gG0Djfk5f6AGHmg/9BAvS3UEmm0PALGkfFXBAmQFdamTad5Gx6Ag==}
 
   '@peerbit/indexer-cache@0.2.6':
     resolution: {integrity: sha512-53l26rXoqJPtGu27wUuzeyuYa+dXvLJWbt9qddErwV6E2uHps+j7OZShIhf95hypHJV7NdKtYx0AAoi6Cn6TEw==}
@@ -3249,8 +3249,8 @@ packages:
   '@peerbit/time@3.0.0':
     resolution: {integrity: sha512-UpFwxHkS9qTFFDPqZji5J1yHJdNEzlGObmZFj9yg1kl+4jEuxhjL7sjL+KYx5W9O1E45RMZUTw1mMvUEhCr18Q==}
 
-  '@peerbit/trusted-network@6.0.23':
-    resolution: {integrity: sha512-8KrxQg18nNHc1c9OV3QdhXerceNKvaFu/z2igBEKSEe9khiPO4NWBtIekrVYaoN2bGnd0pgU/ODs5iClNtfrwA==}
+  '@peerbit/trusted-network@6.0.24':
+    resolution: {integrity: sha512-40yBEYgfYHksFQeR2LB3oU87Nad/N8z9B9LaPs3ZjDK3FMAOE+40zSZ+g5YNsM66aM8+LKvLgq6DxJXq7cJvwQ==}
 
   '@peerbit/vite@2.0.2':
     resolution: {integrity: sha512-y83VUxkwMbDDIe0tn7vNAJxxFsDGEDhPZZqm2cVOGTd6bZSS27GCUCsb/HglTgJxhqtftstICXrxKS6kjA+HOA==}
@@ -12049,7 +12049,7 @@ snapshots:
       '@dao-xyz/borsh-rpc': 2.0.5
       '@peerbit/canonical-client': 1.1.20(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/canonical-host': 1.0.26(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
-      '@peerbit/document': 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+      '@peerbit/document': 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/document-interface': 3.2.26
       '@peerbit/indexer-interface': 3.0.3
       '@peerbit/program': 6.0.17(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
@@ -12061,9 +12061,23 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@peerbit/document-react@1.0.24(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@peerbit/document': 13.0.24(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))
+      '@peerbit/indexer-interface': 3.0.3
+      '@peerbit/logger': 2.0.1
+      '@peerbit/react': 1.1.9(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - react-native
+      - supports-color
+      - utf-8-validate
+
   '@peerbit/document-react@1.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@peerbit/document': 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+      '@peerbit/document': 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/indexer-interface': 3.0.3
       '@peerbit/logger': 2.0.1
       '@peerbit/react': 1.1.9(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
@@ -12075,7 +12089,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@peerbit/document@13.0.23(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))':
+  '@peerbit/document@13.0.24(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))':
     dependencies:
       '@chainsafe/libp2p-yamux': 8.0.1
       '@dao-xyz/borsh': 6.0.1
@@ -12104,7 +12118,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@peerbit/document@13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))':
+  '@peerbit/document@13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))':
     dependencies:
       '@chainsafe/libp2p-yamux': 8.0.1
       '@dao-xyz/borsh': 6.0.1
@@ -12689,12 +12703,12 @@ snapshots:
 
   '@peerbit/time@3.0.0': {}
 
-  '@peerbit/trusted-network@6.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))':
+  '@peerbit/trusted-network@6.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
       '@libp2p/interface': 3.1.1
       '@peerbit/crypto': 3.1.0
-      '@peerbit/document': 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+      '@peerbit/document': 13.0.24(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/log': 6.0.21
       '@peerbit/program': 6.0.17(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/shared-log': 13.0.23(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))


### PR DESCRIPTION
## Summary\n- update the root pnpm overrides so examples actually resolves the released document and trusted-network line\n- stop reapplying the initial file-share replication role before the first list and expose first-open timing diagnostics through the test hooks\n- include the reader and writer diagnostics in the transfer benchmark artifacts so we can separate peer/program open latency from list latency\n\n## Validation\n- pnpm --filter @peerbit/please-lib build\n- pnpm --filter file-share build\n- pnpm exec playwright test -c packages/file-share/frontend/playwright.config.ts packages/file-share/frontend/tests/observer-role.local.e2e.spec.ts --project chromium\n- PW_BENCH=1 PW_BENCH_SCENARIO=local PW_FILE_MB=16 pnpm exec playwright test -c packages/file-share/frontend/playwright.config.ts packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts --project chromium\n\n## Notes\nThe local benchmark now shows the first file-share list itself is fast; the remaining discovery delay is mostly before Files.open even begins, which points at peer readiness/bootstrap gating rather than the list query itself.