### PR TITLE
Benchmark adaptive file-share two-runner reads

### DIFF
--- a/.github/workflows/file-share-two-runner-benchmarks.yml
+++ b/.github/workflows/file-share-two-runner-benchmarks.yml
@@ -13,6 +13,14 @@ on:
                 required: true
                 type: string
                 default: https://files.dao.xyz
+            reader_role:
+                description: Reader replication role
+                required: true
+                type: choice
+                default: adaptive
+                options:
+                    - adaptive
+                    - observer
             min_upload_mbps:
                 description: Fail if upload throughput is below this value (0 disables)
                 required: true
@@ -178,6 +186,7 @@ jobs:
                   COORDINATION_ISSUE: ${{ needs.coordinator.outputs.issue_number }}
                   PW_BASE_URL: ${{ inputs.base_url }}
                   PW_FILE_MB: ${{ inputs.file_mb }}
+                  PW_READER_ROLE: ${{ inputs.reader_role }}
                   PW_RESULT_FILE: ${{ github.workspace }}/bench-results/reader.json
               run: |
                   mkdir -p "$GITHUB_WORKSPACE/bench-results"
@@ -214,6 +223,7 @@ jobs:
               env:
                   BENCH_FILE_MB: ${{ inputs.file_mb }}
                   BENCH_BASE_URL: ${{ inputs.base_url }}
+                  BENCH_READER_ROLE: ${{ inputs.reader_role }}
                   BENCH_MIN_UPLOAD_MBPS: ${{ inputs.min_upload_mbps }}
                   BENCH_MIN_DOWNLOAD_MBPS: ${{ inputs.min_download_mbps }}
               run: |
@@ -232,6 +242,7 @@ jobs:
                     "",
                     `- Base URL: \`${process.env.BENCH_BASE_URL}\``,
                     `- File size: \`${process.env.BENCH_FILE_MB} MiB\``,
+                    `- Reader role: \`${process.env.BENCH_READER_ROLE}\``,
                     `- Writer status: \`${writer.status}\``,
                     `- Reader status: \`${reader.status}\``,
                   ];

