### PR TITLE
chore(file-share): add upload path diagnostics

### DIFF
--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -288,6 +288,8 @@ export const Drop = () => {
                     peerLoading,
                     programOpenDiagnostics:
                         files.program?.openDiagnostics ?? null,
+                    lastUploadDiagnostics:
+                        files.program?.lastUploadDiagnostics ?? null,
                     lastReadDiagnostics:
                         files.program?.lastReadDiagnostics ?? null,
                     replicatorCount:

--- a/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
@@ -134,6 +134,8 @@ test.describe("file-share transfer benchmark", () => {
         );
         let writerDiagnostics: Record<string, unknown> | undefined;
         let readerDiagnostics: Record<string, unknown> | undefined;
+        let writerDiagnosticsAfterDownload: Record<string, unknown> | undefined;
+        let readerDiagnosticsAfterDownload: Record<string, unknown> | undefined;
         const usesStreamingDownload =
             preparedFile != null &&
             FILE_SIZE_MB * 1024 * 1024 >= STREAMING_DOWNLOAD_THRESHOLD_BYTES;
@@ -204,6 +206,12 @@ test.describe("file-share transfer benchmark", () => {
                       DOWNLOAD_TIMEOUT_MS
                   );
             const downloadFinishedAt = Date.now();
+            writerDiagnosticsAfterDownload =
+                (await getDiagnostics(writer).catch(() => undefined)) ??
+                writerDiagnostics;
+            readerDiagnosticsAfterDownload =
+                (await getDiagnostics(reader).catch(() => undefined)) ??
+                readerDiagnostics;
 
             const result = {
                 status: "passed",
@@ -221,6 +229,8 @@ test.describe("file-share transfer benchmark", () => {
                 downloadDurationMs: downloadFinishedAt - downloadStartedAt,
                 writerDiagnostics,
                 readerDiagnostics,
+                writerDiagnosticsAfterDownload,
+                readerDiagnosticsAfterDownload,
                 uploadMiBps: toMiBPerSecond(
                     downloaded.size,
                     uploadFinishedAt - uploadStartedAt

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -176,6 +176,31 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
+        it("records diagnostics for chunked uploads", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileId = await filestore.add("diagnostic large file", largeFile);
+
+            expect(fileId).to.be.a("string");
+            expect(filestore.lastUploadDiagnostics).to.deep.include({
+                uploadId: fileId,
+                fileName: "diagnostic large file",
+                sizeBytes: largeFile.byteLength,
+            });
+            expect(filestore.lastUploadDiagnostics?.chunkCount).to.be.greaterThan(1);
+            expect(filestore.lastUploadDiagnostics?.chunkPutCount).to.eq(
+                filestore.lastUploadDiagnostics?.chunkCount
+            );
+            expect(filestore.lastUploadDiagnostics?.manifestFinishedAt).to.not.eq(
+                null
+            );
+            expect(
+                filestore.lastUploadDiagnostics?.readyManifestFinishedAt
+            ).to.not.eq(null);
+            expect(filestore.lastUploadDiagnostics?.finishedAt).to.not.eq(null);
+            expect(filestore.lastUploadDiagnostics?.failureMessage).to.eq(null);
+        });
+
         it("pipelines persisted chunk reads without using parentId searches", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -582,6 +582,32 @@ type OpenDiagnostics = {
     finishedAt: number | null;
 };
 
+type UploadDiagnostics = {
+    uploadId: string;
+    fileName: string;
+    sizeBytes: number;
+    chunkSize: number;
+    chunkCount: number;
+    startedAt: number;
+    manifestStartedAt: number | null;
+    manifestFinishedAt: number | null;
+    firstChunkStartedAt: number | null;
+    firstChunkFinishedAt: number | null;
+    lastChunkFinishedAt: number | null;
+    chunkPutCount: number;
+    chunkReadTotalMs: number;
+    chunkReadMaxMs: number;
+    chunkPutTotalMs: number;
+    chunkPutMaxMs: number;
+    slowestChunkIndex: number | null;
+    slowestChunkPutMs: number | null;
+    readyManifestStartedAt: number | null;
+    readyManifestFinishedAt: number | null;
+    finishedAt: number | null;
+    failureAt: number | null;
+    failureMessage: string | null;
+};
+
 @variant("files")
 export class Files extends Program<Args> {
     @field({ type: Uint8Array })
@@ -599,6 +625,7 @@ export class Files extends Program<Args> {
     persistChunkReads: boolean;
     openDiagnostics?: OpenDiagnostics;
     lastReadDiagnostics?: Record<string, any>;
+    lastUploadDiagnostics?: UploadDiagnostics;
 
     constructor(
         properties: {
@@ -797,6 +824,32 @@ export class Files extends Program<Args> {
 
         const uploadId = createUploadId();
         const chunkCount = getChunkCount(size, chunkSize);
+        const diagnostics: UploadDiagnostics = {
+            uploadId,
+            fileName: name,
+            sizeBytes: Number(size),
+            chunkSize,
+            chunkCount,
+            startedAt: Date.now(),
+            manifestStartedAt: null,
+            manifestFinishedAt: null,
+            firstChunkStartedAt: null,
+            firstChunkFinishedAt: null,
+            lastChunkFinishedAt: null,
+            chunkPutCount: 0,
+            chunkReadTotalMs: 0,
+            chunkReadMaxMs: 0,
+            chunkPutTotalMs: 0,
+            chunkPutMaxMs: 0,
+            slowestChunkIndex: null,
+            slowestChunkPutMs: null,
+            readyManifestStartedAt: null,
+            readyManifestFinishedAt: null,
+            finishedAt: null,
+            failureAt: null,
+            failureMessage: null,
+        };
+        this.lastUploadDiagnostics = diagnostics;
         const manifest = new LargeFile({
             id: uploadId,
             name,
@@ -805,13 +858,24 @@ export class Files extends Program<Args> {
             ready: false,
         });
 
+        diagnostics.manifestStartedAt = Date.now();
         await this.files.put(manifest);
+        diagnostics.manifestFinishedAt = Date.now();
         const hasher = new SHA256();
         try {
             let uploadedBytes = 0;
             for (let i = 0; i < chunkCount; i++) {
+                const readStartedAt = Date.now();
                 const chunkBytes = await getChunk(i);
+                const readFinishedAt = Date.now();
+                diagnostics.chunkReadTotalMs += readFinishedAt - readStartedAt;
+                diagnostics.chunkReadMaxMs = Math.max(
+                    diagnostics.chunkReadMaxMs,
+                    readFinishedAt - readStartedAt
+                );
                 hasher.update(chunkBytes);
+                const putStartedAt = Date.now();
+                diagnostics.firstChunkStartedAt ??= putStartedAt;
                 await this.files.put(
                     new TinyFile({
                         name: name + "/" + i,
@@ -820,9 +884,27 @@ export class Files extends Program<Args> {
                         index: i,
                     })
                 );
+                const putFinishedAt = Date.now();
+                const putDurationMs = putFinishedAt - putStartedAt;
+                diagnostics.firstChunkFinishedAt ??= putFinishedAt;
+                diagnostics.lastChunkFinishedAt = putFinishedAt;
+                diagnostics.chunkPutCount += 1;
+                diagnostics.chunkPutTotalMs += putDurationMs;
+                diagnostics.chunkPutMaxMs = Math.max(
+                    diagnostics.chunkPutMaxMs,
+                    putDurationMs
+                );
+                if (
+                    diagnostics.slowestChunkPutMs == null ||
+                    putDurationMs > diagnostics.slowestChunkPutMs
+                ) {
+                    diagnostics.slowestChunkPutMs = putDurationMs;
+                    diagnostics.slowestChunkIndex = i;
+                }
                 uploadedBytes += chunkBytes.byteLength;
                 progress?.(uploadedBytes / Math.max(Number(size), 1));
             }
+            diagnostics.readyManifestStartedAt = Date.now();
             await this.files.put(
                 new LargeFile({
                     id: uploadId,
@@ -833,12 +915,17 @@ export class Files extends Program<Args> {
                     finalHash: toBase64(hasher.digest()),
                 })
             );
+            diagnostics.readyManifestFinishedAt = Date.now();
         } catch (error) {
+            diagnostics.failureAt = Date.now();
+            diagnostics.failureMessage =
+                error instanceof Error ? error.message : String(error);
             await this.cleanupChunkedUpload(uploadId).catch(() => {});
             await this.files.del(uploadId).catch(() => {});
             throw error;
         }
 
+        diagnostics.finishedAt = Date.now();
         progress?.(1);
         return uploadId;
     }


### PR DESCRIPTION
## Summary
- record upload timing diagnostics for chunked file-share uploads
- expose those diagnostics through the existing frontend benchmark hooks
- persist post-download benchmark diagnostics so successful runs include reader read-path details too

## Why
We needed to move from “upload feels slow” to concrete timing splits. The first remote-network measurement on this branch showed the bottleneck is the chunk publish path, not local file reads:
- 16 MiB upload total: about 18-21s
- local chunk reads: about 0.4s total
- chunk publish time: about 17-20s total across 32 chunks
- placeholder/final manifest writes are comparatively small

This patch makes those numbers available in normal benchmark artifacts instead of one-off local debug runs.

## Validation
- `pnpm --filter @peerbit/please-lib build`
- `pnpm exec vitest run packages/file-share/library/src/__tests__/index.integration.test.ts -t "records diagnostics for chunked uploads|falls back to chunk-id lookups when observer chunk searches miss available chunks|avoids keep-open remote waits for observer chunk downloads"`
- local remote-network browser benchmark (`16 MiB`) passed and now includes `writerDiagnostics.lastUploadDiagnostics` plus `readerDiagnosticsAfterDownload.lastReadDiagnostics`
