### PR TITLE
Fix adaptive file-share chunk fallback resolution

### DIFF
--- a/packages/file-share/frontend/src/File.tsx
+++ b/packages/file-share/frontend/src/File.tsx
@@ -22,7 +22,7 @@ export const File = (properties: {
     const largeFile =
         properties.file instanceof LargeFile ? properties.file : undefined;
     const chunkCount = largeFile?.chunkCount ?? 0;
-    const downloadDisabled = progress != null || !!(largeFile && !largeFile.ready);
+    const downloadDisabled = progress != null;
 
     useEffect(() => {
         if (!properties.files) {
@@ -38,23 +38,20 @@ export const File = (properties: {
                             Math.round((count * 100) / Math.max(chunkCount, 1))
                         );
                 });
-        let changeListener =
-            largeFile
-                ? (
-                      e: CustomEvent<
-                          DocumentsChange<AbstractFile, IndexableFile>
-                      >
-                  ) => {
-                      for (const added of e.detail.added) {
-                          if (
-                              added instanceof TinyFile &&
-                              added.parentId === properties.file.id
-                          ) {
-                              fetchLocalChunks();
-                          }
+        let changeListener = largeFile
+            ? (
+                  e: CustomEvent<DocumentsChange<AbstractFile, IndexableFile>>
+              ) => {
+                  for (const added of e.detail.added) {
+                      if (
+                          added instanceof TinyFile &&
+                          added.parentId === properties.file.id
+                      ) {
+                          fetchLocalChunks();
                       }
                   }
-                : undefined;
+              }
+            : undefined;
 
         changeListener &&
             properties.files.files.events.addEventListener(
@@ -113,6 +110,7 @@ export const File = (properties: {
                 disabled={downloadDisabled}
                 onClick={() => {
                     setFailedDownload(false);
+                    setProgess(0);
                     properties
                         .download((p) => {
                             setProgess(p);

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -1,5 +1,11 @@
 import { Peerbit } from "peerbit";
-import { Files, IndexableFile, LargeFile, TinyFile } from "../index.js";
+import {
+    Files,
+    IndexableFile,
+    LargeFile,
+    LargeFileWithChunkHeads,
+    TinyFile,
+} from "../index.js";
 import { concat, equals } from "uint8arrays";
 import crypto from "crypto";
 import { delay, waitForResolved } from "@peerbit/time";
@@ -11,6 +17,9 @@ const getQueryKey = (query: any) =>
     Array.isArray(query?.key) ? query.key.join(".") : query?.key;
 
 const getQueryValue = (query: any) => query?.value?.value ?? query?.value;
+const stripChunkEntryHeads = (file: LargeFile | undefined) => {
+    (file as any).chunkEntryHeads = undefined;
+};
 
 describe("index", () => {
     let peer: Peerbit, peer2: Peerbit;
@@ -123,6 +132,24 @@ describe("index", () => {
             } finally {
                 (filestore.files.log.log as any).get = originalGet;
             }
+        });
+
+        it("keeps ready root manifests during adaptive pruning", async () => {
+            const writer = await peer.open(new Files());
+            const reader = await peer2.open<Files>(writer.address);
+            const readyRoot = new LargeFileWithChunkHeads({
+                id: "adaptive-root-ready",
+                name: "adaptive-root-ready.bin",
+                size: 12n * 1024n * 1024n,
+                chunkCount: 2,
+                ready: true,
+                finalHash: "final-hash",
+                chunkEntryHeads: ["chunk-head-0", "chunk-head-1"],
+            });
+            const appended = await writer.files.put(readyRoot);
+
+            expect(await (reader as any).shouldKeepFileEntry(appended.entry)).to
+                .be.true;
         });
 
         it("stores upload-scoped chunks for repeated large-file segments", async () => {
@@ -317,6 +344,7 @@ describe("index", () => {
 
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
+            stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
                 filestoreReader.files.index
@@ -460,6 +488,7 @@ describe("index", () => {
 
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
+            stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
                 filestoreReader.files.index
@@ -534,6 +563,7 @@ describe("index", () => {
 
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
+            stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
                 filestoreReader.files.index
@@ -619,6 +649,7 @@ describe("index", () => {
 
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
+            stripChunkEntryHeads(file);
 
             const writerHash = peer.identity.publicKey.hashcode();
             (filestoreReader as any).getReadPeerHints = async () => [
@@ -630,8 +661,21 @@ describe("index", () => {
             const originalGet = filestoreReader.files.index.get.bind(
                 filestoreReader.files.index
             );
+            const originalLogGet = filestoreReader.files.log.log.get.bind(
+                filestoreReader.files.log.log
+            );
             const delayedChunkId = `${fileId}:1`;
+            const writerIndexed = await filestore.files.index.get(
+                delayedChunkId,
+                {
+                    resolve: false,
+                    local: true,
+                    remote: false,
+                } as any
+            );
+            const writerHead = (writerIndexed as any)?.__context?.head;
             let indexedChunkGets = 0;
+            let indexedHeadGets = 0;
             let exactNonReplicatingGets = 0;
             let indexedPreciseSearches = 0;
             let resolvedPreciseSearches = 0;
@@ -713,19 +757,35 @@ describe("index", () => {
                 return originalSearch(request as never, options as never);
             };
 
+            (filestoreReader.files.log.log as any).get = async (
+                hash: string,
+                options: { remote?: unknown }
+            ) => {
+                if (hash === writerHead && options?.remote) {
+                    indexedHeadGets++;
+                    return undefined;
+                }
+                return originalLogGet(hash as never, options as never);
+            };
+
             const streamedChunks: Uint8Array[] = [];
 
-            await file!.writeFile(
-                filestoreReader,
-                {
-                    write: async (chunk) => {
-                        streamedChunks.push(chunk);
+            try {
+                await file!.writeFile(
+                    filestoreReader,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
                     },
-                },
-                { timeout: 20_000 }
-            );
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestoreReader.files.log.log as any).get = originalLogGet;
+            }
 
             expect(indexedChunkGets).to.be.greaterThan(0);
+            expect(indexedHeadGets).to.be.greaterThan(0);
             expect(indexedPreciseSearches).to.be.greaterThan(0);
             expect(exactNonReplicatingGets).to.be.greaterThan(0);
             expect(resolvedPreciseSearches).to.be.greaterThan(0);
@@ -733,6 +793,1352 @@ describe("index", () => {
             expect(
                 filestoreReader.lastReadDiagnostics?.chunkResolved?.[1]
             ).to.eq("resolved-search");
+            expect(streamedChunks.length).to.be.greaterThan(1);
+            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
+        it("materializes an adaptive indexed chunk from its entry head", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileName = "streamed download with indexed head fallback";
+            const fileId = await filestore.add(fileName, largeFile);
+            const delayedChunkId = `${fileId}:1`;
+            const writerIndexed = await filestore.files.index.get(
+                delayedChunkId,
+                {
+                    resolve: false,
+                    local: true,
+                    remote: false,
+                } as any
+            );
+            const writerHead = (writerIndexed as any)?.__context?.head;
+            const writerEntry = writerHead
+                ? await filestore.files.log.log.get(writerHead)
+                : undefined;
+            expect(writerIndexed).to.be.instanceOf(IndexableFile);
+            expect(writerHead).to.be.a("string");
+            expect(writerEntry).to.exist;
+
+            const filestoreReader = await peer2.open<Files>(filestore.address);
+            await filestoreReader.files.log.waitForReplicator(
+                peer.identity.publicKey
+            );
+
+            const file = await filestoreReader.files.index.get(fileId);
+            expect(file).to.be.instanceOf(LargeFile);
+            stripChunkEntryHeads(file);
+
+            const writerHash = peer.identity.publicKey.hashcode();
+            (filestoreReader as any).getReadPeerHints = async () => [
+                writerHash,
+            ];
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
+            const originalLogGet = filestoreReader.files.log.log.get.bind(
+                filestoreReader.files.log.log
+            );
+            const originalIterate =
+                filestoreReader.files.log.log.entryIndex.iterate.bind(
+                    filestoreReader.files.log.log.entryIndex
+                );
+            let indexedChunkGets = 0;
+            let headChunkGets = 0;
+            let preciseSearches = 0;
+
+            (filestoreReader.files.index as any).get = async (
+                id: string,
+                options: {
+                    resolve?: boolean;
+                    remote?:
+                        | {
+                              replicate?: boolean;
+                          }
+                        | false;
+                }
+            ) => {
+                if (id === delayedChunkId) {
+                    if (options?.remote === false) {
+                        return undefined;
+                    }
+                    if (options?.resolve === false) {
+                        indexedChunkGets++;
+                        return writerIndexed;
+                    }
+                    return undefined;
+                }
+                return originalGet(id as never, options as never);
+            };
+
+            (filestoreReader.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                if (
+                    queries.some(
+                        (query: any) =>
+                            getQueryKey(query) === "parentId" &&
+                            getQueryValue(query) === fileId
+                    ) &&
+                    queries.some(
+                        (query: any) =>
+                            getQueryKey(query) === "name" &&
+                            getQueryValue(query) === `${fileName}/1`
+                    )
+                ) {
+                    preciseSearches++;
+                    return [];
+                }
+                return originalSearch(request as never, options as never);
+            };
+
+            (filestoreReader.files.log.log as any).get = async (
+                hash: string,
+                options: { remote?: unknown }
+            ) => {
+                if (hash === writerHead && options?.remote) {
+                    headChunkGets++;
+                    return writerEntry;
+                }
+                return originalLogGet(hash as never, options as never);
+            };
+
+            (filestoreReader.files.log.log.entryIndex as any).iterate = () => ({
+                done: () => true,
+                next: async () => [],
+                all: async () => [],
+                close: async () => {},
+            });
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await file!.writeFile(
+                    filestoreReader,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestoreReader.files.index as any).get = originalGet;
+                (filestoreReader.files.index as any).search = originalSearch;
+                (filestoreReader.files.log.log as any).get = originalLogGet;
+                (filestoreReader.files.log.log.entryIndex as any).iterate =
+                    originalIterate;
+            }
+
+            expect(indexedChunkGets).to.be.greaterThan(0);
+            expect(headChunkGets).to.be.greaterThan(0);
+            expect(preciseSearches).to.eq(0);
+            expect(
+                filestoreReader.lastReadDiagnostics?.chunkResolved?.[1]
+            ).to.eq("indexed-head-get");
+            expect(streamedChunks.length).to.be.greaterThan(1);
+            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
+        it("materializes a locally joined chunk entry when the document index lags", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileName = "streamed download with local metadata fallback";
+            const fileId = await filestore.add(fileName, largeFile);
+            const delayedChunkId = `${fileId}:1`;
+            const writerIndexed = await filestore.files.index.get(
+                delayedChunkId,
+                {
+                    resolve: false,
+                    local: true,
+                    remote: false,
+                } as any
+            );
+            const writerHead = (writerIndexed as any)?.__context?.head;
+            const writerEntry = writerHead
+                ? await filestore.files.log.log.get(writerHead)
+                : undefined;
+            const writerShallow = writerHead
+                ? await filestore.files.log.log.getShallow(writerHead)
+                : undefined;
+            expect(writerHead).to.be.a("string");
+            expect(writerEntry).to.exist;
+            expect(writerShallow?.meta.data?.byteLength).to.be.greaterThan(0);
+
+            const filestoreReader = await peer2.open<Files>(filestore.address);
+            await filestoreReader.files.log.waitForReplicator(
+                peer.identity.publicKey
+            );
+
+            const file = await filestoreReader.files.index.get(fileId);
+            expect(file).to.be.instanceOf(LargeFile);
+            stripChunkEntryHeads(file);
+
+            const writerHash = peer.identity.publicKey.hashcode();
+            (filestoreReader as any).getReadPeerHints = async () => [
+                writerHash,
+            ];
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
+            const originalLogGet = filestoreReader.files.log.log.get.bind(
+                filestoreReader.files.log.log
+            );
+            const originalIterate =
+                filestoreReader.files.log.log.entryIndex.iterate.bind(
+                    filestoreReader.files.log.log.entryIndex
+                );
+            let directChunkGets = 0;
+            let metadataScans = 0;
+            let metadataHeadGets = 0;
+            let preciseSearches = 0;
+
+            (filestoreReader.files.index as any).get = async (
+                id: string,
+                options: unknown
+            ) => {
+                if (id === delayedChunkId) {
+                    directChunkGets++;
+                    return undefined;
+                }
+                return originalGet(id as never, options as never);
+            };
+
+            (filestoreReader.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                if (
+                    queries.some(
+                        (query: any) =>
+                            getQueryKey(query) === "parentId" &&
+                            getQueryValue(query) === fileId
+                    )
+                ) {
+                    preciseSearches++;
+                    return [];
+                }
+                return originalSearch(request as never, options as never);
+            };
+
+            (filestoreReader.files.log.log.entryIndex as any).iterate = () => {
+                metadataScans++;
+                let returned = false;
+                return {
+                    done: () => returned,
+                    next: async () => {
+                        if (returned) {
+                            return [];
+                        }
+                        returned = true;
+                        return [writerShallow];
+                    },
+                    all: async () => [writerShallow],
+                    close: async () => {},
+                };
+            };
+
+            (filestoreReader.files.log.log as any).get = async (
+                hash: string,
+                options: unknown
+            ) => {
+                if (hash === writerHead) {
+                    metadataHeadGets++;
+                    return writerEntry;
+                }
+                return originalLogGet(hash as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await file!.writeFile(
+                    filestoreReader,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestoreReader.files.index as any).get = originalGet;
+                (filestoreReader.files.index as any).search = originalSearch;
+                (filestoreReader.files.log.log as any).get = originalLogGet;
+                (filestoreReader.files.log.log.entryIndex as any).iterate =
+                    originalIterate;
+            }
+
+            expect(directChunkGets).to.be.greaterThan(0);
+            expect(metadataScans).to.be.greaterThan(0);
+            expect(metadataHeadGets).to.be.greaterThan(0);
+            expect(preciseSearches).to.be.greaterThan(0);
+            expect(
+                filestoreReader.lastReadDiagnostics?.chunkResolved?.[1]
+            ).to.eq("local-entry-head");
+            expect(streamedChunks.length).to.be.greaterThan(1);
+            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
+        it("materializes an adaptive chunk from its ready manifest entry head when indexes miss", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileName = "streamed download with manifest head fallback";
+            const fileId = await filestore.add(fileName, largeFile);
+            const delayedChunkId = `${fileId}:1`;
+            const writerIndexed = await filestore.files.index.get(
+                delayedChunkId,
+                {
+                    resolve: false,
+                    local: true,
+                    remote: false,
+                } as any
+            );
+            const writerHead = (writerIndexed as any)?.__context?.head;
+            const writerEntry = writerHead
+                ? await filestore.files.log.log.get(writerHead)
+                : undefined;
+            expect(writerHead).to.be.a("string");
+            expect(writerEntry).to.exist;
+
+            const filestoreReader = await peer2.open<Files>(filestore.address);
+            await filestoreReader.files.log.waitForReplicator(
+                peer.identity.publicKey
+            );
+
+            const file = await filestoreReader.files.index.get(fileId);
+            expect(file).to.be.instanceOf(LargeFile);
+
+            const writerHash = peer.identity.publicKey.hashcode();
+            (filestoreReader as any).getReadPeerHints = async () => [
+                writerHash,
+            ];
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
+            const originalCountLocalChunks =
+                filestoreReader.countLocalChunks.bind(filestoreReader);
+            const originalLogGet = filestoreReader.files.log.log.get.bind(
+                filestoreReader.files.log.log
+            );
+            const originalIterate =
+                filestoreReader.files.log.log.entryIndex.iterate.bind(
+                    filestoreReader.files.log.log.entryIndex
+                );
+            let localChunkGets = 0;
+            let remoteChunkGets = 0;
+            let preciseSearches = 0;
+            let parentSearches = 0;
+            let manifestHeadGets = 0;
+
+            (filestoreReader as any).countLocalChunks = async () => 0;
+            (filestoreReader.files.index as any).get = async (
+                id: string,
+                options: unknown
+            ) => {
+                if (id === delayedChunkId) {
+                    if ((options as { remote?: unknown })?.remote) {
+                        remoteChunkGets++;
+                    } else {
+                        localChunkGets++;
+                    }
+                    return undefined;
+                }
+                return originalGet(id as never, options as never);
+            };
+
+            (filestoreReader.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasParentId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "parentId" &&
+                        getQueryValue(query) === fileId
+                );
+                const hasChunkName = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "name" &&
+                        getQueryValue(query) === `${fileName}/1`
+                );
+                if (hasParentId) {
+                    if (hasChunkName) {
+                        preciseSearches++;
+                    } else {
+                        parentSearches++;
+                    }
+                    return [];
+                }
+                return originalSearch(request as never, options as never);
+            };
+
+            (filestoreReader.files.log.log.entryIndex as any).iterate = () => ({
+                done: () => true,
+                next: async () => [],
+                all: async () => [],
+                close: async () => {},
+            });
+
+            (filestoreReader.files.log.log as any).get = async (
+                hash: string,
+                options: { remote?: unknown }
+            ) => {
+                if (hash === writerHead && options?.remote) {
+                    manifestHeadGets++;
+                    return writerEntry;
+                }
+                return originalLogGet(hash as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await file!.writeFile(
+                    filestoreReader,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestoreReader.files.index as any).get = originalGet;
+                (filestoreReader.files.index as any).search = originalSearch;
+                (filestoreReader as any).countLocalChunks =
+                    originalCountLocalChunks;
+                (filestoreReader.files.log.log as any).get = originalLogGet;
+                (filestoreReader.files.log.log.entryIndex as any).iterate =
+                    originalIterate;
+            }
+
+            expect(localChunkGets).to.be.greaterThan(0);
+            expect(remoteChunkGets).to.eq(0);
+            expect(preciseSearches).to.eq(0);
+            expect(parentSearches).to.eq(0);
+            expect(manifestHeadGets).to.be.greaterThan(0);
+            expect(
+                filestoreReader.lastReadDiagnostics?.chunkManifestHeads?.[1]
+            ).to.eq(writerHead);
+            expect(
+                filestoreReader.lastReadDiagnostics?.chunkResolved?.[1]
+            ).to.eq("manifest-head-get");
+            expect(streamedChunks.length).to.be.greaterThan(1);
+            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
+        it("uses ready manifest entry heads when streaming a pending adaptive manifest", async () => {
+            const filestore = await peer.open(new Files());
+            const filestoreReader = await peer2.open<Files>(filestore.address);
+            await filestoreReader.files.log.waitForReplicator(
+                peer.identity.publicKey
+            );
+
+            const fileName = "pending adaptive manifest head fallback";
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const originalPut = filestore.files.put.bind(filestore.files);
+            let uploadId: string | undefined;
+
+            (filestore.files as any).put = async (entry: unknown) => {
+                if (entry instanceof LargeFile && !entry.ready) {
+                    uploadId = entry.id;
+                }
+                if (entry instanceof TinyFile && entry.parentId != null) {
+                    await delay(250);
+                }
+                return originalPut(entry as never);
+            };
+
+            const addPromise = filestore.add(fileName, largeFile);
+            let pendingFile: LargeFile | undefined;
+            await waitForResolved(
+                async () => {
+                    expect(uploadId).to.be.ok;
+                    const match = await filestoreReader.resolveById(uploadId!, {
+                        replicate: true,
+                        timeout: 1_000,
+                    });
+                    expect(match).to.be.instanceOf(LargeFile);
+                    expect((match as LargeFile).ready).to.be.false;
+                    pendingFile = match as LargeFile;
+                },
+                { timeout: 30_000, delayInterval: 200 }
+            );
+
+            const fileId = await addPromise;
+            (filestore.files as any).put = originalPut;
+
+            const delayedChunkId = `${fileId}:1`;
+            const writerIndexed = await filestore.files.index.get(
+                delayedChunkId,
+                {
+                    resolve: false,
+                    local: true,
+                    remote: false,
+                } as any
+            );
+            const writerHead = (writerIndexed as any)?.__context?.head;
+            const writerEntry = writerHead
+                ? await filestore.files.log.log.get(writerHead)
+                : undefined;
+            expect(writerHead).to.be.a("string");
+            expect(writerEntry).to.exist;
+            (pendingFile as any).chunkEntryHeads = [];
+            (pendingFile as any).chunkEntryHeads[1] = writerHead;
+
+            const writerHash = peer.identity.publicKey.hashcode();
+            (filestoreReader as any).getReadPeerHints = async () => [
+                writerHash,
+            ];
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
+            const originalLogGet = filestoreReader.files.log.log.get.bind(
+                filestoreReader.files.log.log
+            );
+            const originalIterate =
+                filestoreReader.files.log.log.entryIndex.iterate.bind(
+                    filestoreReader.files.log.log.entryIndex
+                );
+            let localChunkGets = 0;
+            let remoteChunkGets = 0;
+            let preciseSearches = 0;
+            let parentSearches = 0;
+            let manifestHeadGets = 0;
+
+            (filestoreReader.files.index as any).get = async (
+                id: string,
+                options: unknown
+            ) => {
+                if (id === delayedChunkId) {
+                    if ((options as { remote?: unknown })?.remote) {
+                        remoteChunkGets++;
+                    } else {
+                        localChunkGets++;
+                    }
+                    return undefined;
+                }
+                return originalGet(id as never, options as never);
+            };
+
+            (filestoreReader.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasParentId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "parentId" &&
+                        getQueryValue(query) === fileId
+                );
+                const hasChunkName = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "name" &&
+                        getQueryValue(query) === `${fileName}/1`
+                );
+                if (hasParentId) {
+                    if (hasChunkName) {
+                        preciseSearches++;
+                    } else {
+                        parentSearches++;
+                    }
+                    return [];
+                }
+                return originalSearch(request as never, options as never);
+            };
+
+            (filestoreReader.files.log.log.entryIndex as any).iterate = () => ({
+                done: () => true,
+                next: async () => [],
+                all: async () => [],
+                close: async () => {},
+            });
+
+            (filestoreReader.files.log.log as any).get = async (
+                hash: string,
+                options: { remote?: unknown }
+            ) => {
+                if (hash === writerHead && options?.remote) {
+                    manifestHeadGets++;
+                    return writerEntry;
+                }
+                return originalLogGet(hash as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await pendingFile!.writeFile(
+                    filestoreReader,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestoreReader.files.index as any).get = originalGet;
+                (filestoreReader.files.index as any).search = originalSearch;
+                (filestoreReader.files.log.log as any).get = originalLogGet;
+                (filestoreReader.files.log.log.entryIndex as any).iterate =
+                    originalIterate;
+            }
+
+            expect(localChunkGets).to.be.greaterThan(0);
+            expect(remoteChunkGets).to.eq(0);
+            expect(preciseSearches).to.eq(0);
+            expect(parentSearches).to.eq(0);
+            expect(manifestHeadGets).to.be.greaterThan(0);
+            expect(
+                filestoreReader.lastReadDiagnostics?.chunkManifestHeads?.[1]
+            ).to.eq(writerHead);
+            expect(
+                filestoreReader.lastReadDiagnostics?.chunkResolved?.[1]
+            ).to.eq("manifest-head-get");
+            expect(streamedChunks.length).to.be.greaterThan(1);
+            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
+        it("streams a pending manifest when the complete chunk set is already local", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileName = "pending manifest with complete local chunks";
+            const fileId = await filestore.add(fileName, largeFile);
+            const pendingFile = new LargeFile({
+                id: fileId,
+                name: fileName,
+                size: BigInt(largeFile.byteLength),
+                chunkCount: filestore.lastUploadDiagnostics!.chunkCount,
+                ready: false,
+            });
+            const originalSearch = filestore.files.index.search.bind(
+                filestore.files.index
+            );
+
+            (filestore.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasRootId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "id" &&
+                        getQueryValue(query) === fileId
+                );
+                if (hasRootId) {
+                    return [pendingFile];
+                }
+                return originalSearch(request as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await pendingFile.writeFile(
+                    filestore,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestore.files.index as any).search = originalSearch;
+            }
+
+            expect(
+                filestore.lastReadDiagnostics?.waitUntilReadyResolvedBy
+            ).to.eq("complete-chunks");
+            expect(streamedChunks.length).to.be.greaterThan(1);
+            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
+        it("checks local complete chunks while read peer hints are present", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileName = "pending manifest with hinted complete chunks";
+            const fileId = await filestore.add(fileName, largeFile);
+            const pendingFile = new LargeFile({
+                id: fileId,
+                name: fileName,
+                size: BigInt(largeFile.byteLength),
+                chunkCount: filestore.lastUploadDiagnostics!.chunkCount,
+                ready: false,
+            });
+            const originalSearch = filestore.files.index.search.bind(
+                filestore.files.index
+            );
+            const originalGetReadPeerHints =
+                filestore.getReadPeerHints.bind(filestore);
+            let readPeerHintCalls = 0;
+            let localReadySearches = 0;
+
+            (filestore as any).getReadPeerHints = async () => {
+                readPeerHintCalls++;
+                return ["missing-read-peer"];
+            };
+            (filestore.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasRootId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "id" &&
+                        getQueryValue(query) === fileId
+                );
+                if (hasRootId) {
+                    if (
+                        (options as any)?.local === true &&
+                        (options as any)?.remote
+                    ) {
+                        throw new Error(
+                            "ready search must not combine local and remote"
+                        );
+                    }
+                    if ((options as any)?.local === true) {
+                        localReadySearches++;
+                        return [pendingFile];
+                    }
+                    return [];
+                }
+                return originalSearch(request as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await pendingFile.writeFile(
+                    filestore,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestore.files.index as any).search = originalSearch;
+                (filestore as any).getReadPeerHints = originalGetReadPeerHints;
+            }
+
+            expect(readPeerHintCalls).to.be.greaterThan(0);
+            expect(localReadySearches).to.be.greaterThan(0);
+            expect(
+                filestore.lastReadDiagnostics?.waitUntilReadyResolvedBy
+            ).to.eq("complete-chunks");
+            expect(
+                filestore.lastReadDiagnostics?.lastReadyProbe?.localChunkCount
+            ).to.eq(pendingFile.chunkCount);
+            expect(streamedChunks.length).to.be.greaterThan(1);
+            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
+        it("uses direct ready manifest gets when hinted ready search fails", async () => {
+            const filestore = await peer.open(new Files());
+            const fileName = "ready manifest get fallback";
+            const fileId = "ready-manifest-get-fallback";
+            const chunkCount = 128;
+            const expected = new Uint8Array(chunkCount);
+            const chunkEntryHeads: string[] = [];
+            for (let index = 0; index < chunkCount; index++) {
+                expected[index] = index % 256;
+                const appended = await filestore.files.put(
+                    new TinyFile({
+                        id: `${fileId}:${index}`,
+                        name: `${fileName}/${index}`,
+                        file: new Uint8Array([expected[index]]),
+                        parentId: fileId,
+                        index,
+                    })
+                );
+                chunkEntryHeads[index] = appended.entry.hash;
+            }
+            const pendingFile = new LargeFile({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount,
+                ready: false,
+            });
+            const readyFile = new LargeFileWithChunkHeads({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount,
+                ready: true,
+                chunkEntryHeads,
+            });
+            const readyPut = await filestore.files.put(readyFile);
+            const readyHead = readyPut.entry.hash;
+            const readyIndexed = await filestore.files.index.get(fileId, {
+                resolve: false,
+                local: true,
+                remote: false,
+            } as any);
+            const readyEntry = await filestore.files.log.log.get(readyHead);
+            expect(readyIndexed).to.exist;
+            expect(readyEntry).to.exist;
+            (readyIndexed as any).__context ??= {};
+            (readyIndexed as any).__context.head = readyHead;
+            const originalSearch = filestore.files.index.search.bind(
+                filestore.files.index
+            );
+            const originalGet = filestore.files.index.get.bind(
+                filestore.files.index
+            );
+            const originalLogGet = filestore.files.log.log.get.bind(
+                filestore.files.log.log
+            );
+            const originalCountLocalChunks =
+                filestore.countLocalChunks.bind(filestore);
+            const originalGetReadPeerHints =
+                filestore.getReadPeerHints.bind(filestore);
+            let remoteReadyFailures = 0;
+            let remoteReadyGets = 0;
+            let remoteReadyHeadGets = 0;
+            const delayedChunkId = `${fileId}:1`;
+
+            (filestore as any).getReadPeerHints = async () => [
+                "ready-manifest-peer",
+            ];
+            (filestore as any).countLocalChunks = async () => 0;
+            (filestore.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasRootId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "id" &&
+                        getQueryValue(query) === fileId
+                );
+                if (hasRootId) {
+                    if ((options as any)?.local === true) {
+                        return [pendingFile];
+                    }
+                    if ((options as any)?.remote) {
+                        remoteReadyFailures++;
+                        throw new Error("remote ready search failed");
+                    }
+                    return [];
+                }
+                return originalSearch(request as never, options as never);
+            };
+            (filestore.files.index as any).get = async (
+                id: string,
+                options: unknown
+            ) => {
+                if (id === fileId && (options as any)?.remote) {
+                    remoteReadyGets++;
+                    return readyIndexed;
+                }
+                if (id === delayedChunkId) {
+                    return undefined;
+                }
+                return originalGet(id as never, options as never);
+            };
+            (filestore.files.log.log as any).get = async (
+                hash: string,
+                options: unknown
+            ) => {
+                if (hash === readyHead && (options as any)?.remote) {
+                    remoteReadyHeadGets++;
+                    return readyEntry;
+                }
+                return originalLogGet(hash as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await pendingFile.writeFile(
+                    filestore,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestore.files.index as any).search = originalSearch;
+                (filestore.files.index as any).get = originalGet;
+                (filestore.files.log.log as any).get = originalLogGet;
+                (filestore as any).countLocalChunks = originalCountLocalChunks;
+                (filestore as any).getReadPeerHints = originalGetReadPeerHints;
+            }
+
+            expect(remoteReadyFailures).to.be.greaterThan(0);
+            expect(remoteReadyGets).to.be.greaterThan(0);
+            expect(remoteReadyHeadGets).to.be.greaterThan(0);
+            expect(
+                filestore.lastReadDiagnostics?.readyRemoteSearchErrors?.[0]
+            ).to.eq("remote ready search failed");
+            expect(
+                filestore.lastReadDiagnostics?.readyRemoteGetHeads?.[0]
+            ).to.eq(readyHead);
+            expect(
+                filestore.lastReadDiagnostics?.waitUntilReadyResolvedBy
+            ).to.eq("ready-manifest-head-get");
+            expect(
+                filestore.lastReadDiagnostics?.chunkManifestHeads?.[1]
+            ).to.eq(chunkEntryHeads[1]);
+            expect(filestore.lastReadDiagnostics?.chunkResolved?.[1]).to.eq(
+                "manifest-head-get"
+            );
+            expect(equals(concat(streamedChunks), expected)).to.be.true;
+        });
+
+        it("uses indexed ready manifest heads when hinted ready search fails", async () => {
+            const filestore = await peer.open(new Files());
+            const fileName = "ready manifest indexed head fallback";
+            const fileId = "ready-manifest-indexed-head-fallback";
+            const chunkCount = 4;
+            const expected = new Uint8Array(chunkCount);
+            const chunkEntryHeads: string[] = [];
+            for (let index = 0; index < chunkCount; index++) {
+                expected[index] = index % 256;
+                const appended = await filestore.files.put(
+                    new TinyFile({
+                        id: `${fileId}:${index}`,
+                        name: `${fileName}/${index}`,
+                        file: new Uint8Array([expected[index]]),
+                        parentId: fileId,
+                        index,
+                    })
+                );
+                chunkEntryHeads[index] = appended.entry.hash;
+            }
+            const pendingFile = new LargeFile({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount,
+                ready: false,
+            });
+            const readyFile = new LargeFileWithChunkHeads({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount,
+                ready: true,
+                chunkEntryHeads,
+            });
+            const readyPut = await filestore.files.put(readyFile);
+            const readyHead = readyPut.entry.hash;
+            const readyIndexed = await filestore.files.index.get(fileId, {
+                resolve: false,
+                local: true,
+                remote: false,
+            } as any);
+            const readyEntry = await filestore.files.log.log.get(readyHead);
+            expect(readyIndexed).to.exist;
+            expect(readyEntry).to.exist;
+            (readyIndexed as any).__context ??= {};
+            (readyIndexed as any).__context.head = readyHead;
+            const originalSearch = filestore.files.index.search.bind(
+                filestore.files.index
+            );
+            const originalGet = filestore.files.index.get.bind(
+                filestore.files.index
+            );
+            const originalLogGet = filestore.files.log.log.get.bind(
+                filestore.files.log.log
+            );
+            const originalCountLocalChunks =
+                filestore.countLocalChunks.bind(filestore);
+            const originalGetReadPeerHints =
+                filestore.getReadPeerHints.bind(filestore);
+            let remoteReadyFailures = 0;
+            let indexedReadySearches = 0;
+            let remoteReadyHeadGets = 0;
+            const delayedChunkId = `${fileId}:1`;
+
+            (filestore as any).getReadPeerHints = async () => [
+                "ready-manifest-peer",
+            ];
+            (filestore as any).countLocalChunks = async () => 0;
+            (filestore.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasRootId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "id" &&
+                        getQueryValue(query) === fileId
+                );
+                if (hasRootId) {
+                    if ((options as any)?.local === true) {
+                        return [pendingFile];
+                    }
+                    if ((options as any)?.remote) {
+                        if ((options as any)?.resolve === false) {
+                            indexedReadySearches++;
+                            return [readyIndexed];
+                        }
+                        remoteReadyFailures++;
+                        throw new Error("remote ready search failed");
+                    }
+                    return [];
+                }
+                return originalSearch(request as never, options as never);
+            };
+            (filestore.files.index as any).get = async (
+                id: string,
+                options: unknown
+            ) => {
+                if (id === delayedChunkId) {
+                    return undefined;
+                }
+                return originalGet(id as never, options as never);
+            };
+            (filestore.files.log.log as any).get = async (
+                hash: string,
+                options: unknown
+            ) => {
+                if (hash === readyHead && (options as any)?.remote) {
+                    remoteReadyHeadGets++;
+                    return readyEntry;
+                }
+                return originalLogGet(hash as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await pendingFile.writeFile(
+                    filestore,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestore.files.index as any).search = originalSearch;
+                (filestore.files.index as any).get = originalGet;
+                (filestore.files.log.log as any).get = originalLogGet;
+                (filestore as any).countLocalChunks = originalCountLocalChunks;
+                (filestore as any).getReadPeerHints = originalGetReadPeerHints;
+            }
+
+            expect(remoteReadyFailures).to.be.greaterThan(0);
+            expect(indexedReadySearches).to.be.greaterThan(0);
+            expect(remoteReadyHeadGets).to.be.greaterThan(0);
+            expect(
+                filestore.lastReadDiagnostics?.waitUntilReadyResolvedBy
+            ).to.eq("ready-manifest-head-search");
+            expect(
+                filestore.lastReadDiagnostics?.chunkManifestHeads?.[1]
+            ).to.eq(chunkEntryHeads[1]);
+            expect(filestore.lastReadDiagnostics?.chunkResolved?.[1]).to.eq(
+                "manifest-head-get"
+            );
+            expect(equals(concat(streamedChunks), expected)).to.be.true;
+        });
+
+        it("streams pending manifests when hinted ready search fails", async () => {
+            const filestore = await peer.open(new Files());
+            const fileName = "pending manifest with failing ready search";
+            const fileId = "pending-ready-search-fails";
+            const chunkCount = 128;
+            const expected = new Uint8Array(chunkCount);
+            for (let index = 0; index < chunkCount; index++) {
+                expected[index] = index % 256;
+                await filestore.files.put(
+                    new TinyFile({
+                        id: `${fileId}:${index}`,
+                        name: `${fileName}/${index}`,
+                        file: new Uint8Array([expected[index]]),
+                        parentId: fileId,
+                        index,
+                    })
+                );
+            }
+            const pendingFile = new LargeFile({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount,
+                ready: false,
+            });
+            const originalSearch = filestore.files.index.search.bind(
+                filestore.files.index
+            );
+            const originalCountLocalChunks =
+                filestore.countLocalChunks.bind(filestore);
+            const originalGetReadPeerHints =
+                filestore.getReadPeerHints.bind(filestore);
+            let countCalls = 0;
+            let remoteReadyFailures = 0;
+
+            (filestore as any).getReadPeerHints = async () => [
+                "missing-read-peer",
+            ];
+            (filestore as any).countLocalChunks = async (parent: LargeFile) => {
+                countCalls++;
+                if (countCalls === 1) {
+                    return Math.ceil(parent.chunkCount / 2);
+                }
+                return originalCountLocalChunks(parent);
+            };
+            (filestore.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasRootId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "id" &&
+                        getQueryValue(query) === fileId
+                );
+                if (hasRootId) {
+                    if ((options as any)?.local === true) {
+                        return [pendingFile];
+                    }
+                    if ((options as any)?.remote) {
+                        remoteReadyFailures++;
+                        throw new Error("remote ready search failed");
+                    }
+                    return [];
+                }
+                return originalSearch(request as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await pendingFile.writeFile(
+                    filestore,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestore.files.index as any).search = originalSearch;
+                (filestore as any).countLocalChunks = originalCountLocalChunks;
+                (filestore as any).getReadPeerHints = originalGetReadPeerHints;
+            }
+
+            expect(remoteReadyFailures).to.be.greaterThan(0);
+            expect(
+                filestore.lastReadDiagnostics?.readyRemoteSearchErrors?.[0]
+            ).to.eq("remote ready search failed");
+            expect(
+                filestore.lastReadDiagnostics?.waitUntilReadyResolvedBy
+            ).to.eq("pending-manifest");
+            expect(equals(concat(streamedChunks), expected)).to.be.true;
+        });
+
+        it("falls back to non-replicating parent search when adaptive exact routes miss", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileName = "streamed download with parent fallback";
+            const fileId = await filestore.add(fileName, largeFile);
+
+            const filestoreReader = await peer2.open<Files>(filestore.address);
+            await filestoreReader.files.log.waitForReplicator(
+                peer.identity.publicKey
+            );
+
+            const file = await filestoreReader.files.index.get(fileId);
+            expect(file).to.be.instanceOf(LargeFile);
+            stripChunkEntryHeads(file);
+
+            const writerHash = peer.identity.publicKey.hashcode();
+            (filestoreReader as any).getReadPeerHints = async () => [
+                writerHash,
+            ];
+            const originalSearch = filestoreReader.files.index.search.bind(
+                filestoreReader.files.index
+            );
+            const originalGet = filestoreReader.files.index.get.bind(
+                filestoreReader.files.index
+            );
+            const originalLogGet = filestoreReader.files.log.log.get.bind(
+                filestoreReader.files.log.log
+            );
+            const delayedChunkId = `${fileId}:1`;
+            const writerIndexed = await filestore.files.index.get(
+                delayedChunkId,
+                {
+                    resolve: false,
+                    local: true,
+                    remote: false,
+                } as any
+            );
+            const writerHead = (writerIndexed as any)?.__context?.head;
+            let indexedChunkGets = 0;
+            let indexedHeadGets = 0;
+            let exactNonReplicatingGets = 0;
+            let indexedPreciseSearches = 0;
+            let resolvedPreciseSearches = 0;
+            let persistedParentSearches = 0;
+            let nonReplicatingParentSearches = 0;
+
+            (filestoreReader.files.index as any).get = async (
+                id: string,
+                options: {
+                    resolve?: boolean;
+                    remote?:
+                        | {
+                              from?: string[];
+                              replicate?: boolean;
+                              strategy?: string;
+                          }
+                        | false;
+                }
+            ) => {
+                if (id === delayedChunkId) {
+                    const remote = options?.remote;
+                    if (remote === false) {
+                        return undefined;
+                    }
+                    if (remote?.replicate === false) {
+                        exactNonReplicatingGets++;
+                        return undefined;
+                    }
+                    if (options?.resolve === false) {
+                        indexedChunkGets++;
+                        return originalGet(id as never, options as never);
+                    }
+                    return undefined;
+                }
+                return originalGet(id as never, options as never);
+            };
+
+            (filestoreReader.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: {
+                    resolve?: boolean;
+                    remote?: false | { replicate?: boolean };
+                }
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasParentId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "parentId" &&
+                        getQueryValue(query) === fileId
+                );
+                const hasChunkName = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "name" &&
+                        getQueryValue(query) === `${fileName}/1`
+                );
+
+                if (hasParentId && hasChunkName) {
+                    if (
+                        options?.remote &&
+                        options.remote !== false &&
+                        options.remote.replicate === false &&
+                        options.resolve !== false
+                    ) {
+                        resolvedPreciseSearches++;
+                    } else {
+                        indexedPreciseSearches++;
+                    }
+                    return [];
+                }
+
+                if (hasParentId) {
+                    if (
+                        options?.remote &&
+                        options.remote !== false &&
+                        options.remote.replicate === false
+                    ) {
+                        nonReplicatingParentSearches++;
+                        return originalSearch(
+                            request as never,
+                            options as never
+                        );
+                    }
+                    persistedParentSearches++;
+                    return [];
+                }
+
+                return originalSearch(request as never, options as never);
+            };
+
+            (filestoreReader.files.log.log as any).get = async (
+                hash: string,
+                options: { remote?: unknown }
+            ) => {
+                if (hash === writerHead && options?.remote) {
+                    indexedHeadGets++;
+                    return undefined;
+                }
+                return originalLogGet(hash as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await file!.writeFile(
+                    filestoreReader,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestoreReader.files.log.log as any).get = originalLogGet;
+            }
+
+            expect(indexedChunkGets).to.be.greaterThan(0);
+            expect(indexedHeadGets).to.be.greaterThan(0);
+            expect(indexedPreciseSearches).to.be.greaterThan(0);
+            expect(exactNonReplicatingGets).to.be.greaterThan(0);
+            expect(resolvedPreciseSearches).to.be.greaterThan(0);
+            expect(persistedParentSearches).to.be.greaterThan(0);
+            expect(nonReplicatingParentSearches).to.be.greaterThan(0);
+            expect(
+                filestoreReader.lastReadDiagnostics?.chunkResolved?.[1]
+            ).to.eq("non-replicating-parent-search");
             expect(streamedChunks.length).to.be.greaterThan(1);
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
@@ -750,6 +2156,7 @@ describe("index", () => {
 
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
+            stripChunkEntryHeads(file);
 
             const writerHash = peer.identity.publicKey.hashcode();
             let readPeerHintLookups = 0;
@@ -848,6 +2255,7 @@ describe("index", () => {
 
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
+            stripChunkEntryHeads(file);
 
             const writerHash = peer.identity.publicKey.hashcode();
             (filestoreReader as any).getReadPeerHints = async () => [
@@ -859,6 +2267,10 @@ describe("index", () => {
             const originalGet = filestoreReader.files.index.get.bind(
                 filestoreReader.files.index
             );
+            const originalIterate =
+                filestoreReader.files.log.log.entryIndex.iterate.bind(
+                    filestoreReader.files.log.log.entryIndex
+                );
             const delayedChunkId = `${fileId}:1`;
             let directChunkGets = 0;
             let hintedDirectGetsAfterFallback = 0;
@@ -946,16 +2358,28 @@ describe("index", () => {
                 return originalSearch(request as never, options as never);
             };
 
+            (filestoreReader.files.log.log.entryIndex as any).iterate = () => ({
+                done: () => true,
+                next: async () => [],
+                all: async () => [],
+                close: async () => {},
+            });
+
             const streamedChunks: Uint8Array[] = [];
-            await file!.writeFile(
-                filestoreReader,
-                {
-                    write: async (chunk) => {
-                        streamedChunks.push(chunk);
+            try {
+                await file!.writeFile(
+                    filestoreReader,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
                     },
-                },
-                { timeout: 20_000 }
-            );
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestoreReader.files.log.log.entryIndex as any).iterate =
+                    originalIterate;
+            }
 
             expect(directChunkGets).to.be.greaterThan(4);
             expect(preciseChunkSearches).to.be.greaterThan(0);
@@ -985,6 +2409,7 @@ describe("index", () => {
 
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
+            stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
                 filestoreReader.files.index
@@ -1073,6 +2498,7 @@ describe("index", () => {
 
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
+            stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
                 filestoreReader.files.index
@@ -1157,6 +2583,7 @@ describe("index", () => {
 
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
+            stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
                 filestoreReader.files.index
@@ -1234,6 +2661,7 @@ describe("index", () => {
 
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
+            stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
                 filestoreReader.files.index
@@ -1321,6 +2749,7 @@ describe("index", () => {
 
             const file = await filestoreReader.files.index.get(fileId);
             expect(file).to.be.instanceOf(LargeFile);
+            stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
                 filestoreReader.files.index

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -12,6 +12,7 @@ import { delay, waitForResolved } from "@peerbit/time";
 import { sha256Base64Sync } from "@peerbit/crypto";
 import { deserialize, serialize } from "@dao-xyz/borsh";
 import { expect, describe, it, beforeEach, afterEach } from "vitest";
+import { SearchRequestIndexed } from "@peerbit/document";
 
 const getQueryKey = (query: any) =>
     Array.isArray(query?.key) ? query.key.join(".") : query?.key;
@@ -1808,6 +1809,9 @@ describe("index", () => {
                     }
                     if ((options as any)?.remote) {
                         if ((options as any)?.resolve === false) {
+                            expect(request).to.be.instanceOf(
+                                SearchRequestIndexed
+                            );
                             indexedReadySearches++;
                             return [readyIndexed];
                         }

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -1617,7 +1617,11 @@ export class LargeFile extends AbstractFile {
                 }
                 try {
                     const indexedMatches = await files.files.index.search(
-                        request,
+                        new SearchRequestIndexed({
+                            query: request.query,
+                            fetch: request.fetch,
+                            sort: request.sort,
+                        }),
                         {
                             resolve: false,
                             local: false,

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -205,6 +205,8 @@ type FileReadOptions = {
 
 type ChunkReadContext = {
     lastReadPeerHints?: string[];
+    localChunkEntryHeads?: Map<string, string>;
+    localChunkEntryHeadsScan?: Promise<Map<string, string>>;
 };
 
 export interface ReReadableChunkSource {
@@ -319,6 +321,7 @@ const LARGE_FILE_TARGET_CHUNK_COUNT = 256;
 const CHUNK_SIZE_GRANULARITY = 64 * 1024;
 const MAX_LARGE_FILE_SEGMENT_SIZE = TINY_FILE_SIZE_LIMIT - 256 * 1024;
 const LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS = 5 * 60 * 1000;
+const LARGE_FILE_PENDING_STREAM_MIN_CHUNKS = LARGE_FILE_TARGET_CHUNK_COUNT / 2;
 const LARGE_FILE_PERSISTED_READ_AHEAD = 4;
 const LARGE_FILE_OBSERVER_READ_AHEAD = 2;
 const LARGE_FILE_OBSERVER_PREFETCH_TIMEOUT_MS = 5_000;
@@ -670,11 +673,187 @@ export class LargeFile extends AbstractFile {
                 return chunk;
             }
         };
+        const rememberChunkEntryHead = (head: string | undefined) => {
+            if (!head) {
+                return;
+            }
+            files.retainChunkEntryHead(head);
+            properties?.debug &&
+                ((properties.debug.chunkIndexedHeads ||= {})[index] = head);
+        };
         const matchesChunkIndex = (candidate: unknown) =>
             candidate instanceof IndexableFile &&
             candidate.id === chunkId &&
             candidate.parentId === this.id &&
             candidate.name === `${this.name}/${index}`;
+        const materializeChunkEntryHead = async (
+            head: string | undefined,
+            remoteFrom: string[] | undefined,
+            resolvedBy: string,
+            replicate = files.persistChunkReads
+        ): Promise<TinyFile | undefined> => {
+            if (!head) {
+                return;
+            }
+            rememberChunkEntryHead(head);
+            properties?.debug &&
+                ((properties.debug.chunkHeadGets ||= {})[index] =
+                    ((properties.debug.chunkHeadGets ||= {})[index] ?? 0) + 1);
+            const entry = await files.files.log.log.get(head, {
+                remote: {
+                    timeout: attemptTimeout,
+                    throwOnMissing: false,
+                    retryMissingResponses: true,
+                    replicate,
+                    from: remoteFrom,
+                } as any,
+            });
+            if (!entry) {
+                return;
+            }
+            files.retainChunkEntryHead(head);
+            const operation = await entry.getPayloadValue();
+            if (!isPutOperation(operation)) {
+                return;
+            }
+            const chunk = files.files.index.valueEncoding.decoder(
+                operation.data
+            );
+            if (
+                chunk instanceof TinyFile &&
+                chunk.parentId === this.id &&
+                chunk.index === index
+            ) {
+                knownChunks.set(index, chunk);
+                files.retainChunkRead(chunk.id);
+                if (replicate) {
+                    try {
+                        await files.files.log.join([entry], {
+                            replicate: { assumeSynced: true },
+                        });
+                    } catch (error) {
+                        properties?.debug &&
+                            ((properties.debug.chunkHeadJoinErrors ||= {})[
+                                index
+                            ] = getErrorMessage(error));
+                    }
+                }
+                properties?.debug &&
+                    ((properties.debug.chunkResolved ||= {})[index] =
+                        resolvedBy);
+                return chunk;
+            }
+        };
+        const scanLocalChunkEntryHeads = async () => {
+            properties?.debug &&
+                ((properties.debug.chunkLocalEntryScans ||= {})[index] =
+                    ((properties.debug.chunkLocalEntryScans ||= {})[index] ??
+                        0) + 1);
+            const heads = new Map<string, string>();
+            const candidateHeads: string[] = [];
+            const iterator = files.files.log.log.entryIndex.iterate(
+                [],
+                undefined,
+                false
+            );
+            try {
+                while (!iterator.done()) {
+                    const entries = await iterator.next(128);
+                    for (const entry of entries) {
+                        const metadata = getEntryMetadata(entry);
+                        if (metadata?.id && !heads.has(metadata.id)) {
+                            heads.set(metadata.id, entry.hash);
+                        }
+                        candidateHeads.push(entry.hash);
+                    }
+                }
+            } finally {
+                await iterator.close();
+            }
+
+            if (!heads.has(chunkId)) {
+                for (const head of candidateHeads) {
+                    const entry = await files.files.log.log.get(head);
+                    if (!entry) {
+                        continue;
+                    }
+                    try {
+                        const operation = await entry.getPayloadValue();
+                        if (!isPutOperation(operation)) {
+                            continue;
+                        }
+                        const file = files.files.index.valueEncoding.decoder(
+                            operation.data
+                        );
+                        if (
+                            file instanceof TinyFile &&
+                            file.parentId === this.id &&
+                            !heads.has(file.id)
+                        ) {
+                            heads.set(file.id, head);
+                        }
+                    } catch {
+                        continue;
+                    }
+                }
+            }
+
+            readContext.localChunkEntryHeads = heads;
+            return heads;
+        };
+        const getLocalChunkEntryHeads = async (refresh = false) => {
+            if (readContext.localChunkEntryHeadsScan) {
+                return readContext.localChunkEntryHeadsScan;
+            }
+            if (!refresh && readContext.localChunkEntryHeads) {
+                return readContext.localChunkEntryHeads;
+            }
+            const scan = scanLocalChunkEntryHeads().finally(() => {
+                if (readContext.localChunkEntryHeadsScan === scan) {
+                    readContext.localChunkEntryHeadsScan = undefined;
+                }
+            });
+            readContext.localChunkEntryHeadsScan = scan;
+            return scan;
+        };
+        const resolveChunkByLocalEntryMetadata = async (
+            remoteFrom: string[] | undefined,
+            refresh = false
+        ): Promise<TinyFile | undefined> => {
+            const localHead = (await getLocalChunkEntryHeads(refresh)).get(
+                chunkId
+            );
+            if (!localHead) {
+                return;
+            }
+            properties?.debug &&
+                ((properties.debug.chunkLocalEntryHeads ||= {})[index] =
+                    localHead);
+            return materializeChunkEntryHead(
+                localHead,
+                remoteFrom,
+                "local-entry-head",
+                files.persistChunkReads
+            );
+        };
+        const resolveChunkByManifestEntryHead = async (
+            remoteFrom: string[] | undefined
+        ): Promise<TinyFile | undefined> => {
+            const heads = (this as { chunkEntryHeads?: unknown })
+                .chunkEntryHeads;
+            const head = Array.isArray(heads) ? heads[index] : undefined;
+            if (typeof head !== "string") {
+                return;
+            }
+            properties?.debug &&
+                ((properties.debug.chunkManifestHeads ||= {})[index] = head);
+            return materializeChunkEntryHead(
+                head,
+                remoteFrom,
+                "manifest-head-get",
+                files.persistChunkReads
+            );
+        };
         const syncChunkByExactIndex = async (
             remoteFrom: string[] | undefined
         ): Promise<TinyFile | typeof indexedChunkPending | undefined> => {
@@ -696,8 +875,16 @@ export class LargeFile extends AbstractFile {
             });
             if (matchesChunkIndex(indexed)) {
                 files.retainResolvedChunk(indexed);
+                const indexedHead = getContextHead(indexed);
+                rememberChunkEntryHead(indexedHead);
                 return (
                     (await materializeLocalChunk("indexed-get")) ??
+                    (await materializeChunkEntryHead(
+                        indexedHead,
+                        remoteFrom,
+                        "indexed-head-get",
+                        true
+                    )) ??
                     indexedChunkPending
                 );
             }
@@ -743,7 +930,17 @@ export class LargeFile extends AbstractFile {
                 const indexed = chunks.find(matchesChunkIndex);
                 if (indexed) {
                     files.retainResolvedChunk(indexed);
-                    return materializeLocalChunk("indexed-search");
+                    const indexedHead = getContextHead(indexed);
+                    rememberChunkEntryHead(indexedHead);
+                    return (
+                        (await materializeLocalChunk("indexed-search")) ??
+                        (await materializeChunkEntryHead(
+                            indexedHead,
+                            remoteFrom,
+                            "indexed-search-head-get",
+                            true
+                        ))
+                    );
                 }
                 return;
             }
@@ -885,12 +1082,20 @@ export class LargeFile extends AbstractFile {
             return resolveChunkByDirectGet(remoteFrom, false);
         };
         const resolveChunksByParentSearch = async (
-            remoteFrom: string[] | undefined
+            remoteFrom: string[] | undefined,
+            options?: {
+                replicate?: boolean;
+                resolvedBy?: string;
+            }
         ): Promise<TinyFile | undefined> => {
-            properties?.debug &&
-                ((properties.debug.chunkParentSearches ||= {})[index] =
-                    ((properties.debug.chunkParentSearches ||= {})[index] ??
-                        0) + 1);
+            const replicate = options?.replicate ?? files.persistChunkReads;
+            if (properties?.debug) {
+                const counter = replicate
+                    ? (properties.debug.chunkParentSearches ||= {})
+                    : (properties.debug.chunkNonReplicatingParentSearches ||=
+                          {});
+                counter[index] = (counter[index] ?? 0) + 1;
+            }
             const chunks = await files.files.index.search(
                 new SearchRequest({
                     query: new StringMatch({
@@ -905,7 +1110,7 @@ export class LargeFile extends AbstractFile {
                         timeout: attemptTimeout,
                         throwOnMissing: false,
                         retryMissingResponses: true,
-                        replicate: files.persistChunkReads,
+                        replicate,
                         from: remoteFrom,
                     },
                 } as any
@@ -920,7 +1125,7 @@ export class LargeFile extends AbstractFile {
             if (chunk) {
                 properties?.debug &&
                     ((properties.debug.chunkResolved ||= {})[index] =
-                        "parent-search");
+                        options?.resolvedBy ?? "parent-search");
                 return chunk;
             }
         };
@@ -968,6 +1173,31 @@ export class LargeFile extends AbstractFile {
             if (properties?.debug) {
                 (properties.debug.chunkHints ||= {})[index] =
                     remoteFrom ?? null;
+            }
+
+            try {
+                const chunk = await resolveChunkByManifestEntryHead(remoteFrom);
+                if (chunk) {
+                    return chunk;
+                }
+            } catch (error) {
+                if (!isRetryableChunkLookupError(error)) {
+                    properties?.debug &&
+                        (properties.debug.chunkFailure = {
+                            index,
+                            type: "non-retryable-manifest-head",
+                            message: getErrorMessage(error),
+                        });
+                    throw error;
+                }
+                if (remoteFrom && shouldRetryChunkLookupWithoutHints(error)) {
+                    hintedDeliveryFailures += 1;
+                }
+                retryableFailures += 1;
+                properties?.debug &&
+                    ((properties.debug.chunkRetryableManifestHeadErrors ||= {})[
+                        index
+                    ] = getErrorMessage(error));
             }
 
             try {
@@ -1142,6 +1372,102 @@ export class LargeFile extends AbstractFile {
                                 {})[index] = getErrorMessage(error));
                     }
                 }
+                if (files.persistChunkReads) {
+                    for (const fallbackFrom of fallbackSources) {
+                        try {
+                            const chunk = await resolveChunksByParentSearch(
+                                fallbackFrom,
+                                {
+                                    replicate: false,
+                                    resolvedBy: "non-replicating-parent-search",
+                                }
+                            );
+                            if (chunk) {
+                                return chunk;
+                            }
+                        } catch (error) {
+                            if (!isRetryableChunkLookupError(error)) {
+                                properties?.debug &&
+                                    (properties.debug.chunkFailure = {
+                                        index,
+                                        type: "non-retryable-non-replicating-parent-search",
+                                        message: getErrorMessage(error),
+                                    });
+                                throw error;
+                            }
+                            if (
+                                fallbackFrom &&
+                                shouldRetryChunkLookupWithoutHints(error)
+                            ) {
+                                hintedDeliveryFailures += 1;
+                            }
+                            retryableFailures += 1;
+                            properties?.debug &&
+                                ((properties.debug.chunkRetryableNonReplicatingParentSearchErrors ||=
+                                    {})[index] = getErrorMessage(error));
+                        }
+                    }
+                }
+                for (const fallbackFrom of fallbackSources) {
+                    try {
+                        const chunk =
+                            await resolveChunkByManifestEntryHead(fallbackFrom);
+                        if (chunk) {
+                            return chunk;
+                        }
+                    } catch (error) {
+                        if (!isRetryableChunkLookupError(error)) {
+                            properties?.debug &&
+                                (properties.debug.chunkFailure = {
+                                    index,
+                                    type: "non-retryable-manifest-head",
+                                    message: getErrorMessage(error),
+                                });
+                            throw error;
+                        }
+                        if (
+                            fallbackFrom &&
+                            shouldRetryChunkLookupWithoutHints(error)
+                        ) {
+                            hintedDeliveryFailures += 1;
+                        }
+                        retryableFailures += 1;
+                        properties?.debug &&
+                            ((properties.debug.chunkRetryableManifestHeadErrors ||=
+                                {})[index] = getErrorMessage(error));
+                    }
+                }
+                for (const fallbackFrom of fallbackSources) {
+                    try {
+                        const chunk = await resolveChunkByLocalEntryMetadata(
+                            fallbackFrom,
+                            true
+                        );
+                        if (chunk) {
+                            return chunk;
+                        }
+                    } catch (error) {
+                        if (!isRetryableChunkLookupError(error)) {
+                            properties?.debug &&
+                                (properties.debug.chunkFailure = {
+                                    index,
+                                    type: "non-retryable-local-metadata-head",
+                                    message: getErrorMessage(error),
+                                });
+                            throw error;
+                        }
+                        if (
+                            fallbackFrom &&
+                            shouldRetryChunkLookupWithoutHints(error)
+                        ) {
+                            hintedDeliveryFailures += 1;
+                        }
+                        retryableFailures += 1;
+                        properties?.debug &&
+                            ((properties.debug.chunkRetryableLocalMetadataErrors ||=
+                                {})[index] = getErrorMessage(error));
+                    }
+                }
                 nextNonReplicatingReadAfterFailures *= 2;
             }
 
@@ -1172,18 +1498,108 @@ export class LargeFile extends AbstractFile {
                 debug.waitUntilReadyAttempts += 1;
             }
             const remoteFrom = await files.getReadPeerHints();
-            const matches = await files.files.index.search(
-                new SearchRequest({
-                    query: new StringMatch({
-                        key: "id",
-                        value: this.id,
-                        caseInsensitive: false,
-                        method: StringMatchMethod.exact,
-                    }),
-                    fetch: 0xffffffff,
+            const request = new SearchRequest({
+                query: new StringMatch({
+                    key: "id",
+                    value: this.id,
+                    caseInsensitive: false,
+                    method: StringMatchMethod.exact,
                 }),
-                {
-                    local: remoteFrom == null,
+                fetch: 0xffffffff,
+            });
+            const pickLatest = (matches: AbstractFile[]) => {
+                const largeMatches = matches.filter(isLargeFileLike);
+                return (
+                    largeMatches.find(
+                        (match) =>
+                            match.ready &&
+                            Array.isArray((match as any).chunkEntryHeads) &&
+                            (match as any).chunkEntryHeads.length > 0
+                    ) ??
+                    largeMatches.find((match) => match.ready) ??
+                    largeMatches[0]
+                );
+            };
+            const hasChunkEntryHeads = (file: LargeFile | undefined) =>
+                Array.isArray((file as any)?.chunkEntryHeads) &&
+                (file as any).chunkEntryHeads.some(
+                    (head: unknown) => typeof head === "string"
+                );
+            const localMatches = await files.files.index.search(request, {
+                local: true,
+                remote: false,
+            } as any);
+            const localLatest = pickLatest(localMatches);
+            const thisCandidate = toReadableLargeFile(this) ?? this;
+            const localCandidate = toReadableLargeFile(localLatest);
+            const readinessCandidate =
+                localCandidate &&
+                (localCandidate.ready ||
+                    !hasChunkEntryHeads(thisCandidate) ||
+                    hasChunkEntryHeads(localCandidate))
+                    ? localCandidate
+                    : thisCandidate;
+            if (debug) {
+                debug.lastReadyProbe = {
+                    at: Date.now(),
+                    ready: readinessCandidate.ready,
+                    from: remoteFrom ?? null,
+                    localChunkCount: null,
+                };
+            }
+
+            const localReady = toReadableLargeFile(localLatest);
+            if (localReady && localReady.ready) {
+                if (debug) {
+                    debug.waitUntilReadyResolvedBy = "ready-manifest";
+                }
+                return localReady;
+            }
+            const materializeReadyManifestHead = async (
+                head: string | undefined
+            ): Promise<LargeFile | undefined> => {
+                if (!head) {
+                    return;
+                }
+                files.retainChunkEntryHead(head);
+                if (debug) {
+                    (debug.readyRemoteGetHeads ||= []).push(head);
+                }
+                const entry = await files.files.log.log.get(head, {
+                    remote: {
+                        timeout: attemptTimeout,
+                        throwOnMissing: false,
+                        retryMissingResponses: true,
+                        replicate: files.persistChunkReads,
+                        from: remoteFrom,
+                    } as any,
+                });
+                if (!entry) {
+                    return;
+                }
+                files.retainChunkEntryHead(head);
+                const operation = await entry.getPayloadValue();
+                if (!isPutOperation(operation)) {
+                    return;
+                }
+                try {
+                    return toReadableLargeFile(
+                        files.files.index.valueEncoding.decoder(operation.data)
+                    );
+                } catch (error) {
+                    if (debug) {
+                        (debug.readyRemoteDecodeFallbacks ||= []).push(
+                            getErrorMessage(error)
+                        );
+                    }
+                    return decodeLargeFileWithChunkHeads(operation.data);
+                }
+            };
+            let remoteMatches: AbstractFile[] = [];
+            let remoteSearchFailed = false;
+            try {
+                remoteMatches = await files.files.index.search(request, {
+                    local: false,
                     remote: {
                         timeout: attemptTimeout,
                         throwOnMissing: false,
@@ -1191,22 +1607,156 @@ export class LargeFile extends AbstractFile {
                         replicate: files.persistChunkReads,
                         from: remoteFrom,
                     },
-                } as any
-            );
-            const latest =
-                matches.find(
-                    (match) => match instanceof LargeFile && match.ready
-                ) ?? matches.find((match) => match instanceof LargeFile);
-            if (debug) {
-                debug.lastReadyProbe = {
-                    at: Date.now(),
-                    ready: latest instanceof LargeFile ? latest.ready : null,
-                    from: remoteFrom ?? null,
-                };
+                } as any);
+            } catch (error) {
+                remoteSearchFailed = true;
+                if (debug) {
+                    (debug.readyRemoteSearchErrors ||= []).push(
+                        getErrorMessage(error)
+                    );
+                }
+                try {
+                    const indexedMatches = await files.files.index.search(
+                        request,
+                        {
+                            resolve: false,
+                            local: false,
+                            remote: {
+                                timeout: attemptTimeout,
+                                throwOnMissing: false,
+                                retryMissingResponses: true,
+                                replicate: files.persistChunkReads,
+                                from: remoteFrom,
+                            },
+                        } as any
+                    );
+                    const materializedMatches: LargeFile[] = [];
+                    for (const indexedMatch of indexedMatches) {
+                        try {
+                            const materialized =
+                                await materializeReadyManifestHead(
+                                    getContextHead(indexedMatch)
+                                );
+                            if (materialized) {
+                                materializedMatches.push(materialized);
+                            }
+                        } catch (headError) {
+                            if (debug) {
+                                (debug.readyRemoteIndexedHeadErrors ||=
+                                    []).push(getErrorMessage(headError));
+                            }
+                        }
+                    }
+                    const indexedReady = materializedMatches.find(
+                        (match) => match.ready
+                    );
+                    if (indexedReady) {
+                        if (debug) {
+                            debug.waitUntilReadyResolvedBy =
+                                "ready-manifest-head-search";
+                        }
+                        return indexedReady;
+                    }
+                    remoteMatches = materializedMatches as AbstractFile[];
+                } catch (indexedError) {
+                    if (debug) {
+                        (debug.readyRemoteIndexedSearchErrors ||= []).push(
+                            getErrorMessage(indexedError)
+                        );
+                    }
+                }
+            }
+            const remoteLatest = pickLatest(remoteMatches);
+            let remoteReady = toReadableLargeFile(remoteLatest);
+            if (debug?.lastReadyProbe && isLargeFileLike(remoteLatest)) {
+                debug.lastReadyProbe.ready = remoteLatest.ready;
             }
 
-            if (latest instanceof LargeFile && latest.ready) {
-                return latest;
+            if (remoteReady && remoteReady.ready) {
+                if (debug) {
+                    debug.waitUntilReadyResolvedBy = "ready-manifest";
+                }
+                return remoteReady;
+            }
+            try {
+                const directRemote = await files.files.index.get(this.id, {
+                    resolve: false,
+                    local: false,
+                    remote: {
+                        timeout: attemptTimeout,
+                        strategy: "always" as any,
+                        throwOnMissing: false,
+                        retryMissingResponses: true,
+                        replicate: files.persistChunkReads,
+                        from: remoteFrom,
+                    },
+                });
+                let directReady = toReadableLargeFile(directRemote);
+                let directReadySource = "ready-manifest-get";
+                if (!directReady) {
+                    directReady = await materializeReadyManifestHead(
+                        getContextHead(directRemote)
+                    );
+                    directReadySource = "ready-manifest-head-get";
+                }
+                if (debug?.lastReadyProbe && isLargeFileLike(directRemote)) {
+                    debug.lastReadyProbe.ready = directRemote.ready;
+                }
+                if (debug?.lastReadyProbe && directReady) {
+                    debug.lastReadyProbe.ready = directReady.ready;
+                }
+                if (directReady?.ready) {
+                    if (debug) {
+                        debug.waitUntilReadyResolvedBy = directReadySource;
+                    }
+                    return directReady;
+                }
+                if (
+                    directReady &&
+                    (!remoteReady ||
+                        hasChunkEntryHeads(directReady) ||
+                        !hasChunkEntryHeads(remoteReady))
+                ) {
+                    remoteReady = directReady;
+                }
+            } catch (error) {
+                if (debug) {
+                    (debug.readyRemoteGetErrors ||= []).push(
+                        getErrorMessage(error)
+                    );
+                }
+            }
+            const countCandidate =
+                remoteReady &&
+                (remoteReady.ready ||
+                    !hasChunkEntryHeads(readinessCandidate) ||
+                    hasChunkEntryHeads(remoteReady))
+                    ? remoteReady
+                    : readinessCandidate;
+            const localChunkCount = await files
+                .countLocalChunks(countCandidate)
+                .catch(() => 0);
+            if (debug?.lastReadyProbe) {
+                debug.lastReadyProbe.localChunkCount = localChunkCount;
+            }
+            if (localChunkCount >= countCandidate.chunkCount) {
+                if (debug) {
+                    debug.waitUntilReadyResolvedBy = "complete-chunks";
+                }
+                return countCandidate;
+            }
+            if (
+                remoteSearchFailed &&
+                files.persistChunkReads &&
+                readinessCandidate.chunkCount >=
+                    LARGE_FILE_PENDING_STREAM_MIN_CHUNKS &&
+                localChunkCount >=
+                    Math.max(1, Math.ceil(readinessCandidate.chunkCount / 2))
+            ) {
+                if (debug) {
+                    debug.waitUntilReadyResolvedBy = "pending-manifest";
+                }
+                return readinessCandidate;
             }
 
             await sleep(250);
@@ -1231,6 +1781,7 @@ export class LargeFile extends AbstractFile {
             waitUntilReadyAttempts: 0,
             waitUntilReadyResolvedAt: null as number | null,
             waitUntilReadyResolvedReady: null as boolean | null,
+            waitUntilReadyResolvedBy: null as string | null,
             prefetchedChunkCount: 0,
             readAhead: 0,
             initialReadPeerHints: null as string[] | null,
@@ -1254,6 +1805,9 @@ export class LargeFile extends AbstractFile {
             } | null,
         };
         files.lastReadDiagnostics = debug;
+        if (files.persistChunkReads) {
+            files.retainFileRead(this);
+        }
         const resolvedFile = await this.waitUntilReady(files, properties);
         debug.waitUntilReadyResolvedAt = Date.now();
         debug.waitUntilReadyResolvedReady = resolvedFile.ready;
@@ -1294,7 +1848,7 @@ export class LargeFile extends AbstractFile {
             const pending = (async () => {
                 debug.chunkResolveStartedAt[index] = Date.now();
                 try {
-                    return await this.resolveChunk(
+                    return await resolvedFile.resolveChunk(
                         files,
                         index,
                         knownChunks,
@@ -1362,11 +1916,169 @@ export class LargeFile extends AbstractFile {
     }
 }
 
+@variant(2)
+export class LargeFileWithChunkHeads extends AbstractFile {
+    @field({ type: "string" })
+    id: string;
+
+    @field({ type: "string" })
+    name: string;
+
+    @field({ type: "u64" })
+    size: bigint;
+
+    @field({ type: "u32" })
+    chunkCount: number;
+
+    @field({ type: "bool" })
+    ready: boolean;
+
+    @field({ type: option("string") })
+    finalHash?: string;
+
+    @field({ type: vec("string") })
+    chunkEntryHeads: string[];
+
+    constructor(properties: {
+        id?: string;
+        name: string;
+        size: bigint;
+        chunkCount: number;
+        ready?: boolean;
+        finalHash?: string;
+        chunkEntryHeads?: string[];
+    }) {
+        super();
+        this.id = properties.id || createUploadId();
+        this.name = properties.name;
+        this.size = properties.size;
+        this.chunkCount = properties.chunkCount;
+        this.ready = properties.ready ?? false;
+        this.finalHash = properties.finalHash;
+        this.chunkEntryHeads = properties.chunkEntryHeads ?? [];
+    }
+
+    get parentId() {
+        return undefined;
+    }
+
+    streamFile(files: Files, properties?: FileReadOptions) {
+        return LargeFile.prototype.streamFile.call(
+            this as unknown as LargeFile,
+            files,
+            properties
+        );
+    }
+
+    delete(files: Files) {
+        return LargeFile.prototype.delete.call(
+            this as unknown as LargeFile,
+            files
+        );
+    }
+}
+Object.setPrototypeOf(LargeFileWithChunkHeads.prototype, LargeFile.prototype);
+
+const isLargeFileLike = (value: unknown): value is LargeFile => {
+    const file = value as Partial<LargeFile> & {
+        parentId?: unknown;
+    };
+    return (
+        value instanceof LargeFile ||
+        (value != null &&
+            typeof value === "object" &&
+            file.parentId == null &&
+            typeof file.id === "string" &&
+            typeof file.name === "string" &&
+            typeof file.size === "bigint" &&
+            typeof file.chunkCount === "number" &&
+            typeof file.ready === "boolean")
+    );
+};
+
+const toReadableLargeFile = (value: unknown): LargeFile | undefined => {
+    if (!isLargeFileLike(value)) {
+        return;
+    }
+    if (typeof (value as any).resolveChunk === "function") {
+        return value as LargeFile;
+    }
+    if (Array.isArray((value as any).chunkEntryHeads)) {
+        return new LargeFileWithChunkHeads({
+            id: value.id,
+            name: value.name,
+            size: value.size,
+            chunkCount: value.chunkCount,
+            ready: value.ready,
+            finalHash: value.finalHash,
+            chunkEntryHeads: (value as any).chunkEntryHeads,
+        }) as unknown as LargeFile;
+    }
+    return new LargeFile({
+        id: value.id,
+        name: value.name,
+        size: value.size,
+        chunkCount: value.chunkCount,
+        ready: value.ready,
+        finalHash: value.finalHash,
+    });
+};
+
+const readBorshStringVector = (data: Uint8Array, offset: number) => {
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    if (offset + 4 > data.byteLength) {
+        return [];
+    }
+    const decoder = new TextDecoder();
+    const count = view.getUint32(offset, true);
+    offset += 4;
+    const values: string[] = [];
+    for (let i = 0; i < count; i++) {
+        if (offset + 4 > data.byteLength) {
+            throw new Error("Malformed chunk head vector");
+        }
+        const byteLength = view.getUint32(offset, true);
+        offset += 4;
+        if (offset + byteLength > data.byteLength) {
+            throw new Error("Malformed chunk head string");
+        }
+        values.push(decoder.decode(data.subarray(offset, offset + byteLength)));
+        offset += byteLength;
+    }
+    return values;
+};
+
+const decodeLargeFileWithChunkHeads = (data: Uint8Array) => {
+    const base = deserialize(data, LargeFile, { unchecked: true });
+    const baseBytes = serialize(
+        new LargeFile({
+            id: base.id,
+            name: base.name,
+            size: base.size,
+            chunkCount: base.chunkCount,
+            ready: base.ready,
+            finalHash: base.finalHash,
+        })
+    );
+    return new LargeFileWithChunkHeads({
+        id: base.id,
+        name: base.name,
+        size: base.size,
+        chunkCount: base.chunkCount,
+        ready: base.ready,
+        finalHash: base.finalHash,
+        chunkEntryHeads:
+            baseBytes.byteLength < data.byteLength
+                ? readBorshStringVector(data, baseBytes.byteLength)
+                : [],
+    }) as unknown as LargeFile;
+};
+
 const preferListCandidate = (
     candidate: AbstractFile,
     existing: AbstractFile
 ) => {
-    if (candidate instanceof LargeFile && existing instanceof LargeFile) {
+    if (isLargeFileLike(candidate) && isLargeFileLike(existing)) {
         if (candidate.ready !== existing.ready) {
             return candidate.ready;
         }
@@ -1478,11 +2190,15 @@ export class Files extends Program<Args> {
         this.retainedChunkIds.add(chunkId);
     }
 
+    retainChunkEntryHead(entryHash: string) {
+        this.retainedChunkEntryHeads ??= new Set();
+        this.retainedChunkEntryHeads.add(entryHash);
+    }
+
     retainResolvedChunk(value: unknown) {
         const head = getContextHead(value);
         if (head) {
-            this.retainedChunkEntryHeads ??= new Set();
-            this.retainedChunkEntryHeads.add(head);
+            this.retainChunkEntryHead(head);
         }
     }
 
@@ -1491,7 +2207,7 @@ export class Files extends Program<Args> {
             this.retainChunkRead(file.id);
             return;
         }
-        if (file instanceof LargeFile) {
+        if (isLargeFileLike(file)) {
             for (let index = 0; index < file.chunkCount; index++) {
                 this.retainChunkRead(getChunkId(file.id, index));
             }
@@ -1503,8 +2219,7 @@ export class Files extends Program<Args> {
             this.retainChunkRead(chunk.id);
         }
         if (entryHash) {
-            this.retainedChunkEntryHeads ??= new Set();
-            this.retainedChunkEntryHeads.add(entryHash);
+            this.retainChunkEntryHead(entryHash);
         }
     }
 
@@ -1595,6 +2310,13 @@ export class Files extends Program<Args> {
                 return false;
             }
             const file = this.files.index.valueEncoding.decoder(operation.data);
+            if (
+                (file instanceof TinyFile || isLargeFileLike(file)) &&
+                file.parentId == null
+            ) {
+                this.retainedChunkEntryHeads.add(entry.hash);
+                return true;
+            }
             if (
                 file instanceof TinyFile &&
                 file.parentId != null &&
@@ -1720,6 +2442,7 @@ export class Files extends Program<Args> {
         try {
             let uploadedBytes = 0n;
             let chunkCount = 0;
+            const chunkEntryHeads: string[] = [];
             for await (const chunkBytes of source.readChunks(chunkSize)) {
                 hasher.update(chunkBytes);
                 const chunk = new TinyFile({
@@ -1733,19 +2456,21 @@ export class Files extends Program<Args> {
                     meta: { data: getEntryMetadataForFile(chunk) },
                 });
                 this.retainAuthoredChunk(chunk, appended.entry.hash);
+                chunkEntryHeads[chunkCount] = appended.entry.hash;
                 uploadedBytes += BigInt(chunkBytes.byteLength);
                 chunkCount++;
                 progress?.(Number(uploadedBytes) / Math.max(Number(size), 1));
             }
             ensureSourceSize(uploadedBytes, source.size);
             await this.files.put(
-                new LargeFile({
+                new LargeFileWithChunkHeads({
                     id: uploadId,
                     name,
                     size,
                     chunkCount,
                     ready: true,
                     finalHash: toBase64(hasher.digest()),
+                    chunkEntryHeads,
                 })
             );
         } catch (error) {
@@ -1826,6 +2551,7 @@ export class Files extends Program<Args> {
         const hasher = new SHA256();
         try {
             let uploadedBytes = 0;
+            const chunkEntryHeads: string[] = [];
             for (let i = 0; i < chunkCount; i++) {
                 const readStartedAt = Date.now();
                 const chunkBytes = await getChunk(i);
@@ -1849,6 +2575,7 @@ export class Files extends Program<Args> {
                     meta: { data: getEntryMetadataForFile(chunk) },
                 });
                 this.retainAuthoredChunk(chunk, appended.entry.hash);
+                chunkEntryHeads[i] = appended.entry.hash;
                 const putFinishedAt = Date.now();
                 const putDurationMs = putFinishedAt - putStartedAt;
                 diagnostics.firstChunkFinishedAt ??= putFinishedAt;
@@ -1871,13 +2598,14 @@ export class Files extends Program<Args> {
             }
             diagnostics.readyManifestStartedAt = Date.now();
             await this.files.put(
-                new LargeFile({
+                new LargeFileWithChunkHeads({
                     id: uploadId,
                     name,
                     size,
                     chunkCount,
                     ready: true,
                     finalHash: toBase64(hasher.digest()),
+                    chunkEntryHeads,
                 })
             );
             diagnostics.readyManifestFinishedAt = Date.now();
@@ -1944,7 +2672,7 @@ export class Files extends Program<Args> {
         const rootFiles = deduplicateListedRoots(files);
         const resolvedRoots = await Promise.all(
             rootFiles.map(async (file) => {
-                if (!(file instanceof LargeFile) || file.ready) {
+                if (!isLargeFileLike(file) || file.ready) {
                     return file;
                 }
                 try {


### PR DESCRIPTION
## Summary
- add a late non-replicating parent-search fallback for adaptive persisted large-file reads when exact chunk routes miss
- keep adaptive replication enabled; this does not switch readers to observer/fixed-size replication
- add a regression test for adaptive exact-route misses recovering through the parent-search path

## Verification
- pnpm --filter @peerbit/please-lib exec vitest run src/__tests__/index.integration.test.ts -t "non-replicating parent search|resolved precise search|pins persisted|keeps retained"
- pnpm --filter @peerbit/please-lib test
- pnpm --filter @peerbit/please-lib build
- pnpm --filter file-share build
- pnpm exec prettier --check packages/file-share/library/src/index.ts packages/file-share/library/src/__tests__/index.integration.test.ts && git diff --check