### PR TITLE
Retain authored file-share chunks for adaptive readers

### DIFF
--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -643,6 +643,9 @@ export const Drop = () => {
                 ? Math.max(60_000, Math.ceil(Number(file.size) / 1e6) * 1_000)
                 : 10_000;
         try {
+            if (file instanceof LargeFile) {
+                files.program?.retainFileRead(file);
+            }
             scheduleAdaptiveRefresh("download-start");
 
             const saveFilePicker = (window as SaveFilePickerWindow)

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -75,6 +75,56 @@ describe("index", () => {
     });
 
     describe("large file", () => {
+        it("keeps self-signed shallow chunk entries during adaptive pruning", async () => {
+            const filestore = await peer.open(new Files());
+            const entryHash = "self-signed-chunk-entry";
+
+            expect(
+                await (filestore as any).shouldKeepFileEntry({
+                    hash: entryHash,
+                    signatures: [{ publicKey: peer.identity.publicKey }],
+                })
+            ).to.be.true;
+        });
+
+        it("keeps retained shallow chunk entries by metadata during adaptive pruning", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileId = await filestore.add(
+                "metadata retained chunks",
+                largeFile
+            );
+            const retainedChunkId = `${fileId}:2`;
+            const retainedChunk = await filestore.files.index.get(
+                retainedChunkId,
+                {
+                    local: true,
+                    remote: false,
+                }
+            );
+            const retainedHead = (retainedChunk as any).__context.head;
+            const shallowEntry =
+                await filestore.files.log.log.getShallow(retainedHead);
+            const originalGet = filestore.files.log.log.get.bind(
+                filestore.files.log.log
+            );
+
+            expect(shallowEntry?.meta.data?.byteLength).to.be.greaterThan(0);
+            filestore.retainChunkRead(retainedChunkId);
+
+            (filestore.files.log.log as any).get = async () => {
+                throw new Error("full entry payload should not be required");
+            };
+
+            try {
+                expect(
+                    await (filestore as any).shouldKeepFileEntry(shallowEntry)
+                ).to.be.true;
+            } finally {
+                (filestore.files.log.log as any).get = originalGet;
+            }
+        });
+
         it("stores upload-scoped chunks for repeated large-file segments", async () => {
             // Peer 1 is subscribing to a replication topic (to start helping the network)
             const filestore = await peer.open(new Files());
@@ -194,6 +244,32 @@ describe("index", () => {
 
             expect(streamedChunks.length).to.be.greaterThan(1);
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
+        it("pins persisted large-file chunk reads before streaming starts", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileId = await filestore.add(
+                "pinned streamed download",
+                largeFile
+            );
+            const file = (await filestore.files.index.get(fileId)) as LargeFile;
+            const retainedChunks = new Set<string>();
+            const retainChunkRead = filestore.retainChunkRead.bind(filestore);
+            let firstWriteRetainedCount: number | undefined;
+
+            (filestore as any).retainChunkRead = (chunkId: string) => {
+                retainedChunks.add(chunkId);
+                return retainChunkRead(chunkId);
+            };
+
+            await file.writeFile(filestore, {
+                write: async () => {
+                    firstWriteRetainedCount ??= retainedChunks.size;
+                },
+            });
+
+            expect(firstWriteRetainedCount).to.eq(file.chunkCount);
         });
 
         it("records diagnostics for chunked uploads", async () => {

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -1,4 +1,11 @@
-import { field, variant, vec, option } from "@dao-xyz/borsh";
+import {
+    deserialize,
+    field,
+    option,
+    serialize,
+    variant,
+    vec,
+} from "@dao-xyz/borsh";
 import { Program, ProgramHandler } from "@peerbit/program";
 import {
     Documents,
@@ -296,6 +303,16 @@ export class IndexableFile {
     }
 }
 
+@variant("files_entry_metadata")
+class FileEntryMetadata {
+    @field({ type: "string" })
+    id: string;
+
+    constructor(properties?: { id: string }) {
+        this.id = properties?.id ?? "";
+    }
+}
+
 const TINY_FILE_SIZE_LIMIT = 5 * 1e6; // 6mb
 const LARGE_FILE_SEGMENT_SIZE = TINY_FILE_SIZE_LIMIT / 10;
 const LARGE_FILE_TARGET_CHUNK_COUNT = 256;
@@ -337,6 +354,25 @@ const getEntryHash = (entry: unknown) =>
     typeof (entry as { hash?: unknown })?.hash === "string"
         ? (entry as { hash: string }).hash
         : undefined;
+const getEntrySignatures = (entry: unknown) => {
+    const signatures = (entry as { signatures?: unknown })?.signatures;
+    return Array.isArray(signatures)
+        ? (signatures as {
+              publicKey?: { equals?: (key: unknown) => boolean };
+          }[])
+        : undefined;
+};
+const getEntryMetadata = (entry: unknown) => {
+    const data = (entry as { meta?: { data?: unknown } })?.meta?.data;
+    if (!(data instanceof Uint8Array)) {
+        return undefined;
+    }
+    try {
+        return deserialize(data, FileEntryMetadata);
+    } catch {
+        return undefined;
+    }
+};
 const getContextHead = (value: unknown) =>
     typeof (value as { __context?: { head?: unknown } })?.__context?.head ===
     "string"
@@ -408,6 +444,10 @@ const readBlobSequentialChunks = async function* (
         reader.releaseLock();
     }
 };
+const getEntryMetadataForFile = (file: AbstractFile) =>
+    file.parentId != null
+        ? serialize(new FileEntryMetadata({ id: file.id }))
+        : undefined;
 const ensureSourceSize = (actual: bigint, expected: bigint) => {
     if (actual !== expected) {
         throw new Error(
@@ -1217,6 +1257,9 @@ export class LargeFile extends AbstractFile {
         const resolvedFile = await this.waitUntilReady(files, properties);
         debug.waitUntilReadyResolvedAt = Date.now();
         debug.waitUntilReadyResolvedReady = resolvedFile.ready;
+        if (files.persistChunkReads) {
+            files.retainFileRead(resolvedFile);
+        }
 
         properties?.progress?.(0);
 
@@ -1443,11 +1486,57 @@ export class Files extends Program<Args> {
         }
     }
 
+    retainFileRead(file: AbstractFile) {
+        if (file instanceof TinyFile && file.parentId != null) {
+            this.retainChunkRead(file.id);
+            return;
+        }
+        if (file instanceof LargeFile) {
+            for (let index = 0; index < file.chunkCount; index++) {
+                this.retainChunkRead(getChunkId(file.id, index));
+            }
+        }
+    }
+
+    private retainAuthoredChunk(chunk: TinyFile, entryHash?: string) {
+        if (chunk.parentId != null) {
+            this.retainChunkRead(chunk.id);
+        }
+        if (entryHash) {
+            this.retainedChunkEntryHeads ??= new Set();
+            this.retainedChunkEntryHeads.add(entryHash);
+        }
+    }
+
     private async shouldKeepFileEntry(entryLike: unknown) {
         this.retainedChunkIds ??= new Set();
         this.retainedChunkEntryHeads ??= new Set();
         const hash = getEntryHash(entryLike);
         if (hash && this.retainedChunkEntryHeads.has(hash)) {
+            return true;
+        }
+
+        const metadata = getEntryMetadata(entryLike);
+        if (metadata && this.retainedChunkIds.has(metadata.id)) {
+            if (hash) {
+                this.retainedChunkEntryHeads.add(hash);
+            }
+            return true;
+        }
+
+        const isSignedBySelf = (
+            signatures:
+                | { publicKey?: { equals?: (key: unknown) => boolean } }[]
+                | undefined
+        ) =>
+            signatures?.some((signature) =>
+                signature.publicKey?.equals?.(this.node.identity.publicKey)
+            ) === true;
+
+        if (isSignedBySelf(getEntrySignatures(entryLike))) {
+            if (hash) {
+                this.retainedChunkEntryHeads.add(hash);
+            }
             return true;
         }
 
@@ -1472,24 +1561,28 @@ export class Files extends Program<Args> {
             return false;
         }
 
-        if (!entry) {
-            return false;
+        if (isSignedBySelf(getEntrySignatures(entry))) {
+            const entryHash = hash ?? getEntryHash(entry);
+            if (entryHash) {
+                this.retainedChunkEntryHeads.add(entryHash);
+            }
+            return true;
         }
 
-        const signatures = (
-            entry as {
-                signatures?: {
-                    publicKey?: { equals?: (key: unknown) => boolean };
-                }[];
-            }
-        ).signatures;
+        const resolvedMetadata = getEntryMetadata(entry);
         if (
-            signatures?.some((signature) =>
-                signature.publicKey?.equals?.(this.node.identity.publicKey)
-            )
+            resolvedMetadata &&
+            this.retainedChunkIds.has(resolvedMetadata.id)
         ) {
-            this.retainedChunkEntryHeads.add(entry.hash);
+            const entryHash = hash ?? getEntryHash(entry);
+            if (entryHash) {
+                this.retainedChunkEntryHeads.add(entryHash);
+            }
             return true;
+        }
+
+        if (!entry) {
+            return false;
         }
 
         if (!this.persistChunkReads) {
@@ -1629,14 +1722,17 @@ export class Files extends Program<Args> {
             let chunkCount = 0;
             for await (const chunkBytes of source.readChunks(chunkSize)) {
                 hasher.update(chunkBytes);
-                await this.files.put(
-                    new TinyFile({
-                        name: name + "/" + chunkCount,
-                        file: chunkBytes,
-                        parentId: uploadId,
-                        index: chunkCount,
-                    })
-                );
+                const chunk = new TinyFile({
+                    name: name + "/" + chunkCount,
+                    file: chunkBytes,
+                    parentId: uploadId,
+                    index: chunkCount,
+                });
+                this.retainAuthoredChunk(chunk);
+                const appended = await this.files.put(chunk, {
+                    meta: { data: getEntryMetadataForFile(chunk) },
+                });
+                this.retainAuthoredChunk(chunk, appended.entry.hash);
                 uploadedBytes += BigInt(chunkBytes.byteLength);
                 chunkCount++;
                 progress?.(Number(uploadedBytes) / Math.max(Number(size), 1));
@@ -1742,14 +1838,17 @@ export class Files extends Program<Args> {
                 hasher.update(chunkBytes);
                 const putStartedAt = Date.now();
                 diagnostics.firstChunkStartedAt ??= putStartedAt;
-                await this.files.put(
-                    new TinyFile({
-                        name: name + "/" + i,
-                        file: chunkBytes,
-                        parentId: uploadId,
-                        index: i,
-                    })
-                );
+                const chunk = new TinyFile({
+                    name: name + "/" + i,
+                    file: chunkBytes,
+                    parentId: uploadId,
+                    index: i,
+                });
+                this.retainAuthoredChunk(chunk);
+                const appended = await this.files.put(chunk, {
+                    meta: { data: getEntryMetadataForFile(chunk) },
+                });
+                this.retainAuthoredChunk(chunk, appended.entry.hash);
                 const putFinishedAt = Date.now();
                 const putDurationMs = putFinishedAt - putStartedAt;
                 diagnostics.firstChunkFinishedAt ??= putFinishedAt;


### PR DESCRIPTION
## Summary
- preserve retained file-share chunk entries even when adaptive pruning only sees shallow log metadata
- retain authored chunk ids and entry heads during large-file uploads
- pin large-file read intent before download-start adaptive refresh and before persisted streaming read-ahead
- add regressions for self-signed shallow entries, retained shallow chunk metadata, and pre-stream chunk pinning

## Why
Hosted adaptive two-runner benchmark 25067855952 still failed after PR #102. The reader saw the file ready and had local chunk index rows, but failed resolving chunk 9/256 after repeated indexed, exact, resolved-search, and parent-search fallbacks. The writer had all 256 chunks locally, so the failure pointed at payload log entries being pruned while index rows remained visible.

PR #103 then exposed two reader-side races in branch benchmarks. Run 25068980091 showed download-start adaptive refresh could prune early read-ahead chunks before streaming retained them. Run 25069862770 still failed after stream pre-pinning: index 2 was lost while neighboring chunks were local, which showed the keep callback also needs to recognize retained chunks from shallow metadata without loading the full payload.

The fix keeps adaptive replication enabled. It marks real read intent before rebalancing and gives chunk entries a small metadata id so the pruning keep predicate can preserve retained chunks even when the full entry payload is not locally materializable.

## Verification
- `pnpm --filter @peerbit/please-lib exec vitest run src/__tests__/index.integration.test.ts -t "keeps self-signed shallow|keeps retained shallow|pins persisted|resolved precise search"`
- `pnpm --filter @peerbit/please-lib test`
- `pnpm --filter @peerbit/please-lib build`
- `pnpm --filter file-share build`
- `pnpm exec prettier --check packages/file-share/library/src/index.ts packages/file-share/library/src/__tests__/index.integration.test.ts packages/file-share/frontend/src/Drop.tsx`
- `git diff --check`

## Benchmark History
- `25067855952`: hosted adaptive two-runner on deployed #102 failed at chunk 9/256
- `25068980091`: branch local adaptive #103 failed in early read-ahead during download-start refresh
- `25069862770`: branch local adaptive #103 failed at chunk 3/256 after shallow retained chunks were still pruned
- `25070778629`: branch local adaptive on `240edb7` passed, 512 MiB, 256/256 chunks written, upload `114.0s` / `37.7 Mbps`, discovery `1.0s`, download `111.9s` / `38.4 Mbps`