### PR TITLE
fix(file-share): stabilize observer chunk reads

### DIFF
--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -45,6 +45,10 @@ type ListingDiagnostics = {
     mountedAt: number;
     shareAddress: string | null;
     initialRole: "replicator" | "replicator-default" | "observer";
+    firstPeerReadyAt: number | null;
+    firstProgramHookReadyAt: number | null;
+    programHookStatus: string | null;
+    programHookLoading: boolean;
     onOpenStartedAt: number | null;
     trustCheckStartedAt: number | null;
     trustCheckFinishedAt: number | null;
@@ -97,6 +101,10 @@ const createListingDiagnostics = (
             : storedRole
               ? "replicator"
               : "replicator-default",
+    firstPeerReadyAt: null,
+    firstProgramHookReadyAt: null,
+    programHookStatus: null,
+    programHookLoading: false,
     onOpenStartedAt: null,
     trustCheckStartedAt: null,
     trustCheckFinishedAt: null,
@@ -140,7 +148,7 @@ function callEvenInterval(func, delay) {
 export const Drop = () => {
     const navigate = useNavigate();
 
-    const { peer } = usePeer();
+    const { peer, loading: peerLoading, status: peerStatus } = usePeer();
 
     const [_, forceUpdate] = useReducer((x) => x + 1, 0);
     const params = useParams();
@@ -180,6 +188,20 @@ export const Drop = () => {
             },
         }
     );
+
+    useEffect(() => {
+        if (peer && diagnosticsRef.current.firstPeerReadyAt == null) {
+            diagnosticsRef.current.firstPeerReadyAt = Date.now();
+        }
+    }, [peer]);
+
+    useEffect(() => {
+        diagnosticsRef.current.programHookStatus = files.status;
+        diagnosticsRef.current.programHookLoading = files.loading;
+        if (files.program && diagnosticsRef.current.firstProgramHookReadyAt == null) {
+            diagnosticsRef.current.firstProgramHookReadyAt = Date.now();
+        }
+    }, [files.loading, files.program, files.status]);
 
     const { memory } = useStorageUsage(files.program?.files.log);
     const { up, down } = useNetworkUsage();
@@ -237,18 +259,43 @@ export const Drop = () => {
                 const replicators = await files.program.files.log
                     .getReplicators()
                     .catch(() => undefined);
+                const listedFiles = await Promise.all(
+                    list.map(async (file) => ({
+                        id: file.id,
+                        name: file.name,
+                        type: file instanceof LargeFile ? "large" : "tiny",
+                        size: file.size.toString(),
+                        ready:
+                            file instanceof LargeFile ? file.ready : undefined,
+                        chunkCount:
+                            file instanceof LargeFile
+                                ? file.chunkCount
+                                : undefined,
+                        localChunkCount:
+                            file instanceof LargeFile
+                                ? await files.program
+                                      ?.countLocalChunks(file)
+                                      .catch(() => null)
+                                : undefined,
+                    }))
+                );
                 return {
                     programAddress: files.program?.address ?? null,
                     programClosed: files.program?.closed ?? null,
                     persistChunkReads: files.program?.persistChunkReads ?? null,
                     peerHash: peer?.identity?.publicKey?.hashcode?.() ?? null,
+                    peerStatus,
+                    peerLoading,
                     programOpenDiagnostics:
                         files.program?.openDiagnostics ?? null,
+                    lastReadDiagnostics:
+                        files.program?.lastReadDiagnostics ?? null,
                     replicatorCount:
                         replicators && typeof replicators.size === "number"
                             ? replicators.size
                             : null,
                     listCount: list.length,
+                    listedFiles,
                     replicationSetSize: replicationSet.size,
                     isHost: isHost ?? null,
                     left,

--- a/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
@@ -132,6 +132,8 @@ test.describe("file-share transfer benchmark", () => {
             fileName,
             FILE_SIZE_MB
         );
+        let writerDiagnostics: Record<string, unknown> | undefined;
+        let readerDiagnostics: Record<string, unknown> | undefined;
         const usesStreamingDownload =
             preparedFile != null &&
             FILE_SIZE_MB * 1024 * 1024 >= STREAMING_DOWNLOAD_THRESHOLD_BYTES;
@@ -177,12 +179,12 @@ test.describe("file-share transfer benchmark", () => {
             logStage("wait-for-upload-complete");
             await waitForUploadComplete(writer, UPLOAD_TIMEOUT_MS);
             const uploadFinishedAt = Date.now();
-            const writerDiagnostics = await getDiagnostics(writer);
+            writerDiagnostics = await getDiagnostics(writer);
 
             logStage("wait-for-reader-listing");
             await waitForFileListed(reader, fileName, UPLOAD_TIMEOUT_MS);
             const readerVisibleAt = Date.now();
-            const readerDiagnostics = await getDiagnostics(reader);
+            readerDiagnostics = await getDiagnostics(reader);
 
             logStage("download");
             const downloadStartedAt = Date.now();
@@ -242,6 +244,12 @@ test.describe("file-share transfer benchmark", () => {
             await persistResult(result);
             console.log(`FILE_SHARE_TRANSFER_BENCH ${JSON.stringify(result)}`);
         } catch (error: any) {
+            const failureWriterDiagnostics =
+                writerDiagnostics ??
+                (await getDiagnostics(writer).catch(() => undefined));
+            const failureReaderDiagnostics =
+                (await getDiagnostics(reader).catch(() => undefined)) ??
+                readerDiagnostics;
             const result = {
                 status: "failed",
                 scenario: SCENARIO,
@@ -255,6 +263,8 @@ test.describe("file-share transfer benchmark", () => {
                     stack:
                         typeof error?.stack === "string" ? error.stack : undefined,
                 },
+                writerDiagnostics: failureWriterDiagnostics,
+                readerDiagnostics: failureReaderDiagnostics,
             };
             await persistResult(result);
             console.error(`FILE_SHARE_TRANSFER_BENCH ${JSON.stringify(result)}`);

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -335,6 +335,167 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
+        it("falls back to chunk-id lookups when observer chunk searches miss available chunks", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileId = await filestore.add(
+                "observer download falls back to chunk-id lookups",
+                largeFile
+            );
+
+            const filestoreReader = await peer2.open<Files>(filestore.address, {
+                args: { replicate: false },
+            });
+            await filestoreReader.files.log.waitForReplicator(
+                peer.identity.publicKey
+            );
+
+            const file = await filestoreReader.files.index.get(fileId);
+            expect(file).to.be.instanceOf(LargeFile);
+
+            const originalSearch =
+                filestoreReader.files.index.search.bind(filestoreReader.files.index);
+            const originalGet =
+                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            let parentIdSearchCalls = 0;
+            let directChunkGets = 0;
+
+            (filestoreReader.files.index as any).search = async (
+                request: unknown,
+                options: unknown
+            ) => {
+                const results = await originalSearch(
+                    request as never,
+                    options as never
+                );
+                const chunkResults = results.filter(
+                    (result: unknown) =>
+                        result instanceof TinyFile && result.parentId === fileId
+                );
+                if (chunkResults.length === 0) {
+                    return results;
+                }
+
+                parentIdSearchCalls++;
+                return results.filter(
+                    (result: unknown) =>
+                        !(
+                            result instanceof TinyFile &&
+                            result.parentId === fileId &&
+                            result.index === 1
+                        )
+                );
+            };
+
+            (filestoreReader.files.index as any).get = async (
+                id: string,
+                options: unknown
+            ) => {
+                if (id.startsWith(`${fileId}:`)) {
+                    directChunkGets++;
+                }
+                return originalGet(id as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+            await file!.writeFile(filestoreReader, {
+                write: async (chunk) => {
+                    streamedChunks.push(chunk);
+                },
+            });
+
+            expect(parentIdSearchCalls).to.be.greaterThan(0);
+            expect(directChunkGets).to.be.greaterThan(0);
+            expect(streamedChunks.length).to.be.greaterThan(1);
+            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
+        it("avoids keep-open remote waits for observer chunk downloads", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileId = await filestore.add(
+                "observer chunk reads stay stateless",
+                largeFile
+            );
+
+            const filestoreReader = await peer2.open<Files>(filestore.address, {
+                args: { replicate: false },
+            });
+            await filestoreReader.files.log.waitForReplicator(
+                peer.identity.publicKey
+            );
+
+            const file = await filestoreReader.files.index.get(fileId);
+            expect(file).to.be.instanceOf(LargeFile);
+
+            const originalSearch =
+                filestoreReader.files.index.search.bind(filestoreReader.files.index);
+            const originalGet =
+                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            let observedChunkGets = 0;
+            let sawKeepOpenWait = false;
+            let sawSelfInHints = false;
+            const selfHash = peer2.identity.publicKey.hashcode();
+
+            (filestoreReader.files.index as any).search = async (
+                request: unknown,
+                options: unknown
+            ) => {
+                const results = await originalSearch(
+                    request as never,
+                    options as never
+                );
+                const chunkResults = results.filter(
+                    (result: unknown) =>
+                        result instanceof TinyFile && result.parentId === fileId
+                );
+                if (chunkResults.length === 0) {
+                    return results;
+                }
+
+                return results.filter(
+                    (result: unknown) =>
+                        !(
+                            result instanceof TinyFile &&
+                            result.parentId === fileId &&
+                            result.index === 1
+                        )
+                );
+            };
+
+            (filestoreReader.files.index as any).get = async (
+                id: string,
+                options: {
+                    remote?: {
+                        wait?: {
+                            timeout: number;
+                            behavior: string;
+                        };
+                    };
+                }
+            ) => {
+                if (id.startsWith(`${fileId}:`)) {
+                    observedChunkGets++;
+                    sawKeepOpenWait ||= options?.remote?.wait?.behavior === "keep-open";
+                    sawSelfInHints ||= options?.remote?.from?.includes(selfHash) === true;
+                }
+                return originalGet(id as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+            await file!.writeFile(filestoreReader, {
+                write: async (chunk) => {
+                    streamedChunks.push(chunk);
+                },
+            });
+
+            expect(observedChunkGets).to.be.greaterThan(0);
+            expect(sawKeepOpenWait).to.be.false;
+            expect(sawSelfInHints).to.be.false;
+            expect(streamedChunks.length).to.be.greaterThan(1);
+            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
         it("retries transient chunk lookup aborts", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -126,6 +126,8 @@ const CHUNK_SIZE_GRANULARITY = 64 * 1024;
 const MAX_LARGE_FILE_SEGMENT_SIZE = TINY_FILE_SIZE_LIMIT - 256 * 1024;
 const LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS = 5 * 60 * 1000;
 const LARGE_FILE_PERSISTED_READ_AHEAD = 16;
+const LARGE_FILE_OBSERVER_READ_AHEAD = 2;
+const LARGE_FILE_OBSERVER_PREFETCH_TIMEOUT_MS = 5_000;
 const TINY_FILE_SIZE_LIMIT_BIGINT = BigInt(TINY_FILE_SIZE_LIMIT);
 
 const roundUpTo = (value: number, multiple: number) =>
@@ -286,17 +288,6 @@ export class LargeFile extends AbstractFile {
         const totalTimeout = properties?.timeout ?? 30_000;
         const deadline = Date.now() + totalTimeout;
         const queryTimeout = Math.min(totalTimeout, 5_000);
-        const searchOptions = {
-            local: true,
-            remote: {
-                timeout: queryTimeout,
-                throwOnMissing: false,
-                // Chunk queries return the full TinyFile document including its
-                // bytes. Observer reads can stream that result directly, while
-                // actual replicators should still persist downloaded chunks.
-                replicate: files.persistChunkReads,
-            },
-        };
         const recordChunks = (results: AbstractFile[]) => {
             for (const chunk of results) {
                 if (
@@ -312,13 +303,25 @@ export class LargeFile extends AbstractFile {
 
         while (chunks.size < this.chunkCount && Date.now() < deadline) {
             const before = chunks.size;
+            const remoteFrom = await files.getReadPeerHints();
             recordChunks(
                 await files.files.index.search(
                     new SearchRequest({
                         query: new StringMatch({ key: "parentId", value: this.id }),
                         fetch: 0xffffffff,
                     }),
-                    searchOptions
+                    {
+                        local: true,
+                        remote: {
+                            timeout: queryTimeout,
+                            throwOnMissing: false,
+                            // Chunk queries return the full TinyFile document including its
+                            // bytes. Observer reads can stream that result directly, while
+                            // actual replicators should still persist downloaded chunks.
+                            replicate: files.persistChunkReads,
+                            from: remoteFrom,
+                        },
+                    } as any
                 )
             );
 
@@ -339,6 +342,7 @@ export class LargeFile extends AbstractFile {
         knownChunks: Map<number, TinyFile>,
         properties?: {
             timeout?: number;
+            debug?: Record<string, any>;
         }
     ): Promise<TinyFile> {
         const totalTimeout =
@@ -348,9 +352,18 @@ export class LargeFile extends AbstractFile {
         const chunkId = getChunkId(this.id, index);
 
         while (Date.now() < deadline) {
+            properties?.debug &&
+                ((properties.debug.chunkAttempts ||= {})[index] =
+                    ((properties.debug.chunkAttempts ||= {})[index] ?? 0) + 1);
             const cached = knownChunks.get(index);
             if (cached) {
+                properties?.debug &&
+                    ((properties.debug.chunkResolved ||= {})[index] = "cached");
                 return cached;
+            }
+            const remoteFrom = await files.getReadPeerHints();
+            if (properties?.debug) {
+                (properties.debug.chunkHints ||= {})[index] = remoteFrom ?? null;
             }
 
             try {
@@ -359,13 +372,16 @@ export class LargeFile extends AbstractFile {
                     waitFor: attemptTimeout,
                     remote: {
                         timeout: attemptTimeout,
-                        wait: {
-                            timeout: attemptTimeout,
-                            behavior: "keep-open",
-                        },
+                        // Chunk docs are immutable once the ready manifest is
+                        // visible. Using keep-open waits here under read-ahead
+                        // fan-out creates long-lived remote queries that can
+                        // stall bulk reads instead of helping them complete.
+                        // We use short stateless retries in the outer loop
+                        // instead.
                         throwOnMissing: false,
                         retryMissingResponses: true,
                         replicate: files.persistChunkReads,
+                        from: remoteFrom,
                     },
                 });
 
@@ -375,10 +391,22 @@ export class LargeFile extends AbstractFile {
                     chunk.index === index
                 ) {
                     knownChunks.set(index, chunk);
+                    properties?.debug &&
+                        ((properties.debug.chunkResolved ||= {})[index] =
+                            "remote-get");
                     return chunk;
                 }
             } catch (error) {
                 if (!isRetryableChunkLookupError(error)) {
+                    properties?.debug &&
+                        (properties.debug.chunkFailure = {
+                            index,
+                            type: "non-retryable",
+                            message:
+                                error instanceof Error
+                                    ? error.message
+                                    : String(error),
+                        });
                     throw error;
                 }
             }
@@ -405,10 +433,23 @@ export class LargeFile extends AbstractFile {
         const attemptTimeout = Math.min(totalTimeout, 5_000);
 
         while (Date.now() < deadline) {
+            const debug = files.lastReadDiagnostics;
+            if (debug) {
+                debug.waitUntilReadyAttempts += 1;
+            }
+            const remoteFrom = await files.getReadPeerHints();
             const latest = await files.resolveById(this.id, {
                 timeout: attemptTimeout,
                 replicate: true,
+                from: remoteFrom,
             });
+            if (debug) {
+                debug.lastReadyProbe = {
+                    at: Date.now(),
+                    ready: latest instanceof LargeFile ? latest.ready : null,
+                    from: remoteFrom ?? null,
+                };
+            }
 
             if (latest instanceof LargeFile && latest.ready) {
                 return latest;
@@ -428,23 +469,48 @@ export class LargeFile extends AbstractFile {
         files: Files,
         properties?: FileReadOptions
     ): AsyncIterable<Uint8Array> {
+        const debug = {
+            fileId: this.id,
+            fileName: this.name,
+            persistChunkReads: files.persistChunkReads,
+            startedAt: Date.now(),
+            waitUntilReadyAttempts: 0,
+            waitUntilReadyResolvedAt: null as number | null,
+            waitUntilReadyResolvedReady: null as boolean | null,
+            prefetchedChunkCount: 0,
+            finishedAt: null as number | null,
+            chunkAttempts: {} as Record<number, number>,
+            chunkHints: {} as Record<number, string[] | null>,
+            chunkResolved: {} as Record<number, string>,
+            chunkFailure: null as
+                | {
+                      index: number;
+                      type: string;
+                      message: string;
+                  }
+                | null,
+        };
+        files.lastReadDiagnostics = debug;
         const resolvedFile = await this.waitUntilReady(files, properties);
+        debug.waitUntilReadyResolvedAt = Date.now();
+        debug.waitUntilReadyResolvedReady = resolvedFile.ready;
 
         properties?.progress?.(0);
 
         let processed = 0;
         const hasher = resolvedFile.finalHash ? new SHA256() : undefined;
-        const knownChunks = files.persistChunkReads
-            ? new Map<number, TinyFile>()
-            : new Map(
-                  (
-                      await resolvedFile.fetchChunks(files, {
-                          timeout:
-                              properties?.timeout ??
-                              LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS,
-                      })
-                  ).map((chunk) => [chunk.index || 0, chunk])
-              );
+        const knownChunks = new Map<number, TinyFile>();
+        if (!files.persistChunkReads) {
+            for (const chunk of await resolvedFile.fetchChunks(files, {
+                timeout: Math.min(
+                    properties?.timeout ?? LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS,
+                    LARGE_FILE_OBSERVER_PREFETCH_TIMEOUT_MS
+                ),
+            })) {
+                knownChunks.set(chunk.index || 0, chunk);
+            }
+            debug.prefetchedChunkCount = knownChunks.size;
+        }
         const inFlightChunks = new Map<number, Promise<TinyFile>>();
         const resolveChunkWithReadAhead = (index: number) => {
             const cached = inFlightChunks.get(index);
@@ -453,36 +519,30 @@ export class LargeFile extends AbstractFile {
             }
             const pending = this.resolveChunk(files, index, knownChunks, {
                 timeout: properties?.timeout,
+                debug,
             });
             inFlightChunks.set(index, pending);
             return pending;
         };
 
-        if (files.persistChunkReads) {
-            for (
-                let index = 0;
-                index <
-                Math.min(
-                    resolvedFile.chunkCount,
-                    LARGE_FILE_PERSISTED_READ_AHEAD
-                );
-                index++
-            ) {
-                void resolveChunkWithReadAhead(index);
-            }
+        const readAhead = files.persistChunkReads
+            ? LARGE_FILE_PERSISTED_READ_AHEAD
+            : LARGE_FILE_OBSERVER_READ_AHEAD;
+
+        for (
+            let index = 0;
+            index < Math.min(resolvedFile.chunkCount, readAhead);
+            index++
+        ) {
+            void resolveChunkWithReadAhead(index);
         }
 
         for (let index = 0; index < resolvedFile.chunkCount; index++) {
-            const nextIndex = index + LARGE_FILE_PERSISTED_READ_AHEAD;
-            if (
-                files.persistChunkReads &&
-                nextIndex < resolvedFile.chunkCount
-            ) {
+            const nextIndex = index + readAhead;
+            if (nextIndex < resolvedFile.chunkCount) {
                 void resolveChunkWithReadAhead(nextIndex);
             }
-            const chunkFile = files.persistChunkReads
-                ? await resolveChunkWithReadAhead(index)
-                : knownChunks.get(index);
+            const chunkFile = await resolveChunkWithReadAhead(index);
             inFlightChunks.delete(index);
             if (!chunkFile) {
                 throw new Error(
@@ -507,6 +567,7 @@ export class LargeFile extends AbstractFile {
         ) {
             throw new Error("File hash does not match the expected content");
         }
+        debug.finishedAt = Date.now();
     }
 }
 
@@ -537,6 +598,7 @@ export class Files extends Program<Args> {
 
     persistChunkReads: boolean;
     openDiagnostics?: OpenDiagnostics;
+    lastReadDiagnostics?: Record<string, any>;
 
     constructor(
         properties: {
@@ -808,6 +870,7 @@ export class Files extends Program<Args> {
     }
 
     async list() {
+        const remoteFrom = await this.getReadPeerHints();
         // only root files (don't fetch fetch chunks here)
         const files = await this.files.index.search(
             new SearchRequest({
@@ -822,8 +885,9 @@ export class Files extends Program<Args> {
                     // all shard roots respond, which feels broken during joins/churn.
                     throwOnMissing: false,
                     replicate: true, // sync here because this, because we might want to access it offline, even though we are not replicators
+                    from: remoteFrom,
                 },
-            }
+            } as any
         );
         return files;
     }
@@ -843,6 +907,7 @@ export class Files extends Program<Args> {
         properties?: {
             timeout?: number;
             replicate?: boolean;
+            from?: string[];
         }
     ): Promise<AbstractFile | undefined> {
         return this.files.index.get(id, {
@@ -859,6 +924,7 @@ export class Files extends Program<Args> {
                 throwOnMissing: false,
                 retryMissingResponses: true,
                 replicate: properties?.replicate,
+                from: properties?.from,
             },
         });
     }
@@ -868,6 +934,7 @@ export class Files extends Program<Args> {
         properties?: {
             timeout?: number;
             replicate?: boolean;
+            from?: string[];
         }
     ): Promise<AbstractFile | undefined> {
         const results = await this.files.index.search(
@@ -888,10 +955,35 @@ export class Files extends Program<Args> {
                     timeout: properties?.timeout ?? 10 * 1000,
                     throwOnMissing: false,
                     replicate: properties?.replicate,
+                    from: properties?.from,
                 },
-            }
+            } as any
         );
         return results[0];
+    }
+
+    async getReadPeerHints(): Promise<string[] | undefined> {
+        const replicators = await this.files.log.getReplicators().catch(() => undefined);
+        if (!replicators || replicators.size === 0) {
+            return undefined;
+        }
+
+        const selfHash = this.node.identity.publicKey.hashcode();
+
+        const hashes = [...replicators]
+            .map((replicator: string | { hashcode?: () => string }) =>
+                typeof replicator === "string"
+                    ? replicator
+                    : replicator.hashcode?.()
+            )
+            .filter(
+                (hash, index, values): hash is string =>
+                    hash != null &&
+                    hash !== selfHash &&
+                    values.indexOf(hash) === index
+            );
+
+        return hashes.length > 0 ? hashes : undefined;
     }
 
     /**


### PR DESCRIPTION
## Summary
- stabilize observer-mode large file reads by using stateless chunk-id retries instead of keep-open per-chunk waits
- exclude the local peer from read hints and bound observer chunk read-ahead to a small stable level
- keep the listing/open diagnostics and add regressions around observer chunk fallback behavior

## Why
Remote observer downloads were still flaky even after the ready-manifest fixes. The reader could see `ready=true` and resolve some chunks, then stall mid-stream on later chunk ids. The useful finding was that immutable chunk reads behave badly when we fan out too many document `get()` calls at once, especially with long-lived remote waits.

The stable model is:
- chunk ids are deterministic once the manifest is ready
- observer reads should use direct chunk-id lookups
- those lookups should be short, stateless retries
- the observer should not query itself
- the read fan-out should stay low

## Validation
- `pnpm --filter @peerbit/please-lib build`
- `pnpm exec vitest run packages/file-share/library/src/__tests__/index.integration.test.ts -t "falls back to chunk-id lookups when observer chunk searches miss available chunks|avoids keep-open remote waits for observer chunk downloads"`
- local browser repro against the remote network shape (`PW_BENCH_SCENARIO=prod`, `PW_VITE_MODE=production`, `16 MiB`) passed twice after the final fix

## Installed deps checked
- frontend: `peerbit 5.2.6`, `@peerbit/document 13.0.24`, `@peerbit/shared-log 13.0.23`, `@peerbit/stream 5.0.9`
- library: `peerbit 5.2.6`, `@peerbit/document 13.0.24`, `@peerbit/trusted-network 6.0.24`, `@peerbit/shared-log 13.0.23`