### PR TITLE
perf(file-share): overlap trust graph and file opens

### DIFF
--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -1149,7 +1149,7 @@ export class Files extends Program<Args> {
 
     // Setup lifecycle, will be invoked on 'open'
     async open(args?: Args): Promise<void> {
-        this.openDiagnostics = {
+        const openDiagnostics: OpenDiagnostics = {
             startedAt: Date.now(),
             trustGraphOpenStartedAt: null,
             trustGraphOpenFinishedAt: null,
@@ -1157,15 +1157,19 @@ export class Files extends Program<Args> {
             filesOpenFinishedAt: null,
             finishedAt: null,
         };
+        this.openDiagnostics = openDiagnostics;
         this.persistChunkReads = args?.replicate !== false;
-        this.openDiagnostics.trustGraphOpenStartedAt = Date.now();
-        await this.trustGraph?.open({
-            replicate: args?.replicate,
+        openDiagnostics.trustGraphOpenStartedAt = Date.now();
+        const trustGraphOpenPromise =
+            this.trustGraph?.open({
+                replicate: args?.replicate,
+            }) ?? Promise.resolve();
+        void trustGraphOpenPromise.finally(() => {
+            openDiagnostics.trustGraphOpenFinishedAt = Date.now();
         });
-        this.openDiagnostics.trustGraphOpenFinishedAt = Date.now();
 
-        this.openDiagnostics.filesOpenStartedAt = Date.now();
-        await this.files.open({
+        openDiagnostics.filesOpenStartedAt = Date.now();
+        const filesOpenPromise = this.files.open({
             type: AbstractFile,
             // TODO add ACL
             replicate: args?.replicate,
@@ -1174,6 +1178,7 @@ export class Files extends Program<Args> {
                 if (!this.trustGraph) {
                     return true;
                 }
+                await trustGraphOpenPromise;
                 for (const key of await operation.entry.getPublicKeys()) {
                     if (await this.trustGraph.isTrusted(key)) {
                         return true;
@@ -1185,7 +1190,11 @@ export class Files extends Program<Args> {
                 type: IndexableFile,
             },
         });
-        this.openDiagnostics.filesOpenFinishedAt = Date.now();
-        this.openDiagnostics.finishedAt = Date.now();
+        void filesOpenPromise.finally(() => {
+            openDiagnostics.filesOpenFinishedAt = Date.now();
+        });
+
+        await Promise.all([trustGraphOpenPromise, filesOpenPromise]);
+        openDiagnostics.finishedAt = Date.now();
     }
 }


### PR DESCRIPTION
## Summary
- open the trust graph and file store concurrently in file-share
- keep write authorization safe by awaiting trust-graph readiness inside canPerform
- reduce reader startup latency before the first list/download path

## Validation
- pnpm --filter @peerbit/please-lib build && pnpm --filter file-share build
- pnpm exec playwright test -c playwright.config.ts tests/observer-role.local.e2e.spec.ts --project chromium
- PW_PROTOCOL=http PW_BENCH=1 PW_BENCH_SCENARIO=prod PW_FILE_MB=16 PW_VITE_MODE=staging PW_VITE_CONFIG=vite.config.remote.ts PW_UPLOAD_TIMEOUT_MS=600000 PW_DOWNLOAD_TIMEOUT_MS=600000 PW_RESULT_FILE=/tmp/peerbit-examples-open-profile-result.json pnpm exec playwright test -c playwright.config.ts tests/transfer.bench.e2e.spec.ts --project chromium

## Notes
- in the scratch prod-mode run, reader program-open time dropped to about 1.06s because trustGraph.open and files.open now overlap instead of running serially