### PR TITLE
Fix file-share hinted adaptive chunk reads

### DIFF
--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -245,6 +245,7 @@ describe("index", () => {
             let directChunkGets = 0;
             let inflightChunkGets = 0;
             let maxInflightChunkGets = 0;
+            let sawChunkWaitFor = false;
 
             (filestoreReader.files.index as any).search = async (
                 request: { query: unknown | unknown[] },
@@ -272,6 +273,8 @@ describe("index", () => {
                 options: unknown
             ) => {
                 if (id.startsWith(`${fileId}:`)) {
+                    sawChunkWaitFor ||=
+                        (options as { waitFor?: number })?.waitFor != null;
                     directChunkGets++;
                     inflightChunkGets++;
                     maxInflightChunkGets = Math.max(
@@ -299,7 +302,8 @@ describe("index", () => {
             expect(readAhead).to.eq(4);
             expect(
                 filestoreReader.lastReadDiagnostics?.chunkAttemptTimeoutMs
-            ).to.be.greaterThan(5_000);
+            ).to.eq(5_000);
+            expect(sawChunkWaitFor).to.be.false;
             expect(maxInflightChunkGets).to.be.lessThanOrEqual(readAhead);
             expect(
                 Object.keys(

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -295,7 +295,21 @@ describe("index", () => {
             expect(parentIdSearches).to.eq(0);
             expect(directChunkGets).to.be.greaterThan(1);
             expect(maxInflightChunkGets).to.be.greaterThan(1);
-            expect(maxInflightChunkGets).to.be.lessThanOrEqual(4);
+            const readAhead = filestoreReader.lastReadDiagnostics?.readAhead;
+            expect(readAhead).to.eq(4);
+            expect(maxInflightChunkGets).to.be.lessThanOrEqual(readAhead);
+            expect(
+                Object.keys(
+                    filestoreReader.lastReadDiagnostics?.chunkResolveStartedAt ??
+                        {}
+                ).length
+            ).to.be.greaterThan(1);
+            expect(
+                Object.keys(
+                    filestoreReader.lastReadDiagnostics?.chunkMaterializeFinishedAt ??
+                        {}
+                ).length
+            ).to.eq(streamedChunks.length);
             expect(streamedChunks.length).to.be.greaterThan(1);
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -199,7 +199,10 @@ describe("index", () => {
         it("records diagnostics for chunked uploads", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const fileId = await filestore.add("diagnostic large file", largeFile);
+            const fileId = await filestore.add(
+                "diagnostic large file",
+                largeFile
+            );
 
             expect(fileId).to.be.a("string");
             expect(filestore.lastUploadDiagnostics).to.deep.include({
@@ -207,13 +210,15 @@ describe("index", () => {
                 fileName: "diagnostic large file",
                 sizeBytes: largeFile.byteLength,
             });
-            expect(filestore.lastUploadDiagnostics?.chunkCount).to.be.greaterThan(1);
+            expect(
+                filestore.lastUploadDiagnostics?.chunkCount
+            ).to.be.greaterThan(1);
             expect(filestore.lastUploadDiagnostics?.chunkPutCount).to.eq(
                 filestore.lastUploadDiagnostics?.chunkCount
             );
-            expect(filestore.lastUploadDiagnostics?.manifestFinishedAt).to.not.eq(
-                null
-            );
+            expect(
+                filestore.lastUploadDiagnostics?.manifestFinishedAt
+            ).to.not.eq(null);
             expect(
                 filestore.lastUploadDiagnostics?.readyManifestFinishedAt
             ).to.not.eq(null);
@@ -237,15 +242,32 @@ describe("index", () => {
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
 
-            const originalSearch =
-                filestoreReader.files.index.search.bind(filestoreReader.files.index);
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
             let parentIdSearches = 0;
             let directChunkGets = 0;
             let inflightChunkGets = 0;
             let maxInflightChunkGets = 0;
             let sawChunkWaitFor = false;
+            let indexedChunkGets = 0;
+            let resolvedRemoteChunkGets = 0;
+            const indexedChunks = new Set<string>();
+            const retainedChunkId = `${fileId}:1`;
+            const retainedWriterChunk = await filestore.files.index.get(
+                retainedChunkId,
+                {
+                    local: true,
+                    remote: false,
+                }
+            );
+            const retainedWriterEntry = await filestore.files.log.log.get(
+                (retainedWriterChunk as any).__context.head
+            );
+            let retainedBeforeIndexedReplication = false;
 
             (filestoreReader.files.index as any).search = async (
                 request: { query: unknown | unknown[] },
@@ -273,8 +295,30 @@ describe("index", () => {
                 options: unknown
             ) => {
                 if (id.startsWith(`${fileId}:`)) {
+                    const getOptions = options as {
+                        resolve?: boolean;
+                        remote?: false | { replicate?: boolean };
+                    };
                     sawChunkWaitFor ||=
-                        (options as { waitFor?: number })?.waitFor != null;
+                        (getOptions as { waitFor?: number })?.waitFor != null;
+                    if (
+                        getOptions.resolve === false &&
+                        getOptions.remote &&
+                        getOptions.remote !== false
+                    ) {
+                        indexedChunkGets++;
+                        indexedChunks.add(id);
+                        if (id === retainedChunkId) {
+                            retainedBeforeIndexedReplication = await (
+                                filestoreReader.files.log as any
+                            ).keep(retainedWriterEntry);
+                        }
+                    } else if (
+                        getOptions.remote &&
+                        getOptions.remote !== false
+                    ) {
+                        resolvedRemoteChunkGets++;
+                    }
                     directChunkGets++;
                     inflightChunkGets++;
                     maxInflightChunkGets = Math.max(
@@ -283,6 +327,9 @@ describe("index", () => {
                     );
                     await delay(25);
                     inflightChunkGets--;
+                    if (getOptions.remote === false && !indexedChunks.has(id)) {
+                        return undefined;
+                    }
                 }
                 return originalGet(id as never, options as never);
             };
@@ -304,17 +351,20 @@ describe("index", () => {
                 filestoreReader.lastReadDiagnostics?.chunkAttemptTimeoutMs
             ).to.eq(5_000);
             expect(sawChunkWaitFor).to.be.false;
+            expect(indexedChunkGets).to.be.greaterThan(1);
+            expect(resolvedRemoteChunkGets).to.eq(0);
+            expect(retainedBeforeIndexedReplication).to.be.true;
             expect(maxInflightChunkGets).to.be.lessThanOrEqual(readAhead);
             expect(
                 Object.keys(
-                    filestoreReader.lastReadDiagnostics?.chunkResolveStartedAt ??
-                        {}
+                    filestoreReader.lastReadDiagnostics
+                        ?.chunkResolveStartedAt ?? {}
                 ).length
             ).to.be.greaterThan(1);
             expect(
                 Object.keys(
-                    filestoreReader.lastReadDiagnostics?.chunkMaterializeFinishedAt ??
-                        {}
+                    filestoreReader.lastReadDiagnostics
+                        ?.chunkMaterializeFinishedAt ?? {}
                 ).length
             ).to.eq(streamedChunks.length);
             expect(streamedChunks.length).to.be.greaterThan(1);
@@ -325,10 +375,7 @@ describe("index", () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
             const fileName = "streamed download with indexed chunk fallback";
-            const fileId = await filestore.add(
-                fileName,
-                largeFile
-            );
+            const fileId = await filestore.add(fileName, largeFile);
 
             const filestoreReader = await peer2.open<Files>(filestore.address);
             await filestoreReader.files.log.waitForReplicator(
@@ -338,10 +385,12 @@ describe("index", () => {
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
 
-            const originalSearch =
-                filestoreReader.files.index.search.bind(filestoreReader.files.index);
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
             const missingDirectChunkId = `${fileId}:1`;
             let directChunkMisses = 0;
             let indexedChunkSearches = 0;
@@ -410,10 +459,12 @@ describe("index", () => {
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
 
-            const originalSearch =
-                filestoreReader.files.index.search.bind(filestoreReader.files.index);
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
             const missingDirectChunkId = `${fileId}:1`;
             let directChunkMisses = 0;
             let preciseChunkSearches = 0;
@@ -499,10 +550,12 @@ describe("index", () => {
                 readPeerHintLookups++;
                 return readPeerHintLookups === 1 ? [writerHash] : undefined;
             };
-            const originalSearch =
-                filestoreReader.files.index.search.bind(filestoreReader.files.index);
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
             const missingDirectChunkId = `${fileId}:1`;
             let directChunkMisses = 0;
             let preciseChunkSearches = 0;
@@ -593,10 +646,12 @@ describe("index", () => {
             (filestoreReader as any).getReadPeerHints = async () => [
                 writerHash,
             ];
-            const originalSearch =
-                filestoreReader.files.index.search.bind(filestoreReader.files.index);
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
             const delayedChunkId = `${fileId}:1`;
             let directChunkGets = 0;
             let hintedDirectGetsAfterFallback = 0;
@@ -604,25 +659,35 @@ describe("index", () => {
             let nonReplicatingFallbacks = 0;
             let preciseChunkSearches = 0;
             let parentChunkSearches = 0;
+            const indexedChunks = new Set<string>();
 
             (filestoreReader.files.index as any).get = async (
                 id: string,
                 options: {
-                    remote?: {
-                        from?: string[];
-                        replicate?: boolean;
-                        strategy?: string;
-                    };
+                    resolve?: boolean;
+                    remote?:
+                        | {
+                              from?: string[];
+                              replicate?: boolean;
+                              strategy?: string;
+                          }
+                        | false;
                 }
             ) => {
                 if (id === delayedChunkId) {
-                    if (options?.remote?.replicate === false) {
+                    const remote = options?.remote;
+                    if (remote === false) {
+                        return indexedChunks.has(id)
+                            ? originalGet(id as never, options as never)
+                            : undefined;
+                    }
+                    if (remote?.replicate === false) {
                         nonReplicatingFallbacks++;
                         return undefined;
                     }
                     directChunkGets++;
                     if (nonReplicatingFallbacks > 0) {
-                        if (options?.remote?.from?.includes(writerHash)) {
+                        if (remote?.from?.includes(writerHash)) {
                             hintedDirectGetsAfterFallback++;
                         } else {
                             unhintedDirectGetsAfterFallback++;
@@ -631,10 +696,15 @@ describe("index", () => {
                     if (directChunkGets <= 4) {
                         return undefined;
                     }
-                    return options?.remote?.from?.includes(writerHash) &&
-                        options.remote.strategy === "always"
-                        ? originalGet(id as never, options as never)
-                        : undefined;
+                    if (
+                        options?.resolve === false &&
+                        remote?.from?.includes(writerHash) &&
+                        remote.strategy === "always"
+                    ) {
+                        indexedChunks.add(id);
+                        return originalGet(id as never, options as never);
+                    }
+                    return undefined;
                 }
                 return originalGet(id as never, options as never);
             };
@@ -709,10 +779,12 @@ describe("index", () => {
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
 
-            const originalSearch =
-                filestoreReader.files.index.search.bind(filestoreReader.files.index);
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
             const missingDirectChunkId = `${fileId}:1`;
             let directChunkMisses = 0;
             let preciseChunkSearches = 0;
@@ -795,10 +867,12 @@ describe("index", () => {
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
 
-            const originalSearch =
-                filestoreReader.files.index.search.bind(filestoreReader.files.index);
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
             let fetchSearchCalls = 0;
             let partialFetches = 0;
             let directChunkGets = 0;
@@ -877,10 +951,12 @@ describe("index", () => {
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
 
-            const originalSearch =
-                filestoreReader.files.index.search.bind(filestoreReader.files.index);
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
             let parentIdSearchCalls = 0;
             let directChunkGets = 0;
 
@@ -952,10 +1028,12 @@ describe("index", () => {
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
 
-            const originalSearch =
-                filestoreReader.files.index.search.bind(filestoreReader.files.index);
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
             let observedChunkGets = 0;
             let sawKeepOpenWait = false;
             let sawSelfInHints = false;
@@ -1000,8 +1078,10 @@ describe("index", () => {
             ) => {
                 if (id.startsWith(`${fileId}:`)) {
                     observedChunkGets++;
-                    sawKeepOpenWait ||= options?.remote?.wait?.behavior === "keep-open";
-                    sawSelfInHints ||= options?.remote?.from?.includes(selfHash) === true;
+                    sawKeepOpenWait ||=
+                        options?.remote?.wait?.behavior === "keep-open";
+                    sawSelfInHints ||=
+                        options?.remote?.from?.includes(selfHash) === true;
                 }
                 return originalGet(id as never, options as never);
             };
@@ -1023,11 +1103,9 @@ describe("index", () => {
         it("retries transient chunk lookup transport failures", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const fileName = "streamed download with transient transport failures";
-            const fileId = await filestore.add(
-                fileName,
-                largeFile
-            );
+            const fileName =
+                "streamed download with transient transport failures";
+            const fileId = await filestore.add(fileName, largeFile);
 
             const filestoreReader = await peer2.open<Files>(filestore.address);
             await filestoreReader.files.log.waitForReplicator(
@@ -1037,10 +1115,12 @@ describe("index", () => {
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
 
-            const originalSearch =
-                filestoreReader.files.index.search.bind(filestoreReader.files.index);
-            const originalGet =
-                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
             const transientChunkId = `${fileId}:1`;
             let abortedOnce = false;
             let failedBlockOnce = false;
@@ -1178,7 +1258,9 @@ describe("index", () => {
             }
 
             expect(error?.message).to.eq("stop-after-measuring");
-            expect(requestedChunkSize).to.be.greaterThanOrEqual(2 * 1024 * 1024);
+            expect(requestedChunkSize).to.be.greaterThanOrEqual(
+                2 * 1024 * 1024
+            );
         });
 
         it("exposes large file metadata before chunk upload finishes", async () => {

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -221,45 +221,6 @@ describe("index", () => {
             expect(filestore.lastUploadDiagnostics?.failureMessage).to.eq(null);
         });
 
-        it("keeps self-authored chunks readable under adaptive storage limits", async () => {
-            const adaptiveRole = {
-                limits: {
-                    cpu: { max: 1 },
-                    storage: 1_000_000,
-                },
-            };
-            const files = new Files();
-            let keepPolicy: unknown;
-            const originalOpen = files.files.open.bind(files.files);
-            (files.files as any).open = async (options: any) => {
-                keepPolicy = options.keep;
-                return originalOpen(options);
-            };
-
-            const filestore = await peer.open(files, {
-                args: { replicate: adaptiveRole },
-            });
-            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const fileId = await filestore.add(
-                "self-authored adaptive file",
-                largeFile
-            );
-
-            await filestore.files.log.replicate(adaptiveRole, {
-                rebalance: true,
-            });
-
-            const file = await filestore.files.index.get(fileId);
-            expect(keepPolicy).to.eq("self");
-            expect(file).to.be.instanceOf(LargeFile);
-            const bytes = await file!.getFile(filestore, {
-                as: "joined",
-                timeout: 20_000,
-            });
-
-            expect(equals(bytes, largeFile)).to.be.true;
-        });
-
         it("pipelines persisted chunk reads without using parentId searches", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
@@ -336,6 +297,9 @@ describe("index", () => {
             expect(maxInflightChunkGets).to.be.greaterThan(1);
             const readAhead = filestoreReader.lastReadDiagnostics?.readAhead;
             expect(readAhead).to.eq(4);
+            expect(
+                filestoreReader.lastReadDiagnostics?.chunkAttemptTimeoutMs
+            ).to.be.greaterThan(5_000);
             expect(maxInflightChunkGets).to.be.lessThanOrEqual(readAhead);
             expect(
                 Object.keys(

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -221,6 +221,45 @@ describe("index", () => {
             expect(filestore.lastUploadDiagnostics?.failureMessage).to.eq(null);
         });
 
+        it("keeps self-authored chunks readable under adaptive storage limits", async () => {
+            const adaptiveRole = {
+                limits: {
+                    cpu: { max: 1 },
+                    storage: 1_000_000,
+                },
+            };
+            const files = new Files();
+            let keepPolicy: unknown;
+            const originalOpen = files.files.open.bind(files.files);
+            (files.files as any).open = async (options: any) => {
+                keepPolicy = options.keep;
+                return originalOpen(options);
+            };
+
+            const filestore = await peer.open(files, {
+                args: { replicate: adaptiveRole },
+            });
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileId = await filestore.add(
+                "self-authored adaptive file",
+                largeFile
+            );
+
+            await filestore.files.log.replicate(adaptiveRole, {
+                rebalance: true,
+            });
+
+            const file = await filestore.files.index.get(fileId);
+            expect(keepPolicy).to.eq("self");
+            expect(file).to.be.instanceOf(LargeFile);
+            const bytes = await file!.getFile(filestore, {
+                as: "joined",
+                timeout: 20_000,
+            });
+
+            expect(equals(bytes, largeFile)).to.be.true;
+        });
+
         it("pipelines persisted chunk reads without using parentId searches", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -568,6 +568,119 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
+        it("keeps read peer hints after exact chunk misses", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileName = "streamed download with stable hinted reads";
+            const fileId = await filestore.add(fileName, largeFile);
+
+            const filestoreReader = await peer2.open<Files>(filestore.address);
+            await filestoreReader.files.log.waitForReplicator(
+                peer.identity.publicKey
+            );
+
+            const file = await filestoreReader.files.index.get(fileId);
+            expect(file).to.be.instanceOf(LargeFile);
+
+            const writerHash = peer.identity.publicKey.hashcode();
+            (filestoreReader as any).getReadPeerHints = async () => [
+                writerHash,
+            ];
+            const originalSearch =
+                filestoreReader.files.index.search.bind(filestoreReader.files.index);
+            const originalGet =
+                filestoreReader.files.index.get.bind(filestoreReader.files.index);
+            const delayedChunkId = `${fileId}:1`;
+            let directChunkGets = 0;
+            let hintedDirectGetsAfterFallback = 0;
+            let unhintedDirectGetsAfterFallback = 0;
+            let nonReplicatingFallbacks = 0;
+            let preciseChunkSearches = 0;
+            let parentChunkSearches = 0;
+
+            (filestoreReader.files.index as any).get = async (
+                id: string,
+                options: { remote?: { from?: string[]; replicate?: boolean } }
+            ) => {
+                if (id === delayedChunkId) {
+                    if (options?.remote?.replicate === false) {
+                        nonReplicatingFallbacks++;
+                        return undefined;
+                    }
+                    directChunkGets++;
+                    if (nonReplicatingFallbacks > 0) {
+                        if (options?.remote?.from?.includes(writerHash)) {
+                            hintedDirectGetsAfterFallback++;
+                        } else {
+                            unhintedDirectGetsAfterFallback++;
+                        }
+                    }
+                    if (directChunkGets <= 4) {
+                        return undefined;
+                    }
+                    return options?.remote?.from?.includes(writerHash)
+                        ? originalGet(id as never, options as never)
+                        : undefined;
+                }
+                return originalGet(id as never, options as never);
+            };
+
+            (filestoreReader.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasParentId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "parentId" &&
+                        getQueryValue(query) === fileId
+                );
+                const hasChunkName = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "name" &&
+                        getQueryValue(query) === `${fileName}/1`
+                );
+
+                if (hasParentId) {
+                    if (hasChunkName) {
+                        preciseChunkSearches++;
+                    } else {
+                        parentChunkSearches++;
+                    }
+                    return [];
+                }
+
+                return originalSearch(request as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+            await file!.writeFile(
+                filestoreReader,
+                {
+                    write: async (chunk) => {
+                        streamedChunks.push(chunk);
+                    },
+                },
+                { timeout: 20_000 }
+            );
+
+            expect(directChunkGets).to.be.greaterThan(4);
+            expect(preciseChunkSearches).to.be.greaterThan(0);
+            expect(parentChunkSearches).to.be.greaterThan(0);
+            expect(nonReplicatingFallbacks).to.be.greaterThan(0);
+            expect(hintedDirectGetsAfterFallback).to.be.greaterThan(0);
+            expect(unhintedDirectGetsAfterFallback).to.eq(0);
+            expect(
+                filestoreReader.lastReadDiagnostics?.initialReadPeerHints
+            ).to.deep.eq([writerHash]);
+            expect(
+                filestoreReader.lastReadDiagnostics?.chunkHints?.[1]
+            ).to.deep.eq([writerHash]);
+            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
         it("falls back to parent chunk search when exact chunk routes miss", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -639,7 +639,13 @@ describe("index", () => {
 
             (filestoreReader.files.index as any).get = async (
                 id: string,
-                options: { remote?: { from?: string[]; replicate?: boolean } }
+                options: {
+                    remote?: {
+                        from?: string[];
+                        replicate?: boolean;
+                        strategy?: string;
+                    };
+                }
             ) => {
                 if (id === delayedChunkId) {
                     if (options?.remote?.replicate === false) {
@@ -657,7 +663,8 @@ describe("index", () => {
                     if (directChunkGets <= 4) {
                         return undefined;
                     }
-                    return options?.remote?.from?.includes(writerHash)
+                    return options?.remote?.from?.includes(writerHash) &&
+                        options.remote.strategy === "always"
                         ? originalGet(id as never, options as never)
                         : undefined;
                 }

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -801,9 +801,9 @@ export class LargeFile extends AbstractFile {
                 directMisses + retryableFailures >=
                 nextNonReplicatingReadAfterFailures
             ) {
-                if (remoteFrom) {
-                    hintedDeliveryFailures = Math.max(hintedDeliveryFailures, 3);
-                }
+                // A miss is not evidence that a peer hint is stale. Keep using
+                // the known writer/replicator hint for direct reads unless a
+                // delivery error specifically tells us to fall back without it.
                 const fallbackHints =
                     remoteFrom ??
                     readContext.lastReadPeerHints ??
@@ -961,6 +961,7 @@ export class LargeFile extends AbstractFile {
             waitUntilReadyResolvedReady: null as boolean | null,
             prefetchedChunkCount: 0,
             readAhead: 0,
+            initialReadPeerHints: null as string[] | null,
             finishedAt: null as number | null,
             chunkAttempts: {} as Record<number, number>,
             chunkHints: {} as Record<number, string[] | null>,
@@ -992,6 +993,13 @@ export class LargeFile extends AbstractFile {
         const hasher = resolvedFile.finalHash ? new SHA256() : undefined;
         const knownChunks = new Map<number, TinyFile>();
         const readContext: ChunkReadContext = {};
+        if (files.persistChunkReads) {
+            const initialReadPeerHints = await files.getReadPeerHints();
+            if (initialReadPeerHints) {
+                readContext.lastReadPeerHints = initialReadPeerHints;
+                debug.initialReadPeerHints = initialReadPeerHints;
+            }
+        }
         if (!files.persistChunkReads) {
             for (const chunk of await resolvedFile.fetchChunks(files, {
                 timeout: Math.min(

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -299,6 +299,9 @@ const LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS = 5 * 60 * 1000;
 const LARGE_FILE_PERSISTED_READ_AHEAD = 4;
 const LARGE_FILE_OBSERVER_READ_AHEAD = 2;
 const LARGE_FILE_OBSERVER_PREFETCH_TIMEOUT_MS = 5_000;
+const LARGE_FILE_CHUNK_ATTEMPT_MIN_TIMEOUT_MS = 5_000;
+const LARGE_FILE_CHUNK_ATTEMPT_MAX_TIMEOUT_MS = 30_000;
+const LARGE_FILE_CHUNK_ATTEMPT_TARGET_BYTES_PER_MS = 64;
 const TINY_FILE_SIZE_LIMIT_BIGINT = BigInt(TINY_FILE_SIZE_LIMIT);
 
 const roundUpTo = (value: number, multiple: number) =>
@@ -325,6 +328,26 @@ const getChunkCount = (
     size: number | bigint,
     chunkSize = LARGE_FILE_SEGMENT_SIZE
 ) => Math.ceil(Number(size) / chunkSize);
+const getChunkLookupAttemptTimeout = (
+    totalTimeout: number,
+    size: number | bigint,
+    chunkCount: number
+) => {
+    const averageChunkSize = Number(size) / Math.max(chunkCount, 1);
+    const chunkTransferBudget = Math.ceil(
+        averageChunkSize / LARGE_FILE_CHUNK_ATTEMPT_TARGET_BYTES_PER_MS
+    );
+    return Math.min(
+        totalTimeout,
+        Math.max(
+            LARGE_FILE_CHUNK_ATTEMPT_MIN_TIMEOUT_MS,
+            Math.min(
+                LARGE_FILE_CHUNK_ATTEMPT_MAX_TIMEOUT_MS,
+                chunkTransferBudget
+            )
+        )
+    );
+};
 const getChunkId = (parentId: string, index: number) => `${parentId}:${index}`;
 const createUploadId = () => toBase64URL(randomBytes(16));
 const isBlobLike = (value: Uint8Array | Blob): value is Blob =>
@@ -568,7 +591,14 @@ export class LargeFile extends AbstractFile {
         const totalTimeout =
             properties?.timeout ?? LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS;
         const deadline = Date.now() + totalTimeout;
-        const attemptTimeout = Math.min(totalTimeout, 5_000);
+        const attemptTimeout = getChunkLookupAttemptTimeout(
+            totalTimeout,
+            this.size,
+            this.chunkCount
+        );
+        if (properties?.debug) {
+            properties.debug.chunkAttemptTimeoutMs = attemptTimeout;
+        }
         const chunkId = getChunkId(this.id, index);
         let hintedDeliveryFailures = 0;
         let directMisses = 0;
@@ -970,6 +1000,7 @@ export class LargeFile extends AbstractFile {
             prefetchedChunkCount: 0,
             readAhead: 0,
             initialReadPeerHints: null as string[] | null,
+            chunkAttemptTimeoutMs: 0,
             finishedAt: null as number | null,
             chunkAttempts: {} as Record<number, number>,
             chunkHints: {} as Record<number, string[] | null>,
@@ -1773,7 +1804,6 @@ export class Files extends Program<Args> {
             // TODO add ACL
             replicate: args?.replicate,
             replicas: { min: 3 },
-            keep: "self",
             canPerform: async (operation) => {
                 if (!this.trustGraph) {
                     return true;

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -239,9 +239,18 @@ export abstract class AbstractFile {
         writable: ChunkWritable,
         properties?: FileReadOptions
     ) {
+        let chunkIndex = 0;
         try {
             for await (const chunk of this.streamFile(files, properties)) {
+                const debug = files.lastReadDiagnostics;
+                if (debug) {
+                    (debug.chunkWriteStartedAt ||= {})[chunkIndex] = Date.now();
+                }
                 await writable.write(chunk);
+                if (debug) {
+                    (debug.chunkWriteFinishedAt ||= {})[chunkIndex] = Date.now();
+                }
+                chunkIndex++;
             }
             await writable.close?.();
         } catch (error) {
@@ -951,10 +960,19 @@ export class LargeFile extends AbstractFile {
             waitUntilReadyResolvedAt: null as number | null,
             waitUntilReadyResolvedReady: null as boolean | null,
             prefetchedChunkCount: 0,
+            readAhead: 0,
             finishedAt: null as number | null,
             chunkAttempts: {} as Record<number, number>,
             chunkHints: {} as Record<number, string[] | null>,
             chunkResolved: {} as Record<number, string>,
+            chunkResolveStartedAt: {} as Record<number, number>,
+            chunkResolveFinishedAt: {} as Record<number, number>,
+            chunkMaterializeStartedAt: {} as Record<number, number>,
+            chunkMaterializeFinishedAt: {} as Record<number, number>,
+            chunkHashStartedAt: {} as Record<number, number>,
+            chunkHashFinishedAt: {} as Record<number, number>,
+            chunkWriteStartedAt: {} as Record<number, number>,
+            chunkWriteFinishedAt: {} as Record<number, number>,
             chunkFailure: null as
                 | {
                       index: number;
@@ -991,16 +1009,23 @@ export class LargeFile extends AbstractFile {
             if (cached) {
                 return cached;
             }
-            const pending = this.resolveChunk(
-                files,
-                index,
-                knownChunks,
-                readContext,
-                {
-                    timeout: properties?.timeout,
-                    debug,
+            const pending = (async () => {
+                debug.chunkResolveStartedAt[index] = Date.now();
+                try {
+                    return await this.resolveChunk(
+                        files,
+                        index,
+                        knownChunks,
+                        readContext,
+                        {
+                            timeout: properties?.timeout,
+                            debug,
+                        }
+                    );
+                } finally {
+                    debug.chunkResolveFinishedAt[index] = Date.now();
                 }
-            );
+            })();
             inFlightChunks.set(index, pending);
             return pending;
         };
@@ -1008,6 +1033,7 @@ export class LargeFile extends AbstractFile {
         const readAhead = files.persistChunkReads
             ? LARGE_FILE_PERSISTED_READ_AHEAD
             : LARGE_FILE_OBSERVER_READ_AHEAD;
+        debug.readAhead = readAhead;
 
         for (
             let index = 0;
@@ -1031,11 +1057,15 @@ export class LargeFile extends AbstractFile {
                     `Failed to resolve chunk ${index + 1}/${resolvedFile.chunkCount} for file ${resolvedFile.id}`
                 );
             }
+            debug.chunkMaterializeStartedAt[index] = Date.now();
             const chunk = await chunkFile.getFile(files, {
                 as: "joined",
                 timeout: properties?.timeout,
             });
+            debug.chunkMaterializeFinishedAt[index] = Date.now();
+            debug.chunkHashStartedAt[index] = Date.now();
             hasher?.update(chunk);
+            debug.chunkHashFinishedAt[index] = Date.now();
             processed += chunk.byteLength;
             properties?.progress?.(
                 processed / Math.max(Number(resolvedFile.size), 1)

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -636,6 +636,10 @@ export class LargeFile extends AbstractFile {
                 waitFor: attemptTimeout,
                 remote: {
                     timeout: attemptTimeout,
+                    // Exact chunk reads must still ask the hinted remote when
+                    // a local indexed row exists but its payload blocks are no
+                    // longer materializable locally.
+                    strategy: "always" as any,
                     throwOnMissing: false,
                     retryMissingResponses: true,
                     replicate: false,
@@ -724,6 +728,10 @@ export class LargeFile extends AbstractFile {
                     waitFor: attemptTimeout,
                     remote: {
                         timeout: attemptTimeout,
+                        // Exact chunk reads must still ask the hinted remote when
+                        // a local indexed row exists but its payload blocks are no
+                        // longer materializable locally.
+                        strategy: "always" as any,
                         // Chunk docs are immutable once the ready manifest is
                         // visible. Using keep-open waits here under read-ahead
                         // fan-out creates long-lived remote queries that can

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -1765,6 +1765,7 @@ export class Files extends Program<Args> {
             // TODO add ACL
             replicate: args?.replicate,
             replicas: { min: 3 },
+            keep: "self",
             canPerform: async (operation) => {
                 if (!this.trustGraph) {
                     return true;

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -299,9 +299,6 @@ const LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS = 5 * 60 * 1000;
 const LARGE_FILE_PERSISTED_READ_AHEAD = 4;
 const LARGE_FILE_OBSERVER_READ_AHEAD = 2;
 const LARGE_FILE_OBSERVER_PREFETCH_TIMEOUT_MS = 5_000;
-const LARGE_FILE_CHUNK_ATTEMPT_MIN_TIMEOUT_MS = 5_000;
-const LARGE_FILE_CHUNK_ATTEMPT_MAX_TIMEOUT_MS = 30_000;
-const LARGE_FILE_CHUNK_ATTEMPT_TARGET_BYTES_PER_MS = 64;
 const TINY_FILE_SIZE_LIMIT_BIGINT = BigInt(TINY_FILE_SIZE_LIMIT);
 
 const roundUpTo = (value: number, multiple: number) =>
@@ -328,26 +325,6 @@ const getChunkCount = (
     size: number | bigint,
     chunkSize = LARGE_FILE_SEGMENT_SIZE
 ) => Math.ceil(Number(size) / chunkSize);
-const getChunkLookupAttemptTimeout = (
-    totalTimeout: number,
-    size: number | bigint,
-    chunkCount: number
-) => {
-    const averageChunkSize = Number(size) / Math.max(chunkCount, 1);
-    const chunkTransferBudget = Math.ceil(
-        averageChunkSize / LARGE_FILE_CHUNK_ATTEMPT_TARGET_BYTES_PER_MS
-    );
-    return Math.min(
-        totalTimeout,
-        Math.max(
-            LARGE_FILE_CHUNK_ATTEMPT_MIN_TIMEOUT_MS,
-            Math.min(
-                LARGE_FILE_CHUNK_ATTEMPT_MAX_TIMEOUT_MS,
-                chunkTransferBudget
-            )
-        )
-    );
-};
 const getChunkId = (parentId: string, index: number) => `${parentId}:${index}`;
 const createUploadId = () => toBase64URL(randomBytes(16));
 const isBlobLike = (value: Uint8Array | Blob): value is Blob =>
@@ -591,11 +568,7 @@ export class LargeFile extends AbstractFile {
         const totalTimeout =
             properties?.timeout ?? LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS;
         const deadline = Date.now() + totalTimeout;
-        const attemptTimeout = getChunkLookupAttemptTimeout(
-            totalTimeout,
-            this.size,
-            this.chunkCount
-        );
+        const attemptTimeout = Math.min(totalTimeout, 5_000);
         if (properties?.debug) {
             properties.debug.chunkAttemptTimeoutMs = attemptTimeout;
         }
@@ -663,7 +636,6 @@ export class LargeFile extends AbstractFile {
                         0) + 1);
             const chunk = await files.files.index.get(chunkId, {
                 local: true,
-                waitFor: attemptTimeout,
                 remote: {
                     timeout: attemptTimeout,
                     // Exact chunk reads must still ask the hinted remote when
@@ -755,7 +727,6 @@ export class LargeFile extends AbstractFile {
             try {
                 const chunk = await files.files.index.get(chunkId, {
                     local: true,
-                    waitFor: attemptTimeout,
                     remote: {
                         timeout: attemptTimeout,
                         // Exact chunk reads must still ask the hinted remote when

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -3,9 +3,12 @@ import { Program, ProgramHandler } from "@peerbit/program";
 import {
     Documents,
     SearchRequest,
+    SearchRequestIndexed,
     StringMatch,
     StringMatchMethod,
     IsNull,
+    isPutOperation,
+    type Operation,
 } from "@peerbit/document";
 import {
     PublicSignKey,
@@ -20,8 +23,7 @@ import { TrustedNetwork } from "@peerbit/trusted-network";
 import { ReplicationOptions, SharedLog } from "@peerbit/shared-log";
 import { SHA256 } from "@stablelib/sha256";
 
-const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 type RuntimeOpenProfileSample = {
     label: string;
@@ -112,7 +114,10 @@ const describeOpenTarget = (target: unknown) => {
     if (typeof target === "string") {
         return "address";
     }
-    return (target as { constructor?: { name?: string } })?.constructor?.name ?? "unknown";
+    return (
+        (target as { constructor?: { name?: string } })?.constructor?.name ??
+        "unknown"
+    );
 };
 
 const installRuntimeOpenProfiler = () => {
@@ -248,7 +253,8 @@ export abstract class AbstractFile {
                 }
                 await writable.write(chunk);
                 if (debug) {
-                    (debug.chunkWriteFinishedAt ||= {})[chunkIndex] = Date.now();
+                    (debug.chunkWriteFinishedAt ||= {})[chunkIndex] =
+                        Date.now();
                 }
                 chunkIndex++;
             }
@@ -327,6 +333,15 @@ const getChunkCount = (
 ) => Math.ceil(Number(size) / chunkSize);
 const getChunkId = (parentId: string, index: number) => `${parentId}:${index}`;
 const createUploadId = () => toBase64URL(randomBytes(16));
+const getEntryHash = (entry: unknown) =>
+    typeof (entry as { hash?: unknown })?.hash === "string"
+        ? (entry as { hash: string }).hash
+        : undefined;
+const getContextHead = (value: unknown) =>
+    typeof (value as { __context?: { head?: unknown } })?.__context?.head ===
+    "string"
+        ? (value as { __context: { head: string } }).__context.head
+        : undefined;
 const isBlobLike = (value: Uint8Array | Blob): value is Blob =>
     typeof Blob !== "undefined" && value instanceof Blob;
 const readBlobChunk = async (blob: Blob, index: number, chunkSize: number) =>
@@ -343,7 +358,11 @@ const readBlobSequentialChunks = async function* (
     chunkSize: number
 ): AsyncIterable<Uint8Array> {
     if (typeof blob.stream !== "function") {
-        for (let index = 0; index < getChunkCount(blob.size, chunkSize); index++) {
+        for (
+            let index = 0;
+            index < getChunkCount(blob.size, chunkSize);
+            index++
+        ) {
             yield readBlobChunk(blob, index, chunkSize);
         }
         return;
@@ -367,7 +386,10 @@ const readBlobSequentialChunks = async function* (
             while (offset < value.byteLength) {
                 const available = chunkSize - pendingOffset;
                 const take = Math.min(available, value.byteLength - offset);
-                pending.set(value.subarray(offset, offset + take), pendingOffset);
+                pending.set(
+                    value.subarray(offset, offset + take),
+                    pendingOffset
+                );
                 pendingOffset += take;
                 offset += take;
 
@@ -526,7 +548,10 @@ export class LargeFile extends AbstractFile {
             recordChunks(
                 await files.files.index.search(
                     new SearchRequest({
-                        query: new StringMatch({ key: "parentId", value: this.id }),
+                        query: new StringMatch({
+                            key: "parentId",
+                            value: this.id,
+                        }),
                         fetch: 0xffffffff,
                     }),
                     {
@@ -549,10 +574,14 @@ export class LargeFile extends AbstractFile {
             }
         }
 
-        return [...chunks.values()].sort((a, b) => (a.index || 0) - (b.index || 0));
+        return [...chunks.values()].sort(
+            (a, b) => (a.index || 0) - (b.index || 0)
+        );
     }
     async delete(files: Files) {
-        await Promise.all((await this.fetchChunks(files)).map((x) => files.files.del(x.id)));
+        await Promise.all(
+            (await this.fetchChunks(files)).map((x) => files.files.del(x.id))
+        );
     }
 
     private async resolveChunk(
@@ -573,10 +602,66 @@ export class LargeFile extends AbstractFile {
             properties.debug.chunkAttemptTimeoutMs = attemptTimeout;
         }
         const chunkId = getChunkId(this.id, index);
+        if (files.persistChunkReads) {
+            files.retainChunkRead(chunkId);
+        }
         let hintedDeliveryFailures = 0;
         let directMisses = 0;
         let retryableFailures = 0;
         let nextNonReplicatingReadAfterFailures = 3;
+        const indexedChunkPending = Symbol("indexed-chunk-pending");
+        const materializeLocalChunk = async (
+            resolvedBy: string
+        ): Promise<TinyFile | undefined> => {
+            const chunk = await files.files.index.get(chunkId, {
+                local: true,
+                remote: false,
+            });
+            if (
+                chunk instanceof TinyFile &&
+                chunk.parentId === this.id &&
+                chunk.index === index
+            ) {
+                knownChunks.set(index, chunk);
+                files.retainResolvedChunk(chunk);
+                properties?.debug &&
+                    ((properties.debug.chunkResolved ||= {})[index] =
+                        resolvedBy);
+                return chunk;
+            }
+        };
+        const matchesChunkIndex = (candidate: unknown) =>
+            candidate instanceof IndexableFile &&
+            candidate.id === chunkId &&
+            candidate.parentId === this.id &&
+            candidate.name === `${this.name}/${index}`;
+        const syncChunkByExactIndex = async (
+            remoteFrom: string[] | undefined
+        ): Promise<TinyFile | typeof indexedChunkPending | undefined> => {
+            properties?.debug &&
+                ((properties.debug.chunkIndexedGets ||= {})[index] =
+                    ((properties.debug.chunkIndexedGets ||= {})[index] ?? 0) +
+                    1);
+            const indexed = await files.files.index.get(chunkId, {
+                resolve: false,
+                local: false,
+                remote: {
+                    timeout: attemptTimeout,
+                    strategy: "always" as any,
+                    throwOnMissing: false,
+                    retryMissingResponses: true,
+                    replicate: true,
+                    from: remoteFrom,
+                },
+            });
+            if (matchesChunkIndex(indexed)) {
+                files.retainResolvedChunk(indexed);
+                return (
+                    (await materializeLocalChunk("indexed-get")) ??
+                    indexedChunkPending
+                );
+            }
+        };
         const resolveChunkByIndexedFields = async (
             remoteFrom: string[] | undefined
         ): Promise<TinyFile | undefined> => {
@@ -584,6 +669,44 @@ export class LargeFile extends AbstractFile {
                 ((properties.debug.chunkIndexedSearches ||= {})[index] =
                     ((properties.debug.chunkIndexedSearches ||= {})[index] ??
                         0) + 1);
+            if (files.persistChunkReads) {
+                const chunks = await files.files.index.search(
+                    new SearchRequestIndexed({
+                        query: [
+                            new StringMatch({
+                                key: "parentId",
+                                value: this.id,
+                                caseInsensitive: false,
+                                method: StringMatchMethod.exact,
+                            }),
+                            new StringMatch({
+                                key: "name",
+                                value: `${this.name}/${index}`,
+                                caseInsensitive: false,
+                                method: StringMatchMethod.exact,
+                            }),
+                        ],
+                        fetch: 1,
+                    }),
+                    {
+                        resolve: false,
+                        local: false,
+                        remote: {
+                            timeout: attemptTimeout,
+                            throwOnMissing: false,
+                            retryMissingResponses: true,
+                            replicate: true,
+                            from: remoteFrom,
+                        },
+                    } as any
+                );
+                const indexed = chunks.find(matchesChunkIndex);
+                if (indexed) {
+                    files.retainResolvedChunk(indexed);
+                    return materializeLocalChunk("indexed-search");
+                }
+                return;
+            }
             const chunks = await files.files.index.search(
                 new SearchRequest({
                     query: [
@@ -621,19 +744,17 @@ export class LargeFile extends AbstractFile {
             ) as TinyFile | undefined;
             if (chunk) {
                 knownChunks.set(index, chunk);
+                files.retainResolvedChunk(chunk);
                 properties?.debug &&
                     ((properties.debug.chunkResolved ||= {})[index] =
                         "indexed-search");
                 return chunk;
             }
         };
-        const resolveChunkWithoutPersisting = async (
-            remoteFrom: string[] | undefined
+        const resolveChunkByDirectGet = async (
+            remoteFrom: string[] | undefined,
+            replicate: boolean
         ): Promise<TinyFile | undefined> => {
-            properties?.debug &&
-                ((properties.debug.chunkNonReplicatingGets ||= {})[index] =
-                    ((properties.debug.chunkNonReplicatingGets ||= {})[index] ??
-                        0) + 1);
             const chunk = await files.files.index.get(chunkId, {
                 local: true,
                 remote: {
@@ -644,21 +765,33 @@ export class LargeFile extends AbstractFile {
                     strategy: "always" as any,
                     throwOnMissing: false,
                     retryMissingResponses: true,
-                    replicate: false,
+                    replicate,
                     from: remoteFrom,
                 },
             });
+
             if (
                 chunk instanceof TinyFile &&
                 chunk.parentId === this.id &&
                 chunk.index === index
             ) {
                 knownChunks.set(index, chunk);
+                files.retainResolvedChunk(chunk);
                 properties?.debug &&
-                    ((properties.debug.chunkResolved ||= {})[index] =
-                        "non-replicating-get");
+                    ((properties.debug.chunkResolved ||= {})[index] = replicate
+                        ? "remote-get"
+                        : "non-replicating-get");
                 return chunk;
             }
+        };
+        const resolveChunkWithoutPersisting = async (
+            remoteFrom: string[] | undefined
+        ): Promise<TinyFile | undefined> => {
+            properties?.debug &&
+                ((properties.debug.chunkNonReplicatingGets ||= {})[index] =
+                    ((properties.debug.chunkNonReplicatingGets ||= {})[index] ??
+                        0) + 1);
+            return resolveChunkByDirectGet(remoteFrom, false);
         };
         const resolveChunksByParentSearch = async (
             remoteFrom: string[] | undefined
@@ -689,6 +822,7 @@ export class LargeFile extends AbstractFile {
             for (const chunk of chunks) {
                 if (chunk instanceof TinyFile && chunk.parentId === this.id) {
                     knownChunks.set(chunk.index || 0, chunk);
+                    files.retainResolvedChunk(chunk);
                 }
             }
             const chunk = knownChunks.get(index);
@@ -710,6 +844,26 @@ export class LargeFile extends AbstractFile {
                     ((properties.debug.chunkResolved ||= {})[index] = "cached");
                 return cached;
             }
+            try {
+                const localChunk = await materializeLocalChunk("local");
+                if (localChunk) {
+                    return localChunk;
+                }
+            } catch (error) {
+                if (!isRetryableChunkLookupError(error)) {
+                    properties?.debug &&
+                        (properties.debug.chunkFailure = {
+                            index,
+                            type: "non-retryable-local-get",
+                            message: getErrorMessage(error),
+                        });
+                    throw error;
+                }
+                retryableFailures += 1;
+                properties?.debug &&
+                    ((properties.debug.chunkRetryableErrors ||= {})[index] =
+                        getErrorMessage(error));
+            }
             const candidateReadPeerHints = await files.getReadPeerHints();
             if (candidateReadPeerHints) {
                 readContext.lastReadPeerHints = candidateReadPeerHints;
@@ -721,41 +875,25 @@ export class LargeFile extends AbstractFile {
                     ? undefined
                     : availableReadPeerHints;
             if (properties?.debug) {
-                (properties.debug.chunkHints ||= {})[index] = remoteFrom ?? null;
+                (properties.debug.chunkHints ||= {})[index] =
+                    remoteFrom ?? null;
             }
 
             try {
-                const chunk = await files.files.index.get(chunkId, {
-                    local: true,
-                    remote: {
-                        timeout: attemptTimeout,
-                        // Exact chunk reads must still ask the hinted remote when
-                        // a local indexed row exists but its payload blocks are no
-                        // longer materializable locally.
-                        strategy: "always" as any,
-                        // Chunk docs are immutable once the ready manifest is
-                        // visible. Using keep-open waits here under read-ahead
-                        // fan-out creates long-lived remote queries that can
-                        // stall bulk reads instead of helping them complete.
-                        // We use short stateless retries in the outer loop
-                        // instead.
-                        throwOnMissing: false,
-                        retryMissingResponses: true,
-                        replicate: files.persistChunkReads,
-                        from: remoteFrom,
-                    },
-                });
-
-                if (
-                    chunk instanceof TinyFile &&
-                    chunk.parentId === this.id &&
-                    chunk.index === index
-                ) {
-                    knownChunks.set(index, chunk);
-                    properties?.debug &&
-                        ((properties.debug.chunkResolved ||= {})[index] =
-                            "remote-get");
+                const chunk = files.persistChunkReads
+                    ? await syncChunkByExactIndex(remoteFrom)
+                    : await resolveChunkByDirectGet(remoteFrom, false);
+                if (chunk instanceof TinyFile) {
                     return chunk;
+                }
+                if (chunk === indexedChunkPending) {
+                    properties?.debug &&
+                        ((properties.debug.chunkGetMisses ||= {})[index] =
+                            ((properties.debug.chunkGetMisses ||= {})[index] ??
+                                0) + 1);
+                    directMisses += 1;
+                    await sleep(250);
+                    continue;
                 }
                 properties?.debug &&
                     ((properties.debug.chunkGetMisses ||= {})[index] =
@@ -845,10 +983,8 @@ export class LargeFile extends AbstractFile {
                         }
                         retryableFailures += 1;
                         properties?.debug &&
-                            ((properties.debug
-                                .chunkRetryableNonReplicatingGetErrors ||= {})[
-                                index
-                            ] = getErrorMessage(error));
+                            ((properties.debug.chunkRetryableNonReplicatingGetErrors ||=
+                                {})[index] = getErrorMessage(error));
                     }
                 }
                 for (const fallbackFrom of fallbackSources) {
@@ -932,8 +1068,9 @@ export class LargeFile extends AbstractFile {
                 } as any
             );
             const latest =
-                matches.find((match) => match instanceof LargeFile && match.ready) ??
-                matches.find((match) => match instanceof LargeFile);
+                matches.find(
+                    (match) => match instanceof LargeFile && match.ready
+                ) ?? matches.find((match) => match instanceof LargeFile);
             if (debug) {
                 debug.lastReadyProbe = {
                     at: Date.now(),
@@ -984,13 +1121,11 @@ export class LargeFile extends AbstractFile {
             chunkHashFinishedAt: {} as Record<number, number>,
             chunkWriteStartedAt: {} as Record<number, number>,
             chunkWriteFinishedAt: {} as Record<number, number>,
-            chunkFailure: null as
-                | {
-                      index: number;
-                      type: string;
-                      message: string;
-                  }
-                | null,
+            chunkFailure: null as {
+                index: number;
+                type: string;
+                message: string;
+            } | null,
         };
         files.lastReadDiagnostics = debug;
         const resolvedFile = await this.waitUntilReady(files, properties);
@@ -1091,10 +1226,7 @@ export class LargeFile extends AbstractFile {
             yield chunk;
         }
 
-        if (
-            hasher &&
-            toBase64(hasher.digest()) !== resolvedFile.finalHash
-        ) {
+        if (hasher && toBase64(hasher.digest()) !== resolvedFile.finalHash) {
             throw new Error("File hash does not match the expected content");
         }
         debug.finishedAt = Date.now();
@@ -1184,6 +1316,8 @@ export class Files extends Program<Args> {
     openDiagnostics?: OpenDiagnostics;
     lastReadDiagnostics?: Record<string, any>;
     lastUploadDiagnostics?: UploadDiagnostics;
+    private retainedChunkIds = new Set<string>();
+    private retainedChunkEntryHeads = new Set<string>();
 
     constructor(
         properties: {
@@ -1208,6 +1342,93 @@ export class Files extends Program<Args> {
             ),
         });
         this.persistChunkReads = true;
+    }
+
+    retainChunkRead(chunkId: string) {
+        this.retainedChunkIds ??= new Set();
+        this.retainedChunkIds.add(chunkId);
+    }
+
+    retainResolvedChunk(value: unknown) {
+        const head = getContextHead(value);
+        if (head) {
+            this.retainedChunkEntryHeads ??= new Set();
+            this.retainedChunkEntryHeads.add(head);
+        }
+    }
+
+    private async shouldKeepFileEntry(entryLike: unknown) {
+        this.retainedChunkIds ??= new Set();
+        this.retainedChunkEntryHeads ??= new Set();
+        const hash = getEntryHash(entryLike);
+        if (hash && this.retainedChunkEntryHeads.has(hash)) {
+            return true;
+        }
+
+        let entry:
+            | {
+                  hash: string;
+                  signatures?: {
+                      publicKey?: { equals?: (key: unknown) => boolean };
+                  }[];
+                  getPayloadValue: () => Promise<Operation>;
+              }
+            | undefined;
+        try {
+            entry =
+                typeof (entryLike as { getPayloadValue?: unknown })
+                    ?.getPayloadValue === "function"
+                    ? (entryLike as typeof entry)
+                    : hash
+                      ? ((await this.files.log.log.get(hash)) as typeof entry)
+                      : undefined;
+        } catch {
+            return false;
+        }
+
+        if (!entry) {
+            return false;
+        }
+
+        const signatures = (
+            entry as {
+                signatures?: {
+                    publicKey?: { equals?: (key: unknown) => boolean };
+                }[];
+            }
+        ).signatures;
+        if (
+            signatures?.some((signature) =>
+                signature.publicKey?.equals?.(this.node.identity.publicKey)
+            )
+        ) {
+            this.retainedChunkEntryHeads.add(entry.hash);
+            return true;
+        }
+
+        if (!this.persistChunkReads) {
+            return false;
+        }
+
+        try {
+            const operation = await entry.getPayloadValue();
+            if (!isPutOperation(operation)) {
+                return false;
+            }
+            const file = this.files.index.valueEncoding.decoder(operation.data);
+            if (
+                file instanceof TinyFile &&
+                file.parentId != null &&
+                this.retainedChunkIds.has(file.id)
+            ) {
+                this.retainedChunkEntryHeads.add(entry.hash);
+                return true;
+            }
+        } catch {
+            return false;
+        }
+
+        return false;
     }
 
     async add(
@@ -1601,12 +1822,13 @@ export class Files extends Program<Args> {
             waitFor: properties?.timeout,
             remote: {
                 timeout: properties?.timeout ?? 10 * 1000,
-                wait: properties?.timeout && properties.wait !== false
-                    ? {
-                          timeout: properties.timeout,
-                          behavior: "keep-open",
-                      }
-                    : undefined,
+                wait:
+                    properties?.timeout && properties.wait !== false
+                        ? {
+                              timeout: properties.timeout,
+                              behavior: "keep-open",
+                          }
+                        : undefined,
                 throwOnMissing: false,
                 retryMissingResponses: true,
                 replicate: properties?.replicate,
@@ -1649,7 +1871,9 @@ export class Files extends Program<Args> {
     }
 
     async getReadPeerHints(): Promise<string[] | undefined> {
-        const replicators = await this.files.log.getReplicators().catch(() => undefined);
+        const replicators = await this.files.log
+            .getReplicators()
+            .catch(() => undefined);
         if (!replicators || replicators.size === 0) {
             return undefined;
         }
@@ -1775,6 +1999,7 @@ export class Files extends Program<Args> {
             // TODO add ACL
             replicate: args?.replicate,
             replicas: { min: 3 },
+            keep: (entry) => this.shouldKeepFileEntry(entry),
             canPerform: async (operation) => {
                 if (!this.trustGraph) {
                     return true;
@@ -1797,8 +2022,9 @@ export class Files extends Program<Args> {
 
         await Promise.all([trustGraphOpenPromise, filesOpenPromise]);
         openDiagnostics.finishedAt = Date.now();
-        openDiagnostics.runtimeProfileSamples = getRuntimeOpenProfilerState().samples.slice(
-            runtimeProfileStartIndex
-        );
+        openDiagnostics.runtimeProfileSamples =
+            getRuntimeOpenProfilerState().samples.slice(
+                runtimeProfileStartIndex
+            );
     }
 }


### PR DESCRIPTION
## Summary
- keep adaptive chunk reads targeting known writer/replicator hints after ordinary exact-lookup misses
- seed persisted stream read-ahead with the current read peer hints before launching concurrent chunk reads
- force exact chunk reads to sync indexed rows from the hinted remote with `resolve: false`, then materialize the local chunk payload
- retain authored chunk log entries and explicitly requested persisted chunk reads so adaptive pruning cannot delete a chunk entry before the reader materializes it
- avoid passing `waitFor` to exact chunk reads, because successful hinted remote gets were being held until the local wait cap in benchmark artifacts
- keep the download timing diagnostics from the earlier commit for benchmark artifacts
- add regressions for stable hinted reads, index-only chunk sync, bounded read-ahead, exact chunk reads without local wait caps, and retention before adaptive prune

## Verification
- `pnpm --filter @peerbit/please-lib test`
- `pnpm --filter @peerbit/please-lib build`
- `pnpm --filter file-share build`
- `pnpm exec prettier --check packages/file-share/library/src/index.ts packages/file-share/library/src/__tests__/index.integration.test.ts`
- `git diff --check`
- Local browser bench: 256 MiB, local scenario, adaptive reader, save-picker stream passed on `503196c` with all 256 chunks local after download; upload 15.5s, download 253.6s, ~1.01 MiB/s
- GitHub Actions file-share benchmark 25054881729 passed on `0211b0f` but remained slow
- GitHub Actions file-share benchmark 25056067684 failed on `c6abcaf`; retaining authored chunks was not sufficient
- GitHub Actions file-share benchmark 25057118372 failed on `6a7a1f5`; forcing hinted remote queries was not sufficient by itself
- GitHub Actions file-share benchmark 25058249674 failed on `fdefb85`; larger per-attempt waits made successful remote gets stall at the wait cap
- GitHub Actions file-share benchmark 25059506322 failed on `8ab12d0`; exact remote gets still left chunk entries unavailable under adaptive prune
- GitHub Actions file-share benchmark 25063460226 passed on `503196c`: 512 MiB local adaptive reader, upload 141.2s at 30.42 Mbps, discovery 0.14s, download 199.0s at 21.58 Mbps, all 256 chunks written, no chunk failure

## Notes
This keeps adaptive replication enabled. It does not switch to fixed-size replication and does not add blind retry loops. The reader now joins the indexed chunk entry first, pins entries it authored or explicitly requested, and only then materializes the local payload so the adaptive prune path cannot erase the chunk while the persisted read is in progress.