### PR TITLE
chore(file-share): add gated open benchmark profiling

### DIFF
--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -283,6 +283,12 @@ export const Drop = () => {
                     programAddress: files.program?.address ?? null,
                     programClosed: files.program?.closed ?? null,
                     persistChunkReads: files.program?.persistChunkReads ?? null,
+                    runtimeOpenProfileSamples:
+                        (window as Window & {
+                            __peerbitFileShareRuntimeOpenProfiler?: {
+                                samples?: Record<string, unknown>[];
+                            };
+                        }).__peerbitFileShareRuntimeOpenProfiler?.samples ?? null,
                     peerHash: peer?.identity?.publicKey?.hashcode?.() ?? null,
                     peerStatus,
                     peerLoading,

--- a/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
@@ -92,6 +92,17 @@ const seedReplicationRole = async (
     );
 };
 
+const enableOpenProfiler = async (page: Page) => {
+    await page.addInitScript(() => {
+        Object.defineProperty(window, "__peerbitFileShareEnableOpenProfiler", {
+            value: true,
+            configurable: true,
+            enumerable: false,
+            writable: true,
+        });
+    });
+};
+
 const toMiBPerSecond = (bytes: number, durationMs: number) =>
     durationMs > 0 ? bytes / (1024 * 1024) / (durationMs / 1000) : null;
 