--- a/packages/file-share/frontend/tests/helpers.ts
+++ b/packages/file-share/frontend/tests/helpers.ts
@@ -149,7 +149,9 @@ export async function waitForFileListed(
 }
 
 export async function waitForUploadComplete(page: Page, timeout = 600_000) {
-    const progress = page.locator('[data-testid="upload-progress"], .progress-root');
+    const progress = page.locator(
+        '[data-testid="upload-progress"], .progress-root'
+    );
     if ((await progress.count()) === 0) {
         return;
     }
@@ -158,10 +160,9 @@ export async function waitForUploadComplete(page: Page, timeout = 600_000) {
 
 export async function setSeedMode(page: Page, seeded: boolean) {
     const byTestId = page.getByTestId("seed-toggle");
-    const toggle =
-        (await byTestId.count())
-            ? byTestId
-            : page.locator("button", { hasText: "Seed" }).first();
+    const toggle = (await byTestId.count())
+        ? byTestId
+        : page.locator("button", { hasText: "Seed" }).first();
     await expect(toggle).toBeVisible({ timeout: 60_000 });
     const expected = seeded ? "on" : "off";
     const current = await toggle.getAttribute("data-state");
@@ -177,7 +178,7 @@ export async function expectDownloadedFile(
     expectedSizeMb: number,
     timeout = 8 * 60 * 1000
 ) {
-    const { button } = await getDownloadButton(page, fileName);
+    const { button } = await getDownloadButton(page, fileName, timeout);
 
     const downloadPromise = page.waitForEvent("download", { timeout });
     const dialogFailure = ignoreTimeout(
@@ -225,24 +226,33 @@ const ignoreTimeout = <T>(promise: Promise<T>) =>
         throw error;
     });
 
-const getDownloadButton = async (page: Page, fileName: string) => {
+const getDownloadButton = async (
+    page: Page,
+    fileName: string,
+    timeout = 60_000
+) => {
     const row = page.locator("li", { hasText: fileName }).first();
-    await expect(row).toBeVisible({ timeout: 60_000 });
+    await expect(row).toBeVisible({ timeout });
     const byTestId = row.getByTestId("download-file");
     const button =
         (await byTestId.count()) > 0 ? byTestId : row.locator("button").first();
+    await expect(button).toBeEnabled({ timeout });
     return { row, button };
 };
 
 export async function installMockSaveFilePicker(page: Page) {
     await page.addInitScript(() => {
         const savedFiles: Array<{ name: string; size: number }> = [];
-        Object.defineProperty(window, "__peerbitStreamingDownloadThresholdBytes", {
-            value: 1,
-            configurable: true,
-            enumerable: false,
-            writable: true,
-        });
+        Object.defineProperty(
+            window,
+            "__peerbitStreamingDownloadThresholdBytes",
+            {
+                value: 1,
+                configurable: true,
+                enumerable: false,
+                writable: true,
+            }
+        );
         Object.defineProperty(window, "__mockSavedFiles", {
             value: savedFiles,
             configurable: true,
@@ -281,7 +291,7 @@ export async function expectSavedViaPicker(
     timeout = 8 * 60 * 1000
 ) {
     const expectedBytes = expectedSizeMb * 1024 * 1024;
-    const { button } = await getDownloadButton(page, fileName);
+    const { button } = await getDownloadButton(page, fileName, timeout);
     const dialogFailure = ignoreTimeout(
         page.waitForEvent("dialog", { timeout }).then(async (dialog) => {
             const message = dialog.message();
@@ -299,9 +309,14 @@ export async function expectSavedViaPicker(
             async () =>
                 page.evaluate((expectedName) => {
                     const savedFiles =
-                        ((window as unknown as {
-                            __mockSavedFiles?: Array<{ name: string; size: number }>;
-                        }).__mockSavedFiles ?? []);
+                        (
+                            window as unknown as {
+                                __mockSavedFiles?: Array<{
+                                    name: string;
+                                    size: number;
+                                }>;
+                            }
+                        ).__mockSavedFiles ?? [];
                     return (
                         savedFiles.find((file) => file.name === expectedName) ??
                         null

--- a/packages/file-share/frontend/tests/two-runner.bench.mjs
+++ b/packages/file-share/frontend/tests/two-runner.bench.mjs
@@ -147,13 +147,20 @@ const ignoreTimeout = (promise) =>
         throw error;
     });
 
-const getDownloadButton = async (page, fileName) => {
+const getDownloadButton = async (page, fileName, timeout = 60_000) => {
     const row = page.locator("li", { hasText: fileName }).first();
-    await row.waitFor({ timeout: 60_000 });
+    await row.waitFor({ timeout });
     const byTestId = row.getByTestId("download-file");
     const button =
         (await byTestId.count()) > 0 ? byTestId : row.locator("button").first();
-    return { row, button };
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+        if (await button.isEnabled().catch(() => false)) {
+            return { row, button };
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    throw new Error(`Download button for ${fileName} did not become enabled`);
 };
 
 const installMockSaveFilePicker = async (page) => {
@@ -206,7 +213,7 @@ const expectDownloadedFile = async (
     expectedSizeMb,
     timeout = 8 * 60 * 1000
 ) => {
-    const { button } = await getDownloadButton(page, fileName);
+    const { button } = await getDownloadButton(page, fileName, timeout);
 
     const downloadPromise = page.waitForEvent("download", { timeout });
     const dialogFailure = ignoreTimeout(
@@ -250,7 +257,7 @@ const expectSavedViaPicker = async (
     timeout = 8 * 60 * 1000
 ) => {
     const expectedBytes = expectedSizeMb * 1024 * 1024;
-    const { button } = await getDownloadButton(page, fileName);
+    const { button } = await getDownloadButton(page, fileName, timeout);
     const dialogFailure = ignoreTimeout(
         page.waitForEvent("dialog", { timeout }).then(async (dialog) => {
             const message = dialog.message();

--- a/packages/file-share/frontend/tests/two-runner.bench.mjs
+++ b/packages/file-share/frontend/tests/two-runner.bench.mjs
@@ -10,11 +10,10 @@ const BASE_URL = (process.env.PW_BASE_URL || "https://files.dao.xyz").replace(
     ""
 );
 const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "512");
+const READER_ROLE = process.env.PW_READER_ROLE || "adaptive";
 const RESULT_FILE = process.env.PW_RESULT_FILE;
 const STREAMING_DOWNLOAD_THRESHOLD_BYTES = 250_000_000;
-const UPLOAD_TIMEOUT_MS = Number(
-    process.env.PW_UPLOAD_TIMEOUT_MS || "1800000"
-);
+const UPLOAD_TIMEOUT_MS = Number(process.env.PW_UPLOAD_TIMEOUT_MS || "1800000");
 const DOWNLOAD_TIMEOUT_MS = Number(
     process.env.PW_DOWNLOAD_TIMEOUT_MS || "1800000"
 );
@@ -29,6 +28,16 @@ const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY;
 const COORDINATION_ISSUE = process.env.COORDINATION_ISSUE;
 
 const rootUrl = (baseURL) => `${baseURL.replace(/\/$/, "")}/#/`;
+
+const getReaderRoleOptions = () => {
+    if (READER_ROLE === "observer") {
+        return false;
+    }
+    if (READER_ROLE === "adaptive") {
+        return { limits: { cpu: { max: 1 } } };
+    }
+    throw new Error(`Unsupported PW_READER_ROLE='${READER_ROLE}'`);
+};
 
 const persistResult = async (result) => {
     if (!RESULT_FILE) {
@@ -102,14 +111,19 @@ const getDiagnostics = async (page) => {
     return await page.evaluate(async () => {
         const hooks = window.__peerbitFileShareTestHooks;
         if (!hooks?.getDiagnostics) {
-            throw new Error("Missing __peerbitFileShareTestHooks.getDiagnostics");
+            throw new Error(
+                "Missing __peerbitFileShareTestHooks.getDiagnostics"
+            );
         }
         return await hooks.getDiagnostics();
     });
 };
 
 const waitForFileListed = async (page, fileName, timeout = 180_000) => {
-    await page.locator("li", { hasText: fileName }).first().waitFor({ timeout });
+    await page
+        .locator("li", { hasText: fileName })
+        .first()
+        .waitFor({ timeout });
 };
 
 const waitForUploadComplete = async (page, timeout = 600_000) => {
@@ -145,12 +159,16 @@ const getDownloadButton = async (page, fileName) => {
 const installMockSaveFilePicker = async (page) => {
     await page.addInitScript(() => {
         const savedFiles = [];
-        Object.defineProperty(window, "__peerbitStreamingDownloadThresholdBytes", {
-            value: 1,
-            configurable: true,
-            enumerable: false,
-            writable: true,
-        });
+        Object.defineProperty(
+            window,
+            "__peerbitStreamingDownloadThresholdBytes",
+            {
+                value: 1,
+                configurable: true,
+                enumerable: false,
+                writable: true,
+            }
+        );
         Object.defineProperty(window, "__mockSavedFiles", {
             value: savedFiles,
             configurable: true,
@@ -308,12 +326,16 @@ const createFileCoordinator = (filePath) => ({
                     .filter(Boolean)
                     .map((line) => JSON.parse(line))
                     .filter((event) => event.runId === RUN_ID);
-                const match = events.find((event) => kinds.includes(event.kind));
+                const match = events.find((event) =>
+                    kinds.includes(event.kind)
+                );
                 if (match) {
                     return match;
                 }
             }
-            await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+            await new Promise((resolve) =>
+                setTimeout(resolve, POLL_INTERVAL_MS)
+            );
         }
         throw new Error(
             `Timed out waiting for coordination event ${kinds.join(", ")}`
@@ -400,7 +422,10 @@ const runWriter = async (coordinator) => {
     const page = await context.newPage();
     await enableOpenProfiler(page);
     const fileName = `file-share-two-runner-${Date.now()}.bin`;
-    const preparedFile = await createSyntheticFileOnDisk(fileName, FILE_SIZE_MB);
+    const preparedFile = await createSyntheticFileOnDisk(
+        fileName,
+        FILE_SIZE_MB
+    );
     let writerDiagnostics;
 
     try {
@@ -507,6 +532,7 @@ const runReader = async (coordinator) => {
     const context = await browser.newContext({ acceptDownloads: true });
     const page = await context.newPage();
     await enableOpenProfiler(page);
+    const readerRoleOptions = getReaderRoleOptions();
     const usesStreamingDownload =
         FILE_SIZE_MB * 1024 * 1024 >= STREAMING_DOWNLOAD_THRESHOLD_BYTES;
     let readerDiagnostics;
@@ -515,7 +541,7 @@ const runReader = async (coordinator) => {
         if (usesStreamingDownload) {
             await installMockSaveFilePicker(page);
         }
-        await seedReplicationRole(page, writer.address, false);
+        await seedReplicationRole(page, writer.address, readerRoleOptions);
         await page.goto(writer.shareUrl, { waitUntil: "domcontentloaded" });
         const readerReadyAt = Date.now();
         await waitForFileListed(page, writer.fileName, UPLOAD_TIMEOUT_MS);
@@ -544,6 +570,7 @@ const runReader = async (coordinator) => {
         const result = {
             status: "passed",
             role: "reader",
+            readerRole: READER_ROLE,
             scenario: "prod",
             baseURL: BASE_URL,
             shareUrl: writer.shareUrl,
@@ -579,6 +606,7 @@ const runReader = async (coordinator) => {
         await persistResult({
             status: "failed",
             role: "reader",
+            readerRole: READER_ROLE,
             scenario: "prod",
             fileName: writer.fileName,
             fileSizeMb: FILE_SIZE_MB,

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -530,6 +530,137 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
+        it("falls back to resolved precise search when adaptive indexed chunks do not materialize", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileName = "streamed download with resolved precise fallback";
+            const fileId = await filestore.add(fileName, largeFile);
+
+            const filestoreReader = await peer2.open<Files>(filestore.address);
+            await filestoreReader.files.log.waitForReplicator(
+                peer.identity.publicKey
+            );
+
+            const file = await filestoreReader.files.index.get(fileId);
+            expect(file).to.be.instanceOf(LargeFile);
+
+            const writerHash = peer.identity.publicKey.hashcode();
+            (filestoreReader as any).getReadPeerHints = async () => [
+                writerHash,
+            ];
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
+            const delayedChunkId = `${fileId}:1`;
+            let indexedChunkGets = 0;
+            let exactNonReplicatingGets = 0;
+            let indexedPreciseSearches = 0;
+            let resolvedPreciseSearches = 0;
+            let parentChunkSearches = 0;
+
+            (filestoreReader.files.index as any).get = async (
+                id: string,
+                options: {
+                    resolve?: boolean;
+                    remote?:
+                        | {
+                              from?: string[];
+                              replicate?: boolean;
+                              strategy?: string;
+                          }
+                        | false;
+                }
+            ) => {
+                if (id === delayedChunkId) {
+                    const remote = options?.remote;
+                    if (remote === false) {
+                        return undefined;
+                    }
+                    if (remote?.replicate === false) {
+                        exactNonReplicatingGets++;
+                        return undefined;
+                    }
+                    if (options?.resolve === false) {
+                        indexedChunkGets++;
+                        return originalGet(id as never, options as never);
+                    }
+                    return undefined;
+                }
+                return originalGet(id as never, options as never);
+            };
+
+            (filestoreReader.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: {
+                    resolve?: boolean;
+                    remote?: false | { replicate?: boolean };
+                }
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasParentId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "parentId" &&
+                        getQueryValue(query) === fileId
+                );
+                const hasChunkName = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "name" &&
+                        getQueryValue(query) === `${fileName}/1`
+                );
+
+                if (hasParentId && hasChunkName) {
+                    if (
+                        options?.remote &&
+                        options.remote !== false &&
+                        options.remote.replicate === false &&
+                        options.resolve !== false
+                    ) {
+                        resolvedPreciseSearches++;
+                        return originalSearch(
+                            request as never,
+                            options as never
+                        );
+                    }
+                    indexedPreciseSearches++;
+                    return [];
+                }
+                if (hasParentId) {
+                    parentChunkSearches++;
+                    return [];
+                }
+
+                return originalSearch(request as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            await file!.writeFile(
+                filestoreReader,
+                {
+                    write: async (chunk) => {
+                        streamedChunks.push(chunk);
+                    },
+                },
+                { timeout: 20_000 }
+            );
+
+            expect(indexedChunkGets).to.be.greaterThan(0);
+            expect(indexedPreciseSearches).to.be.greaterThan(0);
+            expect(exactNonReplicatingGets).to.be.greaterThan(0);
+            expect(resolvedPreciseSearches).to.be.greaterThan(0);
+            expect(parentChunkSearches).to.eq(0);
+            expect(
+                filestoreReader.lastReadDiagnostics?.chunkResolved?.[1]
+            ).to.eq("resolved-search");
+            expect(streamedChunks.length).to.be.greaterThan(1);
+            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
         it("tries hinted non-replicating chunk reads when unhinted fallback misses", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -736,18 +736,69 @@ export class LargeFile extends AbstractFile {
                     },
                 } as any
             );
-            const chunk = chunks.find(
-                (candidate) =>
+            const chunk = (chunks as unknown[]).find(
+                (candidate): candidate is TinyFile =>
                     candidate instanceof TinyFile &&
                     candidate.parentId === this.id &&
                     candidate.index === index
-            ) as TinyFile | undefined;
+            );
             if (chunk) {
                 knownChunks.set(index, chunk);
                 files.retainResolvedChunk(chunk);
                 properties?.debug &&
                     ((properties.debug.chunkResolved ||= {})[index] =
                         "indexed-search");
+                return chunk;
+            }
+        };
+        const resolveChunkByResolvedFields = async (
+            remoteFrom: string[] | undefined
+        ): Promise<TinyFile | undefined> => {
+            properties?.debug &&
+                ((properties.debug.chunkResolvedSearches ||= {})[index] =
+                    ((properties.debug.chunkResolvedSearches ||= {})[index] ??
+                        0) + 1);
+            const chunks = await files.files.index.search(
+                new SearchRequest({
+                    query: [
+                        new StringMatch({
+                            key: "parentId",
+                            value: this.id,
+                            caseInsensitive: false,
+                            method: StringMatchMethod.exact,
+                        }),
+                        new StringMatch({
+                            key: "name",
+                            value: `${this.name}/${index}`,
+                            caseInsensitive: false,
+                            method: StringMatchMethod.exact,
+                        }),
+                    ],
+                    fetch: 1,
+                }),
+                {
+                    local: false,
+                    remote: {
+                        timeout: attemptTimeout,
+                        throwOnMissing: false,
+                        retryMissingResponses: true,
+                        replicate: false,
+                        from: remoteFrom,
+                    },
+                } as any
+            );
+            const chunk = (chunks as unknown[]).find(
+                (candidate): candidate is TinyFile =>
+                    candidate instanceof TinyFile &&
+                    candidate.parentId === this.id &&
+                    candidate.index === index
+            );
+            if (chunk) {
+                knownChunks.set(index, chunk);
+                files.retainResolvedChunk(chunk);
+                properties?.debug &&
+                    ((properties.debug.chunkResolved ||= {})[index] =
+                        "resolved-search");
                 return chunk;
             }
         };
@@ -892,14 +943,20 @@ export class LargeFile extends AbstractFile {
                             ((properties.debug.chunkGetMisses ||= {})[index] ??
                                 0) + 1);
                     directMisses += 1;
-                    await sleep(250);
-                    continue;
+                    if (
+                        directMisses + retryableFailures <
+                        nextNonReplicatingReadAfterFailures
+                    ) {
+                        await sleep(250);
+                        continue;
+                    }
+                } else {
+                    properties?.debug &&
+                        ((properties.debug.chunkGetMisses ||= {})[index] =
+                            ((properties.debug.chunkGetMisses ||= {})[index] ??
+                                0) + 1);
+                    directMisses += 1;
                 }
-                properties?.debug &&
-                    ((properties.debug.chunkGetMisses ||= {})[index] =
-                        ((properties.debug.chunkGetMisses ||= {})[index] ?? 0) +
-                        1);
-                directMisses += 1;
             } catch (error) {
                 if (!isRetryableChunkLookupError(error)) {
                     properties?.debug &&
@@ -984,6 +1041,35 @@ export class LargeFile extends AbstractFile {
                         retryableFailures += 1;
                         properties?.debug &&
                             ((properties.debug.chunkRetryableNonReplicatingGetErrors ||=
+                                {})[index] = getErrorMessage(error));
+                    }
+                }
+                for (const fallbackFrom of fallbackSources) {
+                    try {
+                        const chunk =
+                            await resolveChunkByResolvedFields(fallbackFrom);
+                        if (chunk) {
+                            return chunk;
+                        }
+                    } catch (error) {
+                        if (!isRetryableChunkLookupError(error)) {
+                            properties?.debug &&
+                                (properties.debug.chunkFailure = {
+                                    index,
+                                    type: "non-retryable-resolved-search",
+                                    message: getErrorMessage(error),
+                                });
+                            throw error;
+                        }
+                        if (
+                            fallbackFrom &&
+                            shouldRetryChunkLookupWithoutHints(error)
+                        ) {
+                            hintedDeliveryFailures += 1;
+                        }
+                        retryableFailures += 1;
+                        properties?.debug &&
+                            ((properties.debug.chunkRetryableResolvedSearchErrors ||=
                                 {})[index] = getErrorMessage(error));
                     }
                 }


### PR DESCRIPTION
## Summary
- add a `reader_role` input to the two-runner file-share benchmark workflow
- pass the selected role into the reader runner and record it in reader artifacts
- default the two-runner workflow to adaptive reads so the hosted benchmark can catch adaptive replication regressions, while preserving observer as an explicit option
- fix adaptive persisted reads when the indexed chunk entry is visible but cannot materialize locally because the chunk is outside the reader's adaptive shard; after the existing indexed/exact attempts miss, the reader asks for the specific chunk as a resolved non-replicating read and streams that value
- make benchmark download helpers wait for the download button to become enabled so large-file ready propagation is not mistaken for a transfer failure

## Verification
- `pnpm exec prettier --check .github/workflows/file-share-two-runner-benchmarks.yml packages/file-share/frontend/tests/two-runner.bench.mjs packages/file-share/frontend/tests/helpers.ts packages/file-share/library/src/index.ts packages/file-share/library/src/__tests__/index.integration.test.ts`
- `node --check packages/file-share/frontend/tests/two-runner.bench.mjs`
- `COORDINATION_FILE=/tmp/peerbit-two-runner-smoke.json PW_RESULT_FILE=/tmp/peerbit-two-runner-smoke-result.json PW_READER_ROLE=adaptive node packages/file-share/frontend/tests/two-runner.bench.mjs smoke`
- `pnpm --filter @peerbit/please-lib exec vitest run src/__tests__/index.integration.test.ts -t "resolved precise search"`
- `pnpm --filter @peerbit/please-lib exec vitest run src/__tests__/index.integration.test.ts -t "pipelines persisted chunk reads|resolved precise search|non-replicating chunk reads|tries hinted non-replicating|keeps read peer hints|parent chunk search|indexed chunk search"`
- `pnpm --filter @peerbit/please-lib test`
- `pnpm --filter @peerbit/please-lib build`
- `pnpm --filter file-share build`
- `git diff --check`
- Hosted adaptive two-runner benchmark 25064731441 failed on `94d2aef`, exposing the adaptive reader unresolved-chunk case this PR now fixes
- Hosted adaptive two-runner benchmark 25065963735 still failed on `965eba1` because it targets the deployed `https://files.dao.xyz` bundle, not this unmerged runtime fix; artifact confirmed no `chunkResolvedSearches` diagnostics from this branch were present
- Branch-built local adaptive benchmark 25066602884 failed before transfer because the benchmark clicked while the large-file download button was still disabled; this PR now waits for ready downloads
- Branch-built local adaptive benchmark 25066988088 passed on `4de9b3b` with a 512 MiB file: upload 111.017s / 38.69 Mbps, discovery 0.356s, download 269.386s / 15.94 Mbps, all 256 chunks written, no chunk failure
