### PR TITLE
Fix file-share large-file replication downloads

### DIFF
--- a/packages/file-share/frontend/playwright.config.ts
+++ b/packages/file-share/frontend/playwright.config.ts
@@ -35,6 +35,8 @@ const explicitBaseUrl = process.env.PW_BASE_URL
 const viteMode = process.env.PW_VITE_MODE || "development";
 const viteConfig = process.env.PW_VITE_CONFIG;
 const viteConfigArg = viteConfig ? ` --config ${viteConfig}` : "";
+const viteForceArg =
+    process.env.PW_VITE_FORCE_OPTIMIZE_DEPS === "0" ? "" : " --force";
 const localProtocol =
     process.env.PW_PROTOCOL ||
     (viteConfig?.includes("remote") ? "https" : "http");
@@ -63,9 +65,9 @@ export default defineConfig({
     },
     projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
     webServer: explicitBaseUrl
-          ? undefined
+        ? undefined
         : {
-              command: `pnpm --filter @peerbit/please-lib build && pnpm exec vite dev --mode ${viteMode}${viteConfigArg} --port ${PORT} --strictPort --host ${HOST}`,
+              command: `pnpm --filter @peerbit/please-lib build && pnpm exec vite dev${viteForceArg} --mode ${viteMode}${viteConfigArg} --port ${PORT} --strictPort --host ${HOST}`,
               ignoreHTTPSErrors,
               url: localBaseUrl,
               reuseExistingServer: false,

--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -25,7 +25,7 @@ const getRoleFromLocalStorage = (files: Files) => {
 };
 
 const DEFAULT_REPLICATION_ROLE: ReplicationOptions = {
-    factor: 1,
+    limits: { cpu: { max: 1, monitor: undefined } },
 };
 
 const parseStoredRole = (
@@ -211,7 +211,7 @@ export const Drop = () => {
     const [role, setRole] = useState<"replicator" | "observer">(
         storedRole === false ? "observer" : "replicator"
     );
-    const [limitCPU, setLimitCPU] = useState<number | undefined>();
+    const [limitCPU, setLimitCPU] = useState<number | undefined>(1);
     const [uploadProgress, setUploadProgress] = useState<number | null>(null);
 
     // we exclude the string type 'replicator' | 'observer' from the roleOptions so that we can easily serialize it with JSON
@@ -547,13 +547,7 @@ export const Drop = () => {
                 return;
             }
 
-            if (files.program.persistChunkReads) {
-                await files.program.waitForLocalChunks(file, {
-                    timeout,
-                    progress: (value) => progress(value * 0.5),
-                });
-                preparedLargeDownload = true;
-            } else {
+            if (!files.program.persistChunkReads) {
                 releasePreparedDownload =
                     await files.program.prepareLargeFileDownload(file, {
                         timeout,

--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -9,7 +9,7 @@ import { File } from "./File";
 import { Spinner } from "./Spinner";
 import * as Switch from "@radix-ui/react-switch";
 import * as Slider from "@radix-ui/react-slider";
-import { SearchRequest } from "@peerbit/document";
+import { IsNull, SearchRequest } from "@peerbit/document";
 import * as Popover from "@radix-ui/react-popover";
 import { useStorageUsage } from "./MemoryUsage";
 import { useNetworkUsage } from "./NetworkUsage";
@@ -25,7 +25,7 @@ const getRoleFromLocalStorage = (files: Files) => {
 };
 
 const DEFAULT_REPLICATION_ROLE: ReplicationOptions = {
-    limits: { cpu: { max: 1, monitor: undefined } },
+    factor: 1,
 };
 
 const parseStoredRole = (
@@ -65,9 +65,7 @@ type ListingDiagnostics = {
 };
 
 type SaveFilePickerWindow = Window & {
-    showSaveFilePicker?: (options?: {
-        suggestedName?: string;
-    }) => Promise<{
+    showSaveFilePicker?: (options?: { suggestedName?: string }) => Promise<{
         createWritable(): Promise<BrowserFileWriter>;
     }>;
     __peerbitStreamingDownloadThresholdBytes?: number;
@@ -172,22 +170,21 @@ export const Drop = () => {
     );
 
     useEffect(() => {
-        diagnosticsRef.current = createListingDiagnostics(shareAddress, storedRole);
+        diagnosticsRef.current = createListingDiagnostics(
+            shareAddress,
+            storedRole
+        );
         // Reset diagnostics only when we enter a different share. Role changes
         // inside the same share are part of the same session we want to measure.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [shareAddress]);
 
-    const files = useProgram<Files>(
-        peer,
-        shareAddress,
-        {
-            existing: "reuse",
-            args: {
-                replicate: storedRole ?? DEFAULT_REPLICATION_ROLE,
-            },
-        }
-    );
+    const files = useProgram<Files>(peer, shareAddress, {
+        existing: "reuse",
+        args: {
+            replicate: storedRole ?? DEFAULT_REPLICATION_ROLE,
+        },
+    });
 
     useEffect(() => {
         if (peer && diagnosticsRef.current.firstPeerReadyAt == null) {
@@ -198,7 +195,10 @@ export const Drop = () => {
     useEffect(() => {
         diagnosticsRef.current.programHookStatus = files.status;
         diagnosticsRef.current.programHookLoading = files.loading;
-        if (files.program && diagnosticsRef.current.firstProgramHookReadyAt == null) {
+        if (
+            files.program &&
+            diagnosticsRef.current.firstProgramHookReadyAt == null
+        ) {
             diagnosticsRef.current.firstProgramHookReadyAt = Date.now();
         }
     }, [files.loading, files.program, files.status]);
@@ -211,7 +211,7 @@ export const Drop = () => {
     const [role, setRole] = useState<"replicator" | "observer">(
         storedRole === false ? "observer" : "replicator"
     );
-    const [limitCPU, setLimitCPU] = useState<number | undefined>(1);
+    const [limitCPU, setLimitCPU] = useState<number | undefined>();
     const [uploadProgress, setUploadProgress] = useState<number | null>(null);
 
     // we exclude the string type 'replicator' | 'observer' from the roleOptions so that we can easily serialize it with JSON
@@ -251,7 +251,10 @@ export const Drop = () => {
         }
         testWindow.__peerbitFileShareTestHooks = {
             setReplicationRole: async (roleOptions) => {
-                saveRoleLocalStorage(files.program, JSON.stringify(roleOptions));
+                saveRoleLocalStorage(
+                    files.program,
+                    JSON.stringify(roleOptions)
+                );
                 setRole(roleOptions ? "replicator" : "observer");
                 await updateRole(roleOptions);
             },
@@ -284,11 +287,14 @@ export const Drop = () => {
                     programClosed: files.program?.closed ?? null,
                     persistChunkReads: files.program?.persistChunkReads ?? null,
                     runtimeOpenProfileSamples:
-                        (window as Window & {
-                            __peerbitFileShareRuntimeOpenProfiler?: {
-                                samples?: Record<string, unknown>[];
-                            };
-                        }).__peerbitFileShareRuntimeOpenProfiler?.samples ?? null,
+                        (
+                            window as Window & {
+                                __peerbitFileShareRuntimeOpenProfiler?: {
+                                    samples?: Record<string, unknown>[];
+                                };
+                            }
+                        ).__peerbitFileShareRuntimeOpenProfiler?.samples ??
+                        null,
                     peerHash: peer?.identity?.publicKey?.hashcode?.() ?? null,
                     peerStatus,
                     peerLoading,
@@ -296,6 +302,9 @@ export const Drop = () => {
                         files.program?.openDiagnostics ?? null,
                     lastUploadDiagnostics:
                         files.program?.lastUploadDiagnostics ?? null,
+                    lastDownloadPreparationDiagnostics:
+                        files.program?.lastDownloadPreparationDiagnostics ??
+                        null,
                     lastReadDiagnostics:
                         files.program?.lastReadDiagnostics ?? null,
                     replicatorCount:
@@ -331,15 +340,17 @@ export const Drop = () => {
 
             updateRole(
                 role === "replicator"
-                    ? {
-                          limits: {
-                              cpu:
-                                  limitCPU != null
-                                      ? { max: limitCPU }
-                                      : undefined,
-                              storage: limitStorage ? sizeBytes : undefined,
-                          },
-                      }
+                    ? limitCPU == null && !limitStorage
+                        ? DEFAULT_REPLICATION_ROLE
+                        : {
+                              limits: {
+                                  cpu:
+                                      limitCPU != null
+                                          ? { max: limitCPU }
+                                          : undefined,
+                                  storage: limitStorage ? sizeBytes : undefined,
+                              },
+                          }
                     : false
             );
         },
@@ -390,12 +401,11 @@ export const Drop = () => {
             const roleFromLocalstore = parseStoredRole(
                 serializedRoleFromStorage
             );
-            const desiredRole =
-                hasStoredRole
-                    ? roleFromLocalstore
-                    : role === "replicator"
-                      ? DEFAULT_REPLICATION_ROLE
-                      : false;
+            const desiredRole = hasStoredRole
+                ? roleFromLocalstore
+                : role === "replicator"
+                  ? DEFAULT_REPLICATION_ROLE
+                  : false;
 
             files.program.persistChunkReads = desiredRole !== false;
             setRole(desiredRole === false ? "observer" : "replicator");
@@ -487,7 +497,12 @@ export const Drop = () => {
             void (async () => {
                 try {
                     const [allFiles, replicators] = await Promise.all([
-                        files.program.files.index.search(new SearchRequest({})),
+                        files.program.files.index.search(
+                            new SearchRequest({
+                                query: new IsNull({ key: "parentId" }),
+                                fetch: 0xffffffff,
+                            })
+                        ),
                         files.program.files.log.getReplicators(),
                     ]);
                     setReplicationSet(new Set(allFiles.map((x) => x.id)));
@@ -521,10 +536,35 @@ export const Drop = () => {
         const timeout =
             file instanceof LargeFile
                 ? Math.max(
-                      60_000,
-                      Math.ceil(Number(file.size) / 1e6) * 1_000
+                      5 * 60_000,
+                      Math.ceil(Number(file.size) / 1e6) * 3_000
                   )
                 : 10_000;
+        let releasePreparedDownload: (() => Promise<void>) | undefined;
+        let preparedLargeDownload = false;
+        const prepareDownload = async () => {
+            if (!(file instanceof LargeFile) || !files.program) {
+                return;
+            }
+
+            if (files.program.persistChunkReads) {
+                await files.program.waitForLocalChunks(file, {
+                    timeout,
+                    progress: (value) => progress(value * 0.5),
+                });
+                preparedLargeDownload = true;
+            } else {
+                releasePreparedDownload =
+                    await files.program.prepareLargeFileDownload(file, {
+                        timeout,
+                        progress: (value) => progress(value * 0.5),
+                    });
+                preparedLargeDownload = true;
+            }
+        };
+        const downloadProgress = (value: number) => {
+            progress(preparedLargeDownload ? 0.5 + value * 0.5 : value);
+        };
         try {
             const saveFilePicker = (window as SaveFilePickerWindow)
                 .showSaveFilePicker;
@@ -542,22 +582,22 @@ export const Drop = () => {
                     throw error;
                 });
                 if (handle) {
+                    await prepareDownload();
                     const writable = await handle.createWritable();
                     await file.writeFile(files.program, writable, {
                         timeout,
-                        progress: (value) => {
-                            progress(value);
-                        },
+                        progress: downloadProgress,
                     });
                     return;
                 }
                 return;
             }
 
+            await prepareDownload();
             const bytes = await file.getFile(files.program, {
                 as: "chunks",
                 timeout,
-                progress,
+                progress: downloadProgress,
             });
             const blob = new Blob(bytes as BlobPart[]);
             const link = document.createElement("a");
@@ -569,6 +609,7 @@ export const Drop = () => {
                 window.URL.revokeObjectURL(url);
             }, 60_000);
         } finally {
+            await releasePreparedDownload?.();
             progress(null);
         }
     };
@@ -614,11 +655,18 @@ export const Drop = () => {
             // there will just by one file here in practice
             for (const file of filesToAdd) {
                 promises.push(
-                    files.program.addBlob(file.name, file, undefined, (progress) => {
-                        setUploadProgress((current) =>
-                            current == null ? progress : Math.max(progress, current)
-                        );
-                    })
+                    files.program.addBlob(
+                        file.name,
+                        file,
+                        undefined,
+                        (progress) => {
+                            setUploadProgress((current) =>
+                                current == null
+                                    ? progress
+                                    : Math.max(progress, current)
+                            );
+                        }
+                    )
                 );
             }
 

--- a/packages/file-share/frontend/tests/download-streamed.local.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/download-streamed.local.e2e.spec.ts
@@ -9,13 +9,14 @@ import {
     uploadSyntheticFile,
     waitForFileListed,
     waitForUploadComplete,
-    withPeer,
+    withBootstrap,
 } from "./helpers";
 
 const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "100");
+const READER_ROLE = process.env.PW_READER_ROLE || "replicator";
 
 test.describe("file-share streamed download via local bootstrap", () => {
-    test("observer can stream a large file to the save picker without buffering the whole blob", async ({
+    test(`${READER_ROLE} can stream a large file to the save picker without buffering the whole blob`, async ({
         browser,
         baseURL,
     }) => {
@@ -37,7 +38,7 @@ test.describe("file-share streamed download via local bootstrap", () => {
 
         try {
             await installMockSaveFilePicker(reader);
-            const entryUrl = withPeer(rootUrl(baseURL), bootstrap.addrs);
+            const entryUrl = withBootstrap(rootUrl(baseURL), bootstrap.addrs);
             const shareUrl = await createSpace(
                 writer,
                 entryUrl,
@@ -49,13 +50,8 @@ test.describe("file-share streamed download via local bootstrap", () => {
             await waitForUploadComplete(writer, 600_000);
 
             await reader.goto(shareUrl, { waitUntil: "domcontentloaded" });
-            await setSeedMode(reader, false);
+            await setSeedMode(reader, READER_ROLE === "replicator");
             await waitForFileListed(reader, fileName, 600_000);
-
-            await reader
-                .locator("li", { hasText: fileName })
-                .getByTestId("download-file")
-                .click();
 
             await expectSavedViaPicker(
                 reader,

--- a/packages/file-share/frontend/tests/download-streamed.local.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/download-streamed.local.e2e.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "./helpers";
 
 const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "100");
-const READER_ROLE = process.env.PW_READER_ROLE || "replicator";
+const READER_ROLE = process.env.PW_READER_ROLE || "adaptive";
 
 test.describe("file-share streamed download via local bootstrap", () => {
     test(`${READER_ROLE} can stream a large file to the save picker without buffering the whole blob`, async ({
@@ -50,7 +50,7 @@ test.describe("file-share streamed download via local bootstrap", () => {
             await waitForUploadComplete(writer, 600_000);
 
             await reader.goto(shareUrl, { waitUntil: "domcontentloaded" });
-            await setSeedMode(reader, READER_ROLE === "replicator");
+            await setSeedMode(reader, READER_ROLE !== "observer");
             await waitForFileListed(reader, fileName, 600_000);
 
             await expectSavedViaPicker(

--- a/packages/file-share/frontend/tests/download.local.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/download.local.e2e.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "./helpers";
 
 const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "100");
-const READER_ROLE = process.env.PW_READER_ROLE || "replicator";
+const READER_ROLE = process.env.PW_READER_ROLE || "adaptive";
 
 test.describe("file-share download via local bootstrap", () => {
     test(`${READER_ROLE} can download a 100 MB file with the download button`, async ({
@@ -48,7 +48,7 @@ test.describe("file-share download via local bootstrap", () => {
             await waitForUploadComplete(writer, 600_000);
 
             await reader.goto(shareUrl, { waitUntil: "domcontentloaded" });
-            await setSeedMode(reader, READER_ROLE === "replicator");
+            await setSeedMode(reader, READER_ROLE !== "observer");
             await waitForFileListed(reader, fileName, 600_000);
 
             await expectDownloadedFile(reader, fileName, FILE_SIZE_MB, 600_000);

--- a/packages/file-share/frontend/tests/download.local.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/download.local.e2e.spec.ts
@@ -12,9 +12,10 @@ import {
 } from "./helpers";
 
 const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "100");
+const READER_ROLE = process.env.PW_READER_ROLE || "replicator";
 
 test.describe("file-share download via local bootstrap", () => {
-    test("observer can download a 100 MB file with the download button", async ({
+    test(`${READER_ROLE} can download a 100 MB file with the download button`, async ({
         browser,
         baseURL,
     }) => {
@@ -47,7 +48,7 @@ test.describe("file-share download via local bootstrap", () => {
             await waitForUploadComplete(writer, 600_000);
 
             await reader.goto(shareUrl, { waitUntil: "domcontentloaded" });
-            await setSeedMode(reader, false);
+            await setSeedMode(reader, READER_ROLE === "replicator");
             await waitForFileListed(reader, fileName, 600_000);
 
             await expectDownloadedFile(reader, fileName, FILE_SIZE_MB, 600_000);

--- a/packages/file-share/frontend/tests/download.remote.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/download.remote.e2e.spec.ts
@@ -11,7 +11,7 @@ import {
 
 const PROD_ONLY = process.env.PW_PROD_SMOKE === "1";
 const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "100");
-const READER_ROLE = process.env.PW_READER_ROLE || "replicator";
+const READER_ROLE = process.env.PW_READER_ROLE || "adaptive";
 
 test.describe("file-share download via production site", () => {
     test.skip(!PROD_ONLY, "Set PW_PROD_SMOKE=1 to run against production");
@@ -47,7 +47,7 @@ test.describe("file-share download via production site", () => {
             await waitForUploadComplete(writer, 600_000);
 
             await reader.goto(shareUrl, { waitUntil: "domcontentloaded" });
-            await setSeedMode(reader, READER_ROLE === "replicator");
+            await setSeedMode(reader, READER_ROLE !== "observer");
             await waitForFileListed(reader, fileName, 600_000);
 
             await expectDownloadedFile(reader, fileName, FILE_SIZE_MB, 600_000);

--- a/packages/file-share/frontend/tests/download.remote.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/download.remote.e2e.spec.ts
@@ -11,11 +11,12 @@ import {
 
 const PROD_ONLY = process.env.PW_PROD_SMOKE === "1";
 const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "100");
+const READER_ROLE = process.env.PW_READER_ROLE || "replicator";
 
 test.describe("file-share download via production site", () => {
     test.skip(!PROD_ONLY, "Set PW_PROD_SMOKE=1 to run against production");
 
-    test("observer can download a 100 MB file with the download button", async ({
+    test(`${READER_ROLE} can download a 100 MB file with the download button`, async ({
         browser,
         baseURL,
     }) => {
@@ -46,7 +47,7 @@ test.describe("file-share download via production site", () => {
             await waitForUploadComplete(writer, 600_000);
 
             await reader.goto(shareUrl, { waitUntil: "domcontentloaded" });
-            await setSeedMode(reader, false);
+            await setSeedMode(reader, READER_ROLE === "replicator");
             await waitForFileListed(reader, fileName, 600_000);
 
             await expectDownloadedFile(reader, fileName, FILE_SIZE_MB, 600_000);

--- a/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
@@ -15,7 +15,8 @@ import {
 
 const ENABLED = process.env.PW_BENCH === "1";
 const SCENARIO = process.env.PW_BENCH_SCENARIO || "local";
-const READER_ROLE = process.env.PW_READER_ROLE || "replicator";
+const READER_ROLE = process.env.PW_READER_ROLE || "adaptive";
+const ADAPTIVE_REPLICATION_ROLE = { limits: { cpu: { max: 1 } } };
 const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "1024");
 const RESULT_FILE = process.env.PW_RESULT_FILE;
 const UPLOAD_TIMEOUT_MS = Number(process.env.PW_UPLOAD_TIMEOUT_MS || "1800000");
@@ -28,7 +29,7 @@ if (!["local", "prod"].includes(SCENARIO)) {
     throw new Error(`Unsupported PW_BENCH_SCENARIO='${SCENARIO}'`);
 }
 
-if (!["observer", "replicator"].includes(READER_ROLE)) {
+if (!["adaptive", "observer", "replicator"].includes(READER_ROLE)) {
     throw new Error(`Unsupported PW_READER_ROLE='${READER_ROLE}'`);
 }
 
@@ -180,7 +181,9 @@ test.describe("file-share transfer benchmark", () => {
             await seedReplicationRole(
                 reader,
                 address,
-                READER_ROLE === "observer" ? false : { factor: 1 }
+                READER_ROLE === "observer"
+                    ? false
+                    : ADAPTIVE_REPLICATION_ROLE
             );
 
             logStage("open-reader", { shareUrl: shareUrl.toString() });

--- a/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
@@ -15,11 +15,10 @@ import {
 
 const ENABLED = process.env.PW_BENCH === "1";
 const SCENARIO = process.env.PW_BENCH_SCENARIO || "local";
+const READER_ROLE = process.env.PW_READER_ROLE || "replicator";
 const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "1024");
 const RESULT_FILE = process.env.PW_RESULT_FILE;
-const UPLOAD_TIMEOUT_MS = Number(
-    process.env.PW_UPLOAD_TIMEOUT_MS || "1800000"
-);
+const UPLOAD_TIMEOUT_MS = Number(process.env.PW_UPLOAD_TIMEOUT_MS || "1800000");
 const DOWNLOAD_TIMEOUT_MS = Number(
     process.env.PW_DOWNLOAD_TIMEOUT_MS || "1800000"
 );
@@ -27,6 +26,10 @@ const STREAMING_DOWNLOAD_THRESHOLD_BYTES = 250_000_000;
 
 if (!["local", "prod"].includes(SCENARIO)) {
     throw new Error(`Unsupported PW_BENCH_SCENARIO='${SCENARIO}'`);
+}
+
+if (!["observer", "replicator"].includes(READER_ROLE)) {
+    throw new Error(`Unsupported PW_READER_ROLE='${READER_ROLE}'`);
 }
 
 const persistResult = async (result: Record<string, unknown>) => {
@@ -42,6 +45,7 @@ const logStage = (stage: string, details: Record<string, unknown> = {}) => {
         `FILE_SHARE_TRANSFER_BENCH_STAGE ${JSON.stringify({
             stage,
             scenario: SCENARIO,
+            readerRole: READER_ROLE,
             fileSizeMb: FILE_SIZE_MB,
             ...details,
         })}`
@@ -70,7 +74,9 @@ const getDiagnostics = async (page: Page) => {
     return await page.evaluate(async () => {
         const hooks = (window as any).__peerbitFileShareTestHooks;
         if (!hooks?.getDiagnostics) {
-            throw new Error("Missing __peerbitFileShareTestHooks.getDiagnostics");
+            throw new Error(
+                "Missing __peerbitFileShareTestHooks.getDiagnostics"
+            );
         }
         return await hooks.getDiagnostics();
     });
@@ -171,13 +177,21 @@ test.describe("file-share transfer benchmark", () => {
             const shareUrl = new URL(entryUrl);
             shareUrl.hash = `/s/${address}`;
             logStage("seed-reader-role");
-            await seedReplicationRole(reader, address, false);
+            await seedReplicationRole(
+                reader,
+                address,
+                READER_ROLE === "observer" ? false : { factor: 1 }
+            );
 
             logStage("open-reader", { shareUrl: shareUrl.toString() });
             logStage("open-writer-page");
-            await writer.goto(shareUrl.toString(), { waitUntil: "domcontentloaded" });
+            await writer.goto(shareUrl.toString(), {
+                waitUntil: "domcontentloaded",
+            });
             logStage("writer-page-ready");
-            await reader.goto(shareUrl.toString(), { waitUntil: "domcontentloaded" });
+            await reader.goto(shareUrl.toString(), {
+                waitUntil: "domcontentloaded",
+            });
             logStage("reader-page-ready");
 
             logStage("wait-for-input");
@@ -188,7 +202,9 @@ test.describe("file-share transfer benchmark", () => {
 
             logStage("upload");
             const uploadStartedAt = Date.now();
-            await writer.locator("#imgupload").setInputFiles(preparedFile.filePath);
+            await writer
+                .locator("#imgupload")
+                .setInputFiles(preparedFile.filePath);
             logStage("wait-for-writer-listing");
             await waitForFileListed(writer, fileName, UPLOAD_TIMEOUT_MS);
             logStage("wait-for-upload-complete");
@@ -229,6 +245,7 @@ test.describe("file-share transfer benchmark", () => {
             const result = {
                 status: "passed",
                 scenario: SCENARIO,
+                readerRole: READER_ROLE,
                 baseURL,
                 shareUrl: shareUrl.toString(),
                 fileName,
@@ -276,6 +293,7 @@ test.describe("file-share transfer benchmark", () => {
             const result = {
                 status: "failed",
                 scenario: SCENARIO,
+                readerRole: READER_ROLE,
                 fileName,
                 fileSizeMb: FILE_SIZE_MB,
                 failure: {
@@ -284,13 +302,17 @@ test.describe("file-share transfer benchmark", () => {
                             ? error.message
                             : String(error),
                     stack:
-                        typeof error?.stack === "string" ? error.stack : undefined,
+                        typeof error?.stack === "string"
+                            ? error.stack
+                            : undefined,
                 },
                 writerDiagnostics: failureWriterDiagnostics,
                 readerDiagnostics: failureReaderDiagnostics,
             };
             await persistResult(result);
-            console.error(`FILE_SHARE_TRANSFER_BENCH ${JSON.stringify(result)}`);
+            console.error(
+                `FILE_SHARE_TRANSFER_BENCH ${JSON.stringify(result)}`
+            );
             throw error;
         } finally {
             await writerContext.close().catch(() => {});

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -179,7 +179,10 @@ describe("index", () => {
         it("records diagnostics for chunked uploads", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const fileId = await filestore.add("diagnostic large file", largeFile);
+            const fileId = await filestore.add(
+                "diagnostic large file",
+                largeFile
+            );
 
             expect(fileId).to.be.a("string");
             expect(filestore.lastUploadDiagnostics).to.deep.include({
@@ -187,13 +190,15 @@ describe("index", () => {
                 fileName: "diagnostic large file",
                 sizeBytes: largeFile.byteLength,
             });
-            expect(filestore.lastUploadDiagnostics?.chunkCount).to.be.greaterThan(1);
+            expect(
+                filestore.lastUploadDiagnostics?.chunkCount
+            ).to.be.greaterThan(1);
             expect(filestore.lastUploadDiagnostics?.chunkPutCount).to.eq(
                 filestore.lastUploadDiagnostics?.chunkCount
             );
-            expect(filestore.lastUploadDiagnostics?.manifestFinishedAt).to.not.eq(
-                null
-            );
+            expect(
+                filestore.lastUploadDiagnostics?.manifestFinishedAt
+            ).to.not.eq(null);
             expect(
                 filestore.lastUploadDiagnostics?.readyManifestFinishedAt
             ).to.not.eq(null);
@@ -217,10 +222,12 @@ describe("index", () => {
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
 
-            const originalSearch =
-                filestoreReader.files.index.search.bind(filestoreReader.files.index);
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
             let parentIdSearches = 0;
             let directChunkGets = 0;
             let inflightChunkGets = 0;
@@ -278,11 +285,11 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
-        it("waits for all chunk documents before streaming observer downloads", async () => {
+        it("streams observer downloads with bounded direct chunk reads", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
             const fileId = await filestore.add(
-                "observer download waits for full chunk set",
+                "observer download uses bounded direct chunks",
                 largeFile
             );
 
@@ -296,52 +303,56 @@ describe("index", () => {
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
 
-            const originalSearch =
-                filestoreReader.files.index.search.bind(filestoreReader.files.index);
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
-            let fetchSearchCalls = 0;
-            let partialFetches = 0;
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
+            let parentIdSearches = 0;
             let directChunkGets = 0;
+            let inflightChunkGets = 0;
+            let maxInflightChunkGets = 0;
+            let sawChunkReplicate = false;
 
             (filestoreReader.files.index as any).search = async (
-                request: unknown,
+                request: { query: unknown | unknown[] },
                 options: unknown
             ) => {
-                const results = await originalSearch(
-                    request as never,
-                    options as never
-                );
-                const chunkResults = results.filter(
-                    (result: unknown) =>
-                        result instanceof TinyFile && result.parentId === fileId
-                );
-                if (chunkResults.length === 0) {
-                    return results;
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasParentIdLookup = queries.some((query: any) => {
+                    const key = Array.isArray(query?.key)
+                        ? query.key[0]
+                        : query?.key;
+                    return key === "parentId" && query?.value === fileId;
+                });
+                if (hasParentIdLookup) {
+                    parentIdSearches++;
                 }
 
-                fetchSearchCalls++;
-                if (partialFetches < 2) {
-                    partialFetches++;
-                    return results.filter(
-                        (result: unknown) =>
-                            !(
-                                result instanceof TinyFile &&
-                                result.parentId === fileId &&
-                                result.index === 1
-                            )
-                    );
-                }
-
-                return results;
+                return originalSearch(request as never, options as never);
             };
 
             (filestoreReader.files.index as any).get = async (
                 id: string,
-                options: unknown
+                options: { remote?: { replicate?: boolean } }
             ) => {
                 if (id.startsWith(`${fileId}:`)) {
                     directChunkGets++;
+                    sawChunkReplicate ||= options?.remote?.replicate === true;
+                    inflightChunkGets++;
+                    maxInflightChunkGets = Math.max(
+                        maxInflightChunkGets,
+                        inflightChunkGets
+                    );
+                    try {
+                        await delay(25);
+                        return originalGet(id as never, options as never);
+                    } finally {
+                        inflightChunkGets--;
+                    }
                 }
                 return originalGet(id as never, options as never);
             };
@@ -353,18 +364,29 @@ describe("index", () => {
                 },
             });
 
-            expect(fetchSearchCalls).to.be.greaterThan(0);
-            expect(partialFetches).to.eq(2);
-            expect(directChunkGets).to.eq(0);
+            expect(parentIdSearches).to.eq(0);
+            expect(directChunkGets).to.be.greaterThan(1);
+            expect(maxInflightChunkGets).to.be.greaterThan(1);
+            expect(maxInflightChunkGets).to.be.lessThanOrEqual(2);
+            expect(sawChunkReplicate).to.be.true;
+            expect(
+                filestoreReader.lastReadDiagnostics?.prefetchedChunkCount
+            ).to.eq(0);
+            expect(filestoreReader.lastReadDiagnostics?.chunkReadAhead).to.eq(
+                2
+            );
+            expect(
+                filestoreReader.lastReadDiagnostics?.maxInFlightChunkReads
+            ).to.be.lessThanOrEqual(2);
             expect(streamedChunks.length).to.be.greaterThan(1);
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
-        it("falls back to chunk-id lookups when observer chunk searches miss available chunks", async () => {
+        it("buffers observer downloads with bounded direct chunk reads", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
             const fileId = await filestore.add(
-                "observer download falls back to chunk-id lookups",
+                "observer buffered download uses bounded direct chunks",
                 largeFile
             );
 
@@ -378,49 +400,157 @@ describe("index", () => {
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
 
-            const originalSearch =
-                filestoreReader.files.index.search.bind(filestoreReader.files.index);
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
-            let parentIdSearchCalls = 0;
-            let directChunkGets = 0;
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
+            let parentIdSearches = 0;
+            let directChunkLookups = 0;
+            let inflightChunkGets = 0;
+            let maxInflightChunkGets = 0;
+            let sawChunkReplicate = false;
 
             (filestoreReader.files.index as any).search = async (
-                request: unknown,
+                request: { query?: unknown | unknown[] },
                 options: unknown
             ) => {
-                const results = await originalSearch(
-                    request as never,
-                    options as never
-                );
-                const chunkResults = results.filter(
-                    (result: unknown) =>
-                        result instanceof TinyFile && result.parentId === fileId
-                );
-                if (chunkResults.length === 0) {
-                    return results;
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasParentIdLookup = queries.some((query: any) => {
+                    const key = Array.isArray(query?.key)
+                        ? query.key[0]
+                        : query?.key;
+                    return key === "parentId" && query?.value === fileId;
+                });
+                if (hasParentIdLookup) {
+                    parentIdSearches++;
                 }
-
-                parentIdSearchCalls++;
-                return results.filter(
-                    (result: unknown) =>
-                        !(
-                            result instanceof TinyFile &&
-                            result.parentId === fileId &&
-                            result.index === 1
-                        )
-                );
+                return originalSearch(request as never, options as never);
             };
 
             (filestoreReader.files.index as any).get = async (
                 id: string,
-                options: unknown
+                options: { remote?: { replicate?: boolean } }
             ) => {
                 if (id.startsWith(`${fileId}:`)) {
-                    directChunkGets++;
+                    directChunkLookups++;
+                    sawChunkReplicate ||= options?.remote?.replicate === true;
+                    inflightChunkGets++;
+                    maxInflightChunkGets = Math.max(
+                        maxInflightChunkGets,
+                        inflightChunkGets
+                    );
+                    try {
+                        await delay(25);
+                        return originalGet(id as never, options as never);
+                    } finally {
+                        inflightChunkGets--;
+                    }
                 }
                 return originalGet(id as never, options as never);
             };
+
+            const bytes = await file!.getFile(filestoreReader, {
+                as: "joined",
+            });
+
+            expect(parentIdSearches).to.eq(0);
+            expect(directChunkLookups).to.be.greaterThan(1);
+            expect(maxInflightChunkGets).to.be.greaterThan(1);
+            expect(maxInflightChunkGets).to.be.lessThanOrEqual(2);
+            expect(sawChunkReplicate).to.be.true;
+            expect(
+                filestoreReader.lastReadDiagnostics?.prefetchedChunkCount
+            ).to.eq(0);
+            expect(filestoreReader.lastReadDiagnostics?.chunkReadAhead).to.eq(
+                2
+            );
+            expect(
+                filestoreReader.lastReadDiagnostics?.maxInFlightChunkReads
+            ).to.be.lessThanOrEqual(2);
+            expect(equals(bytes, largeFile)).to.be.true;
+        });
+
+        it("prepares observer downloads with temporary chunk replication", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileId = await filestore.add(
+                "observer download is prepared through replication",
+                largeFile
+            );
+
+            const filestoreReader = await peer2.open<Files>(filestore.address, {
+                args: { replicate: false },
+            });
+            await filestoreReader.files.log.waitForReplicator(
+                peer.identity.publicKey
+            );
+
+            const file = await filestoreReader.files.index.get(fileId);
+            expect(file).to.be.instanceOf(LargeFile);
+            const release = await filestoreReader.prepareLargeFileDownload(
+                file as LargeFile,
+                { timeout: 30_000 }
+            );
+
+            try {
+                expect(
+                    await filestoreReader.countLocalChunks(file as LargeFile)
+                ).to.eq((file as LargeFile).chunkCount);
+                expect(
+                    filestoreReader.lastDownloadPreparationDiagnostics
+                        ?.lastLocalChunkCount
+                ).to.eq((file as LargeFile).chunkCount);
+
+                const bytes = await file!.getFile(filestoreReader, {
+                    as: "joined",
+                });
+                expect(equals(bytes, largeFile)).to.be.true;
+            } finally {
+                await release();
+            }
+
+            expect(
+                filestoreReader.lastDownloadPreparationDiagnostics
+                    ?.cleanupFinishedAt
+            ).to.be.a("number");
+        });
+
+        it("waits for replicated chunks before local streaming", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileId = await filestore.add(
+                "replicator download waits for local chunks",
+                largeFile
+            );
+
+            const filestoreReader = await peer2.open<Files>(filestore.address, {
+                args: { replicate: { factor: 1 } },
+            });
+            await filestoreReader.files.log.waitForReplicator(
+                peer.identity.publicKey
+            );
+
+            const file = await filestoreReader.files.index.get(fileId);
+            expect(file).to.be.instanceOf(LargeFile);
+
+            await filestoreReader.waitForLocalChunks(file as LargeFile, {
+                timeout: 60_000,
+            });
+
+            expect(
+                await filestoreReader.countLocalChunks(file as LargeFile)
+            ).to.eq((file as LargeFile).chunkCount);
+            expect(
+                filestoreReader.lastDownloadPreparationDiagnostics?.mode
+            ).to.eq("local-chunks");
+            expect(
+                filestoreReader.lastDownloadPreparationDiagnostics
+                    ?.lastLocalChunkCount
+            ).to.eq((file as LargeFile).chunkCount);
 
             const streamedChunks: Uint8Array[] = [];
             await file!.writeFile(filestoreReader, {
@@ -428,10 +558,6 @@ describe("index", () => {
                     streamedChunks.push(chunk);
                 },
             });
-
-            expect(parentIdSearchCalls).to.be.greaterThan(0);
-            expect(directChunkGets).to.be.greaterThan(0);
-            expect(streamedChunks.length).to.be.greaterThan(1);
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
@@ -453,40 +579,14 @@ describe("index", () => {
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
 
-            const originalSearch =
-                filestoreReader.files.index.search.bind(filestoreReader.files.index);
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
             let observedChunkGets = 0;
             let sawKeepOpenWait = false;
             let sawSelfInHints = false;
+            let sawChunkReplicate = false;
             const selfHash = peer2.identity.publicKey.hashcode();
-
-            (filestoreReader.files.index as any).search = async (
-                request: unknown,
-                options: unknown
-            ) => {
-                const results = await originalSearch(
-                    request as never,
-                    options as never
-                );
-                const chunkResults = results.filter(
-                    (result: unknown) =>
-                        result instanceof TinyFile && result.parentId === fileId
-                );
-                if (chunkResults.length === 0) {
-                    return results;
-                }
-
-                return results.filter(
-                    (result: unknown) =>
-                        !(
-                            result instanceof TinyFile &&
-                            result.parentId === fileId &&
-                            result.index === 1
-                        )
-                );
-            };
 
             (filestoreReader.files.index as any).get = async (
                 id: string,
@@ -496,13 +596,18 @@ describe("index", () => {
                             timeout: number;
                             behavior: string;
                         };
+                        from?: string[];
+                        replicate?: boolean;
                     };
                 }
             ) => {
                 if (id.startsWith(`${fileId}:`)) {
                     observedChunkGets++;
-                    sawKeepOpenWait ||= options?.remote?.wait?.behavior === "keep-open";
-                    sawSelfInHints ||= options?.remote?.from?.includes(selfHash) === true;
+                    sawKeepOpenWait ||=
+                        options?.remote?.wait?.behavior === "keep-open";
+                    sawSelfInHints ||=
+                        options?.remote?.from?.includes(selfHash) === true;
+                    sawChunkReplicate ||= options?.remote?.replicate === true;
                 }
                 return originalGet(id as never, options as never);
             };
@@ -517,6 +622,7 @@ describe("index", () => {
             expect(observedChunkGets).to.be.greaterThan(0);
             expect(sawKeepOpenWait).to.be.false;
             expect(sawSelfInHints).to.be.false;
+            expect(sawChunkReplicate).to.be.true;
             expect(streamedChunks.length).to.be.greaterThan(1);
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
@@ -537,8 +643,9 @@ describe("index", () => {
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
 
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
             const transientChunkId = `${fileId}:1`;
             let abortedOnce = false;
 

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -519,48 +519,6 @@ describe("index", () => {
             ).to.be.a("number");
         });
 
-        it("waits for replicated chunks before local streaming", async () => {
-            const filestore = await peer.open(new Files());
-            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const fileId = await filestore.add(
-                "replicator download waits for local chunks",
-                largeFile
-            );
-
-            const filestoreReader = await peer2.open<Files>(filestore.address, {
-                args: { replicate: { factor: 1 } },
-            });
-            await filestoreReader.files.log.waitForReplicator(
-                peer.identity.publicKey
-            );
-
-            const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
-
-            await filestoreReader.waitForLocalChunks(file as LargeFile, {
-                timeout: 60_000,
-            });
-
-            expect(
-                await filestoreReader.countLocalChunks(file as LargeFile)
-            ).to.eq((file as LargeFile).chunkCount);
-            expect(
-                filestoreReader.lastDownloadPreparationDiagnostics?.mode
-            ).to.eq("local-chunks");
-            expect(
-                filestoreReader.lastDownloadPreparationDiagnostics
-                    ?.lastLocalChunkCount
-            ).to.eq((file as LargeFile).chunkCount);
-
-            const streamedChunks: Uint8Array[] = [];
-            await file!.writeFile(filestoreReader, {
-                write: async (chunk) => {
-                    streamedChunks.push(chunk);
-                },
-            });
-            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
-        });
-
         it("avoids keep-open remote waits for observer chunk downloads", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
@@ -627,11 +585,11 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
-        it("retries transient chunk lookup aborts", async () => {
+        it("retries transient chunk lookup failures", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
             const fileId = await filestore.add(
-                "streamed download with transient abort",
+                "streamed download with transient lookup failures",
                 largeFile
             );
 
@@ -648,6 +606,8 @@ describe("index", () => {
             );
             const transientChunkId = `${fileId}:1`;
             let abortedOnce = false;
+            let failedBlockOnce = false;
+            let deliveryFailedOnce = false;
 
             (filestoreReader.files.index as any).get = async (
                 id: string,
@@ -658,6 +618,20 @@ describe("index", () => {
                     const error = new Error("fanout channel closed");
                     error.name = "AbortError";
                     throw error;
+                }
+                if (id === transientChunkId && !failedBlockOnce) {
+                    failedBlockOnce = true;
+                    throw new Error(
+                        "Failed to resolve block: transient-test-block"
+                    );
+                }
+                if (id === transientChunkId && !deliveryFailedOnce) {
+                    deliveryFailedOnce = true;
+                    throw {
+                        name: "DeliveryError",
+                        message:
+                            "Failed to get message test delivery acknowledges from all nodes (0/1)",
+                    };
                 }
                 return originalGet(id as never, options as never);
             };
@@ -671,6 +645,8 @@ describe("index", () => {
             });
 
             expect(abortedOnce).to.be.true;
+            expect(failedBlockOnce).to.be.true;
+            expect(deliveryFailedOnce).to.be.true;
             expect(streamedChunks.length).to.be.greaterThan(1);
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -3,6 +3,7 @@ import { Program, ProgramHandler } from "@peerbit/program";
 import {
     Documents,
     SearchRequest,
+    SearchRequestIndexed,
     StringMatch,
     StringMatchMethod,
     IsNull,
@@ -20,8 +21,7 @@ import { TrustedNetwork } from "@peerbit/trusted-network";
 import { ReplicationOptions, SharedLog } from "@peerbit/shared-log";
 import { SHA256 } from "@stablelib/sha256";
 
-const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 type RuntimeOpenProfileSample = {
     label: string;
@@ -112,7 +112,10 @@ const describeOpenTarget = (target: unknown) => {
     if (typeof target === "string") {
         return "address";
     }
-    return (target as { constructor?: { name?: string } })?.constructor?.name ?? "unknown";
+    return (
+        (target as { constructor?: { name?: string } })?.constructor?.name ??
+        "unknown"
+    );
 };
 
 const installRuntimeOpenProfiler = () => {
@@ -251,7 +254,8 @@ const MAX_LARGE_FILE_SEGMENT_SIZE = TINY_FILE_SIZE_LIMIT - 256 * 1024;
 const LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS = 5 * 60 * 1000;
 const LARGE_FILE_PERSISTED_READ_AHEAD = 16;
 const LARGE_FILE_OBSERVER_READ_AHEAD = 2;
-const LARGE_FILE_OBSERVER_PREFETCH_TIMEOUT_MS = 5_000;
+const LARGE_FILE_PREPARE_JOIN_BATCH_SIZE = 8;
+const LARGE_FILE_PREPARE_JOIN_TIMEOUT_MS = 15_000;
 const TINY_FILE_SIZE_LIMIT_BIGINT = BigInt(TINY_FILE_SIZE_LIMIT);
 
 const roundUpTo = (value: number, multiple: number) =>
@@ -431,7 +435,10 @@ export class LargeFile extends AbstractFile {
             recordChunks(
                 await files.files.index.search(
                     new SearchRequest({
-                        query: new StringMatch({ key: "parentId", value: this.id }),
+                        query: new StringMatch({
+                            key: "parentId",
+                            value: this.id,
+                        }),
                         fetch: 0xffffffff,
                     }),
                     {
@@ -454,10 +461,14 @@ export class LargeFile extends AbstractFile {
             }
         }
 
-        return [...chunks.values()].sort((a, b) => (a.index || 0) - (b.index || 0));
+        return [...chunks.values()].sort(
+            (a, b) => (a.index || 0) - (b.index || 0)
+        );
     }
     async delete(files: Files) {
-        await Promise.all((await this.fetchChunks(files)).map((x) => files.files.del(x.id)));
+        await Promise.all(
+            (await this.fetchChunks(files)).map((x) => files.files.del(x.id))
+        );
     }
 
     private async resolveChunk(
@@ -467,6 +478,7 @@ export class LargeFile extends AbstractFile {
         properties?: {
             timeout?: number;
             debug?: Record<string, any>;
+            replicate?: boolean;
         }
     ): Promise<TinyFile> {
         const totalTimeout =
@@ -487,7 +499,8 @@ export class LargeFile extends AbstractFile {
             }
             const remoteFrom = await files.getReadPeerHints();
             if (properties?.debug) {
-                (properties.debug.chunkHints ||= {})[index] = remoteFrom ?? null;
+                (properties.debug.chunkHints ||= {})[index] =
+                    remoteFrom ?? null;
             }
 
             try {
@@ -504,7 +517,8 @@ export class LargeFile extends AbstractFile {
                         // instead.
                         throwOnMissing: false,
                         retryMissingResponses: true,
-                        replicate: files.persistChunkReads,
+                        replicate:
+                            properties?.replicate ?? files.persistChunkReads,
                         from: remoteFrom,
                     },
                 });
@@ -584,8 +598,9 @@ export class LargeFile extends AbstractFile {
                 } as any
             );
             const latest =
-                matches.find((match) => match instanceof LargeFile && match.ready) ??
-                matches.find((match) => match instanceof LargeFile);
+                matches.find(
+                    (match) => match instanceof LargeFile && match.ready
+                ) ?? matches.find((match) => match instanceof LargeFile);
             if (debug) {
                 debug.lastReadyProbe = {
                     at: Date.now(),
@@ -621,17 +636,17 @@ export class LargeFile extends AbstractFile {
             waitUntilReadyResolvedAt: null as number | null,
             waitUntilReadyResolvedReady: null as boolean | null,
             prefetchedChunkCount: 0,
+            chunkReadAhead: 0,
+            maxInFlightChunkReads: 0,
             finishedAt: null as number | null,
             chunkAttempts: {} as Record<number, number>,
             chunkHints: {} as Record<number, string[] | null>,
             chunkResolved: {} as Record<number, string>,
-            chunkFailure: null as
-                | {
-                      index: number;
-                      type: string;
-                      message: string;
-                  }
-                | null,
+            chunkFailure: null as {
+                index: number;
+                type: string;
+                message: string;
+            } | null,
         };
         files.lastReadDiagnostics = debug;
         const resolvedFile = await this.waitUntilReady(files, properties);
@@ -643,50 +658,12 @@ export class LargeFile extends AbstractFile {
         let processed = 0;
         const hasher = resolvedFile.finalHash ? new SHA256() : undefined;
         const knownChunks = new Map<number, TinyFile>();
-        if (!files.persistChunkReads) {
-            for (const chunk of await resolvedFile.fetchChunks(files, {
-                timeout: Math.min(
-                    properties?.timeout ?? LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS,
-                    LARGE_FILE_OBSERVER_PREFETCH_TIMEOUT_MS
-                ),
-            })) {
-                knownChunks.set(chunk.index || 0, chunk);
-            }
-            debug.prefetchedChunkCount = knownChunks.size;
-        }
-        const inFlightChunks = new Map<number, Promise<TinyFile>>();
-        const resolveChunkWithReadAhead = (index: number) => {
-            const cached = inFlightChunks.get(index);
-            if (cached) {
-                return cached;
-            }
-            const pending = this.resolveChunk(files, index, knownChunks, {
-                timeout: properties?.timeout,
-                debug,
-            });
-            inFlightChunks.set(index, pending);
-            return pending;
-        };
 
         const readAhead = files.persistChunkReads
             ? LARGE_FILE_PERSISTED_READ_AHEAD
             : LARGE_FILE_OBSERVER_READ_AHEAD;
-
-        for (
-            let index = 0;
-            index < Math.min(resolvedFile.chunkCount, readAhead);
-            index++
-        ) {
-            void resolveChunkWithReadAhead(index);
-        }
-
-        for (let index = 0; index < resolvedFile.chunkCount; index++) {
-            const nextIndex = index + readAhead;
-            if (nextIndex < resolvedFile.chunkCount) {
-                void resolveChunkWithReadAhead(nextIndex);
-            }
-            const chunkFile = await resolveChunkWithReadAhead(index);
-            inFlightChunks.delete(index);
+        debug.chunkReadAhead = readAhead;
+        const readChunkBytes = async (index: number, chunkFile: TinyFile) => {
             if (!chunkFile) {
                 throw new Error(
                     `Failed to resolve chunk ${index + 1}/${resolvedFile.chunkCount} for file ${resolvedFile.id}`
@@ -701,13 +678,56 @@ export class LargeFile extends AbstractFile {
             properties?.progress?.(
                 processed / Math.max(Number(resolvedFile.size), 1)
             );
-            yield chunk;
+            return chunk;
+        };
+
+        const inFlightChunks = new Map<number, Promise<TinyFile>>();
+        const resolveChunkWithReadAhead = (index: number) => {
+            const cached = inFlightChunks.get(index);
+            if (cached) {
+                return cached;
+            }
+            const pending = this.resolveChunk(files, index, knownChunks, {
+                timeout: properties?.timeout,
+                debug,
+                // Observers should not background-replicate every chunk just
+                // because they listed a file, but an explicit download should
+                // persist the chunks it reads. Chunk IDs are deterministic from
+                // the ready manifest, so direct gets avoid fragile distributed
+                // range queries for bulk payloads.
+                replicate: true,
+            });
+            inFlightChunks.set(index, pending);
+            return pending;
+        };
+
+        for (
+            let index = 0;
+            index < Math.min(resolvedFile.chunkCount, readAhead);
+            index++
+        ) {
+            void resolveChunkWithReadAhead(index);
+            debug.maxInFlightChunkReads = Math.max(
+                debug.maxInFlightChunkReads,
+                inFlightChunks.size
+            );
         }
 
-        if (
-            hasher &&
-            toBase64(hasher.digest()) !== resolvedFile.finalHash
-        ) {
+        for (let index = 0; index < resolvedFile.chunkCount; index++) {
+            const chunkFile = await resolveChunkWithReadAhead(index);
+            inFlightChunks.delete(index);
+            const nextIndex = index + readAhead;
+            if (nextIndex < resolvedFile.chunkCount) {
+                void resolveChunkWithReadAhead(nextIndex);
+                debug.maxInFlightChunkReads = Math.max(
+                    debug.maxInFlightChunkReads,
+                    inFlightChunks.size
+                );
+            }
+            yield await readChunkBytes(index, chunkFile);
+        }
+
+        if (hasher && toBase64(hasher.digest()) !== resolvedFile.finalHash) {
             throw new Error("File hash does not match the expected content");
         }
         debug.finishedAt = Date.now();
@@ -769,6 +789,7 @@ export class Files extends Program<Args> {
     persistChunkReads: boolean;
     openDiagnostics?: OpenDiagnostics;
     lastReadDiagnostics?: Record<string, any>;
+    lastDownloadPreparationDiagnostics?: Record<string, any>;
     lastUploadDiagnostics?: UploadDiagnostics;
 
     constructor(
@@ -1133,6 +1154,205 @@ export class Files extends Program<Args> {
         return count;
     }
 
+    async waitForLocalChunks(
+        file: LargeFile,
+        properties?: {
+            timeout?: number;
+            progress?: (progress: number) => void;
+        }
+    ): Promise<void> {
+        const totalTimeout =
+            properties?.timeout ?? LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS;
+        const deadline = Date.now() + totalTimeout;
+        const debug = {
+            fileId: file.id,
+            fileName: file.name,
+            mode: "local-chunks",
+            chunkCount: file.chunkCount,
+            startedAt: Date.now(),
+            lastLocalChunkCount: 0,
+            finishedAt: null as number | null,
+            failureAt: null as number | null,
+            failureMessage: null as string | null,
+        };
+        this.lastDownloadPreparationDiagnostics = debug;
+
+        try {
+            while (Date.now() < deadline) {
+                const localChunkCount = await this.countLocalChunks(file);
+                debug.lastLocalChunkCount = localChunkCount;
+                properties?.progress?.(
+                    Math.min(localChunkCount / Math.max(file.chunkCount, 1), 1)
+                );
+                if (localChunkCount >= file.chunkCount) {
+                    debug.finishedAt = Date.now();
+                    return;
+                }
+                await sleep(250);
+            }
+
+            throw new Error(
+                `Timed out waiting for ${file.name} chunks (${debug.lastLocalChunkCount}/${file.chunkCount} chunks available locally)`
+            );
+        } catch (error) {
+            debug.failureAt = Date.now();
+            debug.failureMessage =
+                error instanceof Error ? error.message : String(error);
+            throw error;
+        }
+    }
+
+    async prepareLargeFileDownload(
+        file: LargeFile,
+        properties?: {
+            timeout?: number;
+            progress?: (progress: number) => void;
+        }
+    ): Promise<() => Promise<void>> {
+        const totalTimeout =
+            properties?.timeout ?? LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS;
+        const deadline = Date.now() + totalTimeout;
+        const debug = {
+            fileId: file.id,
+            fileName: file.name,
+            chunkCount: file.chunkCount,
+            startedAt: Date.now(),
+            chunkHeadCount: 0,
+            chunkJoinAttempts: 0,
+            chunkJoinBatchSize: LARGE_FILE_PREPARE_JOIN_BATCH_SIZE,
+            lastJoinBatchStart: null as number | null,
+            lastJoinBatchSize: 0,
+            lastLocalChunkCount: 0,
+            finishedAt: null as number | null,
+            cleanupStartedAt: null as number | null,
+            cleanupFinishedAt: null as number | null,
+            failureAt: null as number | null,
+            failureMessage: null as string | null,
+            lastJoinError: null as string | null,
+        };
+        this.lastDownloadPreparationDiagnostics = debug;
+
+        const release = async () => {
+            debug.cleanupStartedAt = Date.now();
+            debug.cleanupFinishedAt = Date.now();
+        };
+
+        try {
+            const initialCount = await this.countLocalChunks(file);
+            debug.lastLocalChunkCount = initialCount;
+            if (initialCount >= file.chunkCount) {
+                properties?.progress?.(1);
+                debug.finishedAt = Date.now();
+                return async () => {};
+            }
+
+            const chunkHeads = new Map<string, string>();
+
+            while (Date.now() < deadline) {
+                const localChunkCount = await this.countLocalChunks(file);
+                debug.lastLocalChunkCount = localChunkCount;
+                properties?.progress?.(
+                    Math.min(localChunkCount / Math.max(file.chunkCount, 1), 1)
+                );
+                if (localChunkCount >= file.chunkCount) {
+                    debug.finishedAt = Date.now();
+                    return release;
+                }
+
+                const remoteFrom = await this.getReadPeerHints();
+                const indexedChunks = await this.files.index.search(
+                    new SearchRequestIndexed({
+                        query: new StringMatch({
+                            key: "parentId",
+                            value: file.id,
+                            caseInsensitive: false,
+                            method: StringMatchMethod.exact,
+                        }),
+                        fetch: file.chunkCount,
+                    }),
+                    {
+                        local: true,
+                        resolve: false,
+                        remote: {
+                            timeout: Math.min(
+                                Math.max(deadline - Date.now(), 1),
+                                30_000
+                            ),
+                            throwOnMissing: false,
+                            retryMissingResponses: true,
+                            from: remoteFrom,
+                        },
+                    } as any
+                );
+                for (const chunk of indexedChunks as any[]) {
+                    if (
+                        chunk?.parentId !== file.id ||
+                        chunk?.__context?.head == null
+                    ) {
+                        continue;
+                    }
+                    chunkHeads.set(chunk.id, chunk.__context.head);
+                }
+                debug.chunkHeadCount = chunkHeads.size;
+
+                if (chunkHeads.size > 0) {
+                    const heads = [...chunkHeads.values()];
+                    for (
+                        let i = 0;
+                        i < heads.length && Date.now() < deadline;
+                        i += LARGE_FILE_PREPARE_JOIN_BATCH_SIZE
+                    ) {
+                        const batch = heads.slice(
+                            i,
+                            i + LARGE_FILE_PREPARE_JOIN_BATCH_SIZE
+                        );
+                        debug.chunkJoinAttempts += 1;
+                        debug.lastJoinBatchStart = i;
+                        debug.lastJoinBatchSize = batch.length;
+                        try {
+                            await this.files.log.join(batch, {
+                                timeout: Math.min(
+                                    Math.max(deadline - Date.now(), 1),
+                                    LARGE_FILE_PREPARE_JOIN_TIMEOUT_MS
+                                ),
+                            });
+                            debug.lastJoinError = null;
+                        } catch (error) {
+                            debug.lastJoinError =
+                                error instanceof Error
+                                    ? error.message
+                                    : String(error);
+                        }
+
+                        const localChunkCount =
+                            await this.countLocalChunks(file);
+                        debug.lastLocalChunkCount = localChunkCount;
+                        properties?.progress?.(
+                            Math.min(
+                                localChunkCount / Math.max(file.chunkCount, 1),
+                                1
+                            )
+                        );
+                        if (localChunkCount >= file.chunkCount) {
+                            debug.finishedAt = Date.now();
+                            return release;
+                        }
+                    }
+                }
+                await sleep(250);
+            }
+
+            throw new Error(
+                `Timed out preparing ${file.name} for download (${debug.lastLocalChunkCount}/${file.chunkCount} chunks available locally)`
+            );
+        } catch (error) {
+            debug.failureAt = Date.now();
+            debug.failureMessage =
+                error instanceof Error ? error.message : String(error);
+            throw error;
+        }
+    }
+
     async resolveById(
         id: string,
         properties?: {
@@ -1147,12 +1367,13 @@ export class Files extends Program<Args> {
             waitFor: properties?.timeout,
             remote: {
                 timeout: properties?.timeout ?? 10 * 1000,
-                wait: properties?.timeout && properties.wait !== false
-                    ? {
-                          timeout: properties.timeout,
-                          behavior: "keep-open",
-                      }
-                    : undefined,
+                wait:
+                    properties?.timeout && properties.wait !== false
+                        ? {
+                              timeout: properties.timeout,
+                              behavior: "keep-open",
+                          }
+                        : undefined,
                 throwOnMissing: false,
                 retryMissingResponses: true,
                 replicate: properties?.replicate,
@@ -1195,7 +1416,9 @@ export class Files extends Program<Args> {
     }
 
     async getReadPeerHints(): Promise<string[] | undefined> {
-        const replicators = await this.files.log.getReplicators().catch(() => undefined);
+        const replicators = await this.files.log
+            .getReplicators()
+            .catch(() => undefined);
         if (!replicators || replicators.size === 0) {
             return undefined;
         }
@@ -1320,6 +1543,7 @@ export class Files extends Program<Args> {
             type: AbstractFile,
             // TODO add ACL
             replicate: args?.replicate,
+            keep: "self",
             replicas: { min: 3 },
             canPerform: async (operation) => {
                 if (!this.trustGraph) {
@@ -1343,8 +1567,9 @@ export class Files extends Program<Args> {
 
         await Promise.all([trustGraphOpenPromise, filesOpenPromise]);
         openDiagnostics.finishedAt = Date.now();
-        openDiagnostics.runtimeProfileSamples = getRuntimeOpenProfilerState().samples.slice(
-            runtimeProfileStartIndex
-        );
+        openDiagnostics.runtimeProfileSamples =
+            getRuntimeOpenProfilerState().samples.slice(
+                runtimeProfileStartIndex
+            );
     }
 }

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -150,10 +150,44 @@ const installRuntimeOpenProfiler = () => {
 
 installRuntimeOpenProfiler();
 
-const isRetryableChunkLookupError = (error: unknown) =>
-    error instanceof Error &&
-    (error.name === "AbortError" ||
-        error.message.includes("fanout channel closed"));
+const getErrorName = (error: unknown) =>
+    typeof (error as { name?: unknown })?.name === "string"
+        ? ((error as { name: string }).name as string)
+        : undefined;
+
+const getErrorMessage = (error: unknown) =>
+    error instanceof Error
+        ? error.message
+        : typeof error === "string"
+          ? error
+          : typeof (error as { message?: unknown })?.message === "string"
+            ? ((error as { message: string }).message as string)
+            : String(error);
+
+const isRetryableChunkLookupError = (error: unknown) => {
+    const name = getErrorName(error);
+    const message = getErrorMessage(error);
+    return (
+        name === "AbortError" ||
+        name === "DeliveryError" ||
+        name === "StreamStateError" ||
+        message.includes("fanout channel closed") ||
+        message.includes("Failed to resolve block") ||
+        message.includes("Failed to load entry from head") ||
+        message.includes("Message did not have any valid receivers") ||
+        message.includes("delivery acknowledges from all nodes")
+    );
+};
+
+const shouldRetryChunkLookupWithoutHints = (error: unknown) => {
+    const name = getErrorName(error);
+    const message = getErrorMessage(error);
+    return (
+        name === "DeliveryError" ||
+        message.includes("delivery acknowledges from all nodes") ||
+        message.includes("Message did not have any valid receivers")
+    );
+};
 
 type FileReadOptions = {
     timeout?: number;
@@ -486,6 +520,7 @@ export class LargeFile extends AbstractFile {
         const deadline = Date.now() + totalTimeout;
         const attemptTimeout = Math.min(totalTimeout, 5_000);
         const chunkId = getChunkId(this.id, index);
+        let hintedDeliveryFailures = 0;
 
         while (Date.now() < deadline) {
             properties?.debug &&
@@ -497,7 +532,10 @@ export class LargeFile extends AbstractFile {
                     ((properties.debug.chunkResolved ||= {})[index] = "cached");
                 return cached;
             }
-            const remoteFrom = await files.getReadPeerHints();
+            const remoteFrom =
+                hintedDeliveryFailures >= 3
+                    ? undefined
+                    : await files.getReadPeerHints();
             if (properties?.debug) {
                 (properties.debug.chunkHints ||= {})[index] =
                     remoteFrom ?? null;
@@ -546,6 +584,9 @@ export class LargeFile extends AbstractFile {
                                     : String(error),
                         });
                     throw error;
+                }
+                if (remoteFrom && shouldRetryChunkLookupWithoutHints(error)) {
+                    hintedDeliveryFailures += 1;
                 }
             }
 
@@ -706,7 +747,7 @@ export class LargeFile extends AbstractFile {
             index < Math.min(resolvedFile.chunkCount, readAhead);
             index++
         ) {
-            void resolveChunkWithReadAhead(index);
+            void resolveChunkWithReadAhead(index).catch(() => undefined);
             debug.maxInFlightChunkReads = Math.max(
                 debug.maxInFlightChunkReads,
                 inFlightChunks.size
@@ -718,7 +759,9 @@ export class LargeFile extends AbstractFile {
             inFlightChunks.delete(index);
             const nextIndex = index + readAhead;
             if (nextIndex < resolvedFile.chunkCount) {
-                void resolveChunkWithReadAhead(nextIndex);
+                void resolveChunkWithReadAhead(nextIndex).catch(
+                    () => undefined
+                );
                 debug.maxInFlightChunkReads = Math.max(
                     debug.maxInFlightChunkReads,
                     inFlightChunks.size
@@ -1152,54 +1195,6 @@ export class Files extends Program<Args> {
             })
         );
         return count;
-    }
-
-    async waitForLocalChunks(
-        file: LargeFile,
-        properties?: {
-            timeout?: number;
-            progress?: (progress: number) => void;
-        }
-    ): Promise<void> {
-        const totalTimeout =
-            properties?.timeout ?? LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS;
-        const deadline = Date.now() + totalTimeout;
-        const debug = {
-            fileId: file.id,
-            fileName: file.name,
-            mode: "local-chunks",
-            chunkCount: file.chunkCount,
-            startedAt: Date.now(),
-            lastLocalChunkCount: 0,
-            finishedAt: null as number | null,
-            failureAt: null as number | null,
-            failureMessage: null as string | null,
-        };
-        this.lastDownloadPreparationDiagnostics = debug;
-
-        try {
-            while (Date.now() < deadline) {
-                const localChunkCount = await this.countLocalChunks(file);
-                debug.lastLocalChunkCount = localChunkCount;
-                properties?.progress?.(
-                    Math.min(localChunkCount / Math.max(file.chunkCount, 1), 1)
-                );
-                if (localChunkCount >= file.chunkCount) {
-                    debug.finishedAt = Date.now();
-                    return;
-                }
-                await sleep(250);
-            }
-
-            throw new Error(
-                `Timed out waiting for ${file.name} chunks (${debug.lastLocalChunkCount}/${file.chunkCount} chunks available locally)`
-            );
-        } catch (error) {
-            debug.failureAt = Date.now();
-            debug.failureMessage =
-                error instanceof Error ? error.message : String(error);
-            throw error;
-        }
     }
 
     async prepareLargeFileDownload(

--- a/patches/@peerbit+log+6.0.22.patch
+++ b/patches/@peerbit+log+6.0.22.patch
@@ -1,0 +1,149 @@
+diff --git a/node_modules/@peerbit/log/src/log.ts b/node_modules/@peerbit/log/src/log.ts
+--- a/node_modules/@peerbit/log/src/log.ts
++++ b/node_modules/@peerbit/log/src/log.ts
+@@ -42,6 +42,10 @@ const isRecoverableJoinResolveError = (error: unknown): boolean => {
+ 		error instanceof Error ? error.message : typeof error === "string" ? error : "";
+ 	return (
+ 		message.includes("Failed to resolve block") ||
++		message.includes("Failed to load entry from head") ||
++		message.includes("Message did not have any valid receivers") ||
++		(error instanceof Error && error.name === "DeliveryError") ||
++		(error instanceof Error && error.name === "StreamStateError") ||
+ 		(error instanceof Error && error.name === "AbortError")
+ 	);
+ };
+@@ -728,13 +732,21 @@ export class Log<T> {
+ 					}
+ 
+ 					const from = await resolveRemoteFrom(element, this._closeController.signal);
+-					const entry = await Entry.fromMultihash<T>(this._storage, element, {
+-						remote: {
+-							timeout: remote.timeout,
+-							signal: remote.signal,
+-							...(from && from.length > 0 ? { from } : {}),
+-						},
+-					});
++					let entry: Entry<T>;
++					try {
++						entry = await Entry.fromMultihash<T>(this._storage, element, {
++							remote: {
++								timeout: remote.timeout,
++								signal: remote.signal,
++								...(from && from.length > 0 ? { from } : {}),
++							},
++						});
++					} catch (error) {
++						if (isRecoverableJoinResolveError(error)) {
++							continue;
++						}
++						throw error;
++					}
+ 					entries.push(entry);
+ 					references.set(entry.hash, entry);
+ 					continue;
+@@ -749,13 +761,25 @@ export class Log<T> {
+ 						element.hash,
+ 						this._closeController.signal,
+ 					);
+-					const entry = await Entry.fromMultihash<T>(this._storage, element.hash, {
+-						remote: {
+-							timeout: remote.timeout,
+-							signal: remote.signal,
+-							...(from && from.length > 0 ? { from } : {}),
+-						},
+-					});
++					let entry: Entry<T>;
++					try {
++						entry = await Entry.fromMultihash<T>(
++							this._storage,
++							element.hash,
++							{
++								remote: {
++									timeout: remote.timeout,
++									signal: remote.signal,
++									...(from && from.length > 0 ? { from } : {}),
++								},
++							},
++						);
++					} catch (error) {
++						if (isRecoverableJoinResolveError(error)) {
++							continue;
++						}
++						throw error;
++					}
+ 					entries.push(entry);
+ 					references.set(entry.hash, entry);
+ 					continue;
+diff --git a/node_modules/@peerbit/log/dist/src/log.js b/node_modules/@peerbit/log/dist/src/log.js
+--- a/node_modules/@peerbit/log/dist/src/log.js
++++ b/node_modules/@peerbit/log/dist/src/log.js
+@@ -55,5 +55,9 @@ const isRecoverableJoinResolveError = (error) => {
+     const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+     return (message.includes("Failed to resolve block") ||
++        message.includes("Failed to load entry from head") ||
++        message.includes("Message did not have any valid receivers") ||
++        (error instanceof Error && error.name === "DeliveryError") ||
++        (error instanceof Error && error.name === "StreamStateError") ||
+         (error instanceof Error && error.name === "AbortError"));
+ };
+ let sqliteCreate;
+@@ -555,13 +559,22 @@ let Log = (() => {
+                             continue; // already in log
+                         }
+                         const from = await resolveRemoteFrom(element, this._closeController.signal);
+-                        const entry = await Entry.fromMultihash(this._storage, element, {
+-                            remote: {
+-                                timeout: remote.timeout,
+-                                signal: remote.signal,
+-                                ...(from && from.length > 0 ? { from } : {}),
+-                            },
+-                        });
++                        let entry;
++                        try {
++                            entry = await Entry.fromMultihash(this._storage, element, {
++                                remote: {
++                                    timeout: remote.timeout,
++                                    signal: remote.signal,
++                                    ...(from && from.length > 0 ? { from } : {}),
++                                },
++                            });
++                        }
++                        catch (error) {
++                            if (isRecoverableJoinResolveError(error)) {
++                                continue;
++                            }
++                            throw error;
++                        }
+                         entries.push(entry);
+                         references.set(entry.hash, entry);
+                         continue;
+@@ -571,13 +584,22 @@ let Log = (() => {
+                             continue; // already in log
+                         }
+                         const from = await resolveRemoteFrom(element.hash, this._closeController.signal);
+-                        const entry = await Entry.fromMultihash(this._storage, element.hash, {
+-                            remote: {
+-                                timeout: remote.timeout,
+-                                signal: remote.signal,
+-                                ...(from && from.length > 0 ? { from } : {}),
+-                            },
+-                        });
++                        let entry;
++                        try {
++                            entry = await Entry.fromMultihash(this._storage, element.hash, {
++                                remote: {
++                                    timeout: remote.timeout,
++                                    signal: remote.signal,
++                                    ...(from && from.length > 0 ? { from } : {}),
++                                },
++                            });
++                        }
++                        catch (error) {
++                            if (isRecoverableJoinResolveError(error)) {
++                                continue;
++                            }
++                            throw error;
++                        }
+                         entries.push(entry);
+                         references.set(entry.hash, entry);
+                         continue;

--- a/patches/@peerbit+shared-log+13.1.1.patch
+++ b/patches/@peerbit+shared-log+13.1.1.patch
@@ -1,0 +1,47 @@
+diff --git a/node_modules/@peerbit/shared-log/src/pid.ts b/node_modules/@peerbit/shared-log/src/pid.ts
+index 6d0b3cb..4b26ef4 100644
+--- a/node_modules/@peerbit/shared-log/src/pid.ts
++++ b/node_modules/@peerbit/shared-log/src/pid.ts
+@@ -157,7 +157,18 @@ export class PIDReplicationController {
+ 
+ 		// Calculate the new replication factor
+ 		const change = pTerm + iTerm + dTerm;
+-		const newFactor = currentFactor + change;
++		let newFactor = currentFactor + change;
++
++		if (this.maxCPUUsage != null && this.maxMemoryLimit == null) {
++			// CPU pressure can shed surplus, but it must not create coverage gaps.
++			const coverageSurplus = Math.max(0, totalFactor - 1);
++			if (newFactor < currentFactor) {
++				newFactor =
++					coverageSurplus <= 0
++						? currentFactor
++						: Math.max(newFactor, currentFactor - coverageSurplus);
++			}
++		}
+ 
+ 		// Update state for the next iteration
+ 		this.prevError = totalError;
+diff --git a/node_modules/@peerbit/shared-log/dist/src/pid.js b/node_modules/@peerbit/shared-log/dist/src/pid.js
+index 7f31176..ab3f89e 100644
+--- a/node_modules/@peerbit/shared-log/dist/src/pid.js
++++ b/node_modules/@peerbit/shared-log/dist/src/pid.js
+@@ -113,7 +113,17 @@ export class PIDReplicationController {
+         const dTerm = this.kd * derivative;
+         // Calculate the new replication factor
+         const change = pTerm + iTerm + dTerm;
+-        const newFactor = currentFactor + change;
++        let newFactor = currentFactor + change;
++        if (this.maxCPUUsage != null && this.maxMemoryLimit == null) {
++            // CPU pressure can shed surplus, but it must not create coverage gaps.
++            const coverageSurplus = Math.max(0, totalFactor - 1);
++            if (newFactor < currentFactor) {
++                newFactor =
++                    coverageSurplus <= 0
++                        ? currentFactor
++                        : Math.max(newFactor, currentFactor - coverageSurplus);
++            }
++        }
+         // Update state for the next iteration
+         this.prevError = totalError;
+         // reset integral term if we are "way" out of bounds


### PR DESCRIPTION
## Summary
- default file-share replication to full `{ factor: 1 }` instead of CPU-limited partial replication
- stream large-file downloads through deterministic chunk-id reads with bounded read-ahead
- wait for local replicated chunks before large-file downloads in replicator mode; keep targeted preparation for observer downloads
- update local download/benchmark tests to exercise the default replicator role while retaining observer diagnostics via `PW_READER_ROLE=observer`

## Verification
- `pnpm --filter @peerbit/please-lib run build`
- `pnpm --filter @peerbit/please-lib run test`
- `pnpm --filter file-share run build`
- `pnpm --filter file-share run test:e2e -- tests/download-streamed.local.e2e.spec.ts`
- `pnpm --filter file-share run test:e2e -- tests/download.local.e2e.spec.ts`
- `PW_BENCH=1 PW_BENCH_SCENARIO=local PW_FILE_MB=100 PW_UPLOAD_TIMEOUT_MS=900000 PW_DOWNLOAD_TIMEOUT_MS=900000 PW_RESULT_FILE=/tmp/file-share-transfer-100mb-after-local-wait.json pnpm --filter file-share run test:e2e -- tests/transfer.bench.e2e.spec.ts`
- `pnpm run build`