@@ -149,6 +160,8 @@ test.describe("file-share transfer benchmark", () => {
                 usesLocalBootstrap && bootstrap
                     ? withBootstrap(rootUrl(baseURL), bootstrap.addrs)
                     : rootUrl(baseURL);
+            await enableOpenProfiler(writer);
+            await enableOpenProfiler(reader);
             await writer.goto(entryUrl, { waitUntil: "domcontentloaded" });
             await waitForCreateSpaceHook(writer);
             const address = await createSpaceFromHook(

--- a/packages/file-share/frontend/tests/two-runner.bench.mjs
+++ b/packages/file-share/frontend/tests/two-runner.bench.mjs
@@ -87,6 +87,17 @@ const seedReplicationRole = async (page, address, roleOptions) => {
     );
 };
 
+const enableOpenProfiler = async (page) => {
+    await page.addInitScript(() => {
+        Object.defineProperty(window, "__peerbitFileShareEnableOpenProfiler", {
+            value: true,
+            configurable: true,
+            enumerable: false,
+            writable: true,
+        });
+    });
+};
+
 const waitForFileListed = async (page, fileName, timeout = 180_000) => {
     await page.locator("li", { hasText: fileName }).first().waitFor({ timeout });
 };
@@ -377,6 +388,7 @@ const runWriter = async (coordinator) => {
     const browser = await chromium.launch({ headless: true });
     const context = await browser.newContext({ acceptDownloads: true });
     const page = await context.newPage();
+    await enableOpenProfiler(page);
     const fileName = `file-share-two-runner-${Date.now()}.bin`;
     const preparedFile = await createSyntheticFileOnDisk(fileName, FILE_SIZE_MB);
 
@@ -477,6 +489,7 @@ const runReader = async (coordinator) => {
     const browser = await chromium.launch({ headless: true });
     const context = await browser.newContext({ acceptDownloads: true });
     const page = await context.newPage();
+    await enableOpenProfiler(page);
     const usesStreamingDownload =
         FILE_SIZE_MB * 1024 * 1024 >= STREAMING_DOWNLOAD_THRESHOLD_BYTES;
 

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -1,5 +1,5 @@
 import { field, variant, vec, option } from "@dao-xyz/borsh";
-import { Program } from "@peerbit/program";
+import { Program, ProgramHandler } from "@peerbit/program";
 import {
     Documents,
     SearchRequest,
@@ -17,11 +17,135 @@ import {
 import { concat } from "uint8arrays";
 import { sha256Sync } from "@peerbit/crypto";
 import { TrustedNetwork } from "@peerbit/trusted-network";
-import { ReplicationOptions } from "@peerbit/shared-log";
+import { ReplicationOptions, SharedLog } from "@peerbit/shared-log";
 import { SHA256 } from "@stablelib/sha256";
 
 const sleep = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
+
+type RuntimeOpenProfileSample = {
+    label: string;
+    target: string;
+    startedAt: number;
+    finishedAt: number;
+    durationMs: number;
+};
+
+type RuntimeOpenProfilerState = {
+    patched: boolean;
+    samples: RuntimeOpenProfileSample[];
+};
+
+const isRuntimeOpenProfilerEnabled = () => {
+    const scope = globalThis as typeof globalThis & {
+        __peerbitFileShareEnableOpenProfiler?: boolean;
+    };
+    return scope.__peerbitFileShareEnableOpenProfiler === true;
+};
+
+const getRuntimeOpenProfilerState = (): RuntimeOpenProfilerState => {
+    const scope = globalThis as typeof globalThis & {
+        __peerbitFileShareRuntimeOpenProfiler?: RuntimeOpenProfilerState;
+    };
+    scope.__peerbitFileShareRuntimeOpenProfiler ??= {
+        patched: false,
+        samples: [],
+    };
+    return scope.__peerbitFileShareRuntimeOpenProfiler;
+};
+
+const recordRuntimeOpenProfileSample = (
+    label: string,
+    target: string,
+    startedAt: number
+) => {
+    if (!isRuntimeOpenProfilerEnabled()) {
+        return;
+    }
+    const finishedAt = Date.now();
+    getRuntimeOpenProfilerState().samples.push({
+        label,
+        target,
+        startedAt,
+        finishedAt,
+        durationMs: finishedAt - startedAt,
+    });
+};
+
+const wrapAsyncMethod = (
+    ctor:
+        | {
+              name?: string;
+              prototype?: object;
+          }
+        | undefined,
+    method: string,
+    getLabel: (instance: any, args: any[]) => string
+) => {
+    const prototype = ctor?.prototype as Record<string, unknown> | undefined;
+    if (!prototype || typeof prototype[method] !== "function") {
+        return;
+    }
+    const original = prototype[method] as ((...args: any[]) => Promise<any>) & {
+        __peerbitOpenProfilePatched?: boolean;
+    };
+    if (original.__peerbitOpenProfilePatched) {
+        return;
+    }
+    const wrapped = async function (this: any, ...args: any[]) {
+        const startedAt = Date.now();
+        try {
+            return await original.apply(this, args);
+        } finally {
+            recordRuntimeOpenProfileSample(
+                getLabel(this, args),
+                this?.constructor?.name ?? ctor?.name ?? "unknown",
+                startedAt
+            );
+        }
+    };
+    wrapped.__peerbitOpenProfilePatched = true;
+    prototype[method] = wrapped;
+};
+
+const describeOpenTarget = (target: unknown) => {
+    if (typeof target === "string") {
+        return "address";
+    }
+    return (target as { constructor?: { name?: string } })?.constructor?.name ?? "unknown";
+};
+
+const installRuntimeOpenProfiler = () => {
+    if (!isRuntimeOpenProfilerEnabled()) {
+        return;
+    }
+    const state = getRuntimeOpenProfilerState();
+    if (state.patched) {
+        return;
+    }
+    state.patched = true;
+
+    wrapAsyncMethod(ProgramHandler, "open", (_instance, args) => {
+        return `ProgramHandler.open(${describeOpenTarget(args[0])})`;
+    });
+    wrapAsyncMethod(Program, "beforeOpen", (instance) => {
+        return `Program.beforeOpen(${instance?.constructor?.name ?? "unknown"})`;
+    });
+    wrapAsyncMethod(Program, "afterOpen", (instance) => {
+        return `Program.afterOpen(${instance?.constructor?.name ?? "unknown"})`;
+    });
+    wrapAsyncMethod(Documents, "open", (instance) => {
+        return `Documents.open(${instance?.constructor?.name ?? "unknown"})`;
+    });
+    wrapAsyncMethod(SharedLog, "open", (instance) => {
+        return `SharedLog.open(${instance?.constructor?.name ?? "unknown"})`;
+    });
+    wrapAsyncMethod(TrustedNetwork, "open", (instance) => {
+        return `TrustedNetwork.open(${instance?.constructor?.name ?? "unknown"})`;
+    });
+};
+
+installRuntimeOpenProfiler();
 
 const isRetryableChunkLookupError = (error: unknown) =>
     error instanceof Error &&
@@ -580,6 +704,7 @@ type OpenDiagnostics = {
     filesOpenStartedAt: number | null;
     filesOpenFinishedAt: number | null;
     finishedAt: number | null;
+    runtimeProfileSamples?: RuntimeOpenProfileSample[];
 };
 
 type UploadDiagnostics = {
@@ -1149,6 +1274,8 @@ export class Files extends Program<Args> {
 
     // Setup lifecycle, will be invoked on 'open'
     async open(args?: Args): Promise<void> {
+        const runtimeProfileStartIndex =
+            getRuntimeOpenProfilerState().samples.length;
         const openDiagnostics: OpenDiagnostics = {
             startedAt: Date.now(),
             trustGraphOpenStartedAt: null,
@@ -1196,5 +1323,8 @@ export class Files extends Program<Args> {
 
         await Promise.all([trustGraphOpenPromise, filesOpenPromise]);
         openDiagnostics.finishedAt = Date.now();
+        openDiagnostics.runtimeProfileSamples = getRuntimeOpenProfilerState().samples.slice(
+            runtimeProfileStartIndex
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add gated runtime open profiling for file-share benchmark sessions
- expose profiler samples through the existing file-share test hook diagnostics
- enable the profiler in the same-runner and two-runner benchmark harnesses

## Validation
- pnpm install --frozen-lockfile
- pnpm --filter @peerbit/please-lib build
- pnpm --filter file-share build
- PW_PROTOCOL=http PW_BENCH=1 PW_BENCH_SCENARIO=prod PW_FILE_MB=16 PW_VITE_MODE=staging PW_VITE_CONFIG=vite.config.remote.ts PW_UPLOAD_TIMEOUT_MS=600000 PW_DOWNLOAD_TIMEOUT_MS=600000 PW_RESULT_FILE=/tmp/peerbit-examples-observer-open-result.json pnpm exec playwright test -c playwright.config.ts tests/transfer.bench.e2e.spec.ts --project chromium