### PR TITLE
Improve file-share benchmark diagnostics and large chunk reads

### DIFF
--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -344,6 +344,9 @@ export const Drop = () => {
                 ) => Promise<void>;
                 getDiagnostics: () => Promise<Record<string, unknown>>;
             };
+            __peerbitFileShareBenchmarkStats?: {
+                updateListCalls?: Array<Record<string, unknown>>;
+            };
         };
         if (!files.program || files.program.closed) {
             delete testWindow.__peerbitFileShareTestHooks;
@@ -362,6 +365,12 @@ export const Drop = () => {
                 const replicators = await files.program.files.log
                     .getReplicators()
                     .catch(() => undefined);
+                const connections = (
+                    (peer as any)?.libp2p?.getConnections?.() ?? []
+                ).map(
+                    (connection) =>
+                        connection?.remotePeer?.toString?.() ?? "unknown"
+                );
                 const listedFiles = await Promise.all(
                     list.map(async (file) => ({
                         id: file.id,
@@ -398,6 +407,8 @@ export const Drop = () => {
                     peerHash: peer?.identity?.publicKey?.hashcode?.() ?? null,
                     peerStatus,
                     peerLoading,
+                    connectionCount: connections.length,
+                    connectionPeers: connections,
                     programOpenDiagnostics:
                         files.program?.openDiagnostics ?? null,
                     lastUploadDiagnostics:
@@ -413,6 +424,8 @@ export const Drop = () => {
                     replicationSetSize: replicationSet.size,
                     isHost: isHost ?? null,
                     left,
+                    benchmarkStats:
+                        testWindow.__peerbitFileShareBenchmarkStats ?? null,
                     timings: diagnosticsRef.current,
                 };
             },
@@ -575,6 +588,16 @@ export const Drop = () => {
 
         const source =
             typeof sourceOrEvent === "string" ? sourceOrEvent : "event";
+        const benchmarkWindow = window as Window & {
+            __peerbitFileShareBenchmarkStats?: {
+                updateListCalls?: Array<Record<string, unknown>>;
+            };
+        };
+        const updateListStartedAt = performance.now();
+        const updateListStats: Record<string, unknown> = {
+            source,
+            startedAt: Date.now(),
+        };
 
         // TODO don't reload the whole list, just add the new elements..
         try {
@@ -584,7 +607,10 @@ export const Drop = () => {
                 diagnosticsRef.current.firstListStartedAt = startedAt;
                 diagnosticsRef.current.firstListSource = source;
             }
+            const listStartedAt = performance.now();
             const list = await files.program.list();
+            updateListStats.listMs = performance.now() - listStartedAt;
+            updateListStats.listCount = list.length;
             const finishedAt = Date.now();
             if (diagnosticsRef.current.firstListFinishedAt == null) {
                 diagnosticsRef.current.firstListFinishedAt = finishedAt;
@@ -606,10 +632,24 @@ export const Drop = () => {
             forceUpdate();
             void (async () => {
                 try {
+                    const metadataStartedAt = performance.now();
                     const [allFiles, replicators] = await Promise.all([
                         files.program.files.index.search(new SearchRequest({})),
                         files.program.files.log.getReplicators(),
                     ]);
+                    updateListStats.metadataMs =
+                        performance.now() - metadataStartedAt;
+                    updateListStats.replicationSetSize = allFiles.length;
+                    updateListStats.replicatorCount = replicators.size;
+                    updateListStats.totalMs =
+                        performance.now() - updateListStartedAt;
+                    const updateListCalls =
+                        benchmarkWindow.__peerbitFileShareBenchmarkStats
+                            ?.updateListCalls ?? [];
+                    updateListCalls.push(updateListStats);
+                    benchmarkWindow.__peerbitFileShareBenchmarkStats = {
+                        updateListCalls,
+                    };
                     setReplicationSet(new Set(allFiles.map((x) => x.id)));
                     setReplicatorCount(replicators.size);
                     if (

--- a/packages/file-share/frontend/tests/generated.upload-benchmark.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/generated.upload-benchmark.e2e.spec.ts
@@ -1,0 +1,532 @@
+import { test, type Page } from "@playwright/test";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { startBootstrapPeer } from "./bootstrapPeer";
+import {
+    createSpace,
+    expectSeedersAtLeast,
+    getSeederCount,
+    rootUrl,
+    uploadSyntheticFile,
+    waitForFileListed,
+    withBootstrap,
+} from "./helpers";
+
+const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "100");
+const POLL_MS = Number(process.env.PW_POLL_MS || "1000");
+const POST_UPLOAD_MONITOR_MS = Number(
+    process.env.PW_POST_UPLOAD_MONITOR_MS || "5000"
+);
+const UPLOAD_TIMEOUT_MS = Number(process.env.PW_UPLOAD_TIMEOUT_MS || "600000");
+const MODE = process.env.PW_REPLICATION_MODE || "adaptive";
+const NETWORK_MODE = process.env.PW_NETWORK_MODE || "local";
+const RESULT_FILE = process.env.PW_RESULT_FILE;
+const ENABLE_VISIBILITY_PROBE = process.env.PW_ENABLE_VISIBILITY_PROBE === "1";
+const MIN_READY_SEEDERS = Number(
+    process.env.PW_MIN_READY_SEEDERS || (MODE === "adaptive" ? "2" : "0")
+);
+const VERBOSE = process.env.PW_VERBOSE === "1";
+
+if (!["local", "remote"].includes(NETWORK_MODE)) {
+    throw new Error(`Unsupported PW_NETWORK_MODE='${NETWORK_MODE}'`);
+}
+
+const ROLE_BY_MODE: Record<string, any> = {
+    adaptive: {
+        limits: {
+            cpu: {
+                max: 1,
+            },
+        },
+    },
+    fixed1: { factor: 1 },
+    observer: false,
+};
+
+const MATCHED_ERRORS = [
+    "Failed to resolve block",
+    "DeliveryError",
+    "Failed to get message",
+    "delivery acknowledges",
+];
+
+const getRole = () => {
+    const role = ROLE_BY_MODE[MODE];
+    if (role === undefined) {
+        throw new Error(`Unsupported PW_REPLICATION_MODE='${MODE}'`);
+    }
+    return role;
+};
+
+const attachTransferErrorCollector = (
+    page: Page,
+    label: string,
+    output: string[]
+) => {
+    page.on("pageerror", (error) => {
+        const text = String(error?.message || error);
+        if (MATCHED_ERRORS.some((match) => text.includes(match))) {
+            output.push(`${label}:pageerror:${text}`);
+        }
+    });
+    page.on("console", (message) => {
+        const text = message.text();
+        if (MATCHED_ERRORS.some((match) => text.includes(match))) {
+            output.push(`${label}:console.${message.type()}:${text}`);
+        }
+    });
+};
+
+const waitForTestHooks = async (
+    page: Page,
+    options: { requireRoleSetter?: boolean } = {}
+) => {
+    await page.waitForFunction(
+        (requireRoleSetter) => {
+            const hooks = (window as any).__peerbitFileShareTestHooks;
+            return requireRoleSetter
+                ? Boolean(hooks?.setReplicationRole && hooks?.getDiagnostics)
+                : Boolean(hooks?.getDiagnostics);
+        },
+        Boolean(options.requireRoleSetter),
+        { timeout: 60_000 }
+    );
+};
+
+const applyRole = async (page: Page, shareUrl: string) => {
+    await page.goto(shareUrl, { waitUntil: "domcontentloaded" });
+    await waitForTestHooks(page, { requireRoleSetter: MODE !== "adaptive" });
+    if (MODE === "adaptive") {
+        return;
+    }
+    await page.evaluate(async (role) => {
+        const hooks = (window as any).__peerbitFileShareTestHooks;
+        if (!hooks?.setReplicationRole) {
+            throw new Error(
+                "Missing __peerbitFileShareTestHooks.setReplicationRole"
+            );
+        }
+        await hooks.setReplicationRole(role);
+    }, getRole());
+};
+
+const getDiagnostics = async (page: Page) => {
+    try {
+        return await page.evaluate(async () => {
+            const hooks = (window as any).__peerbitFileShareTestHooks;
+            const benchmarkStats = (window as any)
+                .__peerbitFileShareBenchmarkStats;
+            if (!hooks?.getDiagnostics) {
+                return benchmarkStats ? { benchmarkStats } : null;
+            }
+            return {
+                ...(await hooks.getDiagnostics()),
+                benchmarkStats: benchmarkStats ?? null,
+            };
+        });
+    } catch {
+        return null;
+    }
+};
+
+const probeVisibilityPath = async (page: Page) => {
+    try {
+        return await page.evaluate(async () => {
+            const hooks = (window as any).__peerbitFileShareTestHooks;
+            if (!hooks?.probeVisibilityPath) {
+                return null;
+            }
+            return await hooks.probeVisibilityPath();
+        });
+    } catch {
+        return null;
+    }
+};
+
+const persistResult = async (result: Record<string, unknown>) => {
+    if (!RESULT_FILE) {
+        return;
+    }
+    await mkdir(path.dirname(RESULT_FILE), { recursive: true });
+    await writeFile(RESULT_FILE, `${JSON.stringify(result, null, 2)}\n`);
+};
+
+const logStage = (stage: string, details: Record<string, unknown> = {}) => {
+    console.log(
+        `FILE_SHARE_BENCHMARK_STAGE ${JSON.stringify({
+            mode: MODE,
+            stage,
+            ...details,
+        })}`
+    );
+};
+
+const logSnapshot = (snapshot: Record<string, unknown>) => {
+    if (!VERBOSE) {
+        return;
+    }
+    console.log(
+        `FILE_SHARE_BENCHMARK_SNAPSHOT ${JSON.stringify({
+            mode: MODE,
+            ...snapshot,
+        })}`
+    );
+};
+
+test.describe("generated upload benchmark", () => {
+    test("measures file-share upload duration", async ({
+        browser,
+        baseURL,
+    }) => {
+        test.setTimeout(
+            Math.max(
+                20 * 60 * 1000,
+                UPLOAD_TIMEOUT_MS + POST_UPLOAD_MONITOR_MS + 5 * 60 * 1000
+            )
+        );
+        if (!baseURL) {
+            throw new Error("Missing baseURL");
+        }
+
+        const usesLocalBootstrap = NETWORK_MODE === "local";
+        const bootstrap:
+            | Awaited<ReturnType<typeof startBootstrapPeer>>
+            | undefined = usesLocalBootstrap
+            ? await startBootstrapPeer()
+            : undefined;
+        const fileName = `file-share-benchmark-${MODE}-${Date.now()}.bin`;
+        const writerContext = await browser.newContext({
+            acceptDownloads: true,
+        });
+        const readerContext = await browser.newContext({
+            acceptDownloads: true,
+        });
+        const writer = await writerContext.newPage();
+        const reader = await readerContext.newPage();
+        const errors: string[] = [];
+        const snapshots: Array<Record<string, unknown>> = [];
+        let stage = "setup";
+        let startedAt: number | undefined;
+        let finishedAt: number | undefined;
+        let shareUrl: string | undefined;
+        let progressVisibleAt: number | undefined;
+        let uploadSettledAt: number | undefined;
+        let writerListedAt: number | undefined;
+        let readerListedAt: number | undefined;
+        let writerVisibilityProbe: Record<string, unknown> | null = null;
+        let readerVisibilityProbe: Record<string, unknown> | null = null;
+        let dropped = false;
+        let baselineWriterSeeders = MIN_READY_SEEDERS;
+        let baselineReaderSeeders = MIN_READY_SEEDERS;
+        attachTransferErrorCollector(writer, "writer", errors);
+        attachTransferErrorCollector(reader, "reader", errors);
+
+        const snapshot = async (label: string) => {
+            const [
+                writerSeeders,
+                readerSeeders,
+                uploadVisible,
+                writerRow,
+                readerRow,
+            ] = await Promise.all([
+                getSeederCount(writer).catch((e) => `error:${e.message}`),
+                getSeederCount(reader).catch((e) => `error:${e.message}`),
+                writer
+                    .locator('[data-testid="upload-progress"], .progress-root')
+                    .first()
+                    .isVisible()
+                    .catch(() => false),
+                writer
+                    .locator("li", { hasText: fileName })
+                    .first()
+                    .isVisible()
+                    .catch(() => false),
+                reader
+                    .locator("li", { hasText: fileName })
+                    .first()
+                    .isVisible()
+                    .catch(() => false),
+            ]);
+
+            const state = {
+                label,
+                writerSeeders,
+                readerSeeders,
+                uploadVisible,
+                writerRow,
+                readerRow,
+                at: Date.now(),
+            };
+            snapshots.push(state);
+            logSnapshot(state);
+            return state;
+        };
+
+        const getPhaseDurations = () =>
+            startedAt == null
+                ? undefined
+                : {
+                      timeToProgressVisible:
+                          progressVisibleAt != null
+                              ? progressVisibleAt - startedAt
+                              : undefined,
+                      activeUpload:
+                          progressVisibleAt != null && uploadSettledAt != null
+                              ? uploadSettledAt - progressVisibleAt
+                              : uploadSettledAt != null
+                                ? uploadSettledAt - startedAt
+                                : undefined,
+                      timeToUploadSettled:
+                          uploadSettledAt != null
+                              ? uploadSettledAt - startedAt
+                              : undefined,
+                      writerListingLag:
+                          uploadSettledAt != null && writerListedAt != null
+                              ? writerListedAt - uploadSettledAt
+                              : undefined,
+                      readerListingLag:
+                          uploadSettledAt != null && readerListedAt != null
+                              ? readerListedAt - uploadSettledAt
+                              : undefined,
+                      readerAfterWriter:
+                          writerListedAt != null && readerListedAt != null
+                              ? readerListedAt - writerListedAt
+                              : undefined,
+                      timeToWriterListed:
+                          writerListedAt != null
+                              ? writerListedAt - startedAt
+                              : undefined,
+                      timeToReaderListed:
+                          readerListedAt != null
+                              ? readerListedAt - startedAt
+                              : undefined,
+                  };
+
+        try {
+            stage = "create-space";
+            logStage(stage, { networkMode: NETWORK_MODE });
+            const entryUrl =
+                usesLocalBootstrap && bootstrap
+                    ? withBootstrap(rootUrl(baseURL), bootstrap.addrs)
+                    : rootUrl(baseURL);
+            shareUrl = await createSpace(
+                writer,
+                entryUrl,
+                `file-share-benchmark-${MODE}-${Date.now()}`
+            );
+
+            stage = "open-share";
+            logStage(stage, { shareUrl });
+            await Promise.all([
+                applyRole(writer, shareUrl),
+                applyRole(reader, shareUrl),
+            ]);
+
+            stage = "wait-for-seeders";
+            logStage(stage, { minReadySeeders: MIN_READY_SEEDERS });
+            if (MIN_READY_SEEDERS > 0) {
+                await expectSeedersAtLeast(writer, MIN_READY_SEEDERS, 180_000);
+                await expectSeedersAtLeast(reader, MIN_READY_SEEDERS, 180_000);
+            } else {
+                await getSeederCount(writer);
+                await getSeederCount(reader);
+            }
+            const ready = await snapshot("seeders-ready");
+            baselineWriterSeeders =
+                typeof ready.writerSeeders === "number"
+                    ? ready.writerSeeders
+                    : MIN_READY_SEEDERS;
+            baselineReaderSeeders =
+                typeof ready.readerSeeders === "number"
+                    ? ready.readerSeeders
+                    : MIN_READY_SEEDERS;
+            logStage(stage, {
+                baselineWriterSeeders,
+                baselineReaderSeeders,
+            });
+
+            stage = "upload";
+            logStage(stage);
+            startedAt = Date.now();
+            stage = "wait-for-upload-input";
+            logStage(stage);
+            await writer.locator("#imgupload").waitFor({
+                state: "attached",
+                timeout: 60_000,
+            });
+            stage = "set-input-files";
+            logStage(stage);
+            await uploadSyntheticFile(writer, fileName, FILE_SIZE_MB);
+            stage = "wait-for-progress";
+            logStage(stage);
+            await writer
+                .locator('[data-testid="upload-progress"], .progress-root')
+                .first()
+                .waitFor({ state: "visible", timeout: 5000 })
+                .catch(() => {});
+            progressVisibleAt = Date.now();
+            stage = "monitor-upload";
+            logStage(stage);
+
+            let uploadCompleted = false;
+            while (!uploadCompleted) {
+                const current = await snapshot(`during-${snapshots.length}`);
+                if (
+                    typeof current.writerSeeders === "number" &&
+                    current.writerSeeders < baselineWriterSeeders
+                ) {
+                    dropped = true;
+                }
+                if (
+                    typeof current.readerSeeders === "number" &&
+                    current.readerSeeders < baselineReaderSeeders
+                ) {
+                    dropped = true;
+                }
+                uploadCompleted = !(current.uploadVisible as boolean);
+                if (uploadCompleted) {
+                    uploadSettledAt = current.at as number;
+                    break;
+                }
+                if (Date.now() - startedAt > UPLOAD_TIMEOUT_MS) {
+                    throw new Error(
+                        `Upload did not finish within ${UPLOAD_TIMEOUT_MS}ms: ${JSON.stringify(snapshots)}`
+                    );
+                }
+                await writer.waitForTimeout(POLL_MS);
+            }
+
+            if (ENABLE_VISIBILITY_PROBE) {
+                stage = "probe-visibility-path";
+                logStage(stage);
+                [writerVisibilityProbe, readerVisibilityProbe] =
+                    await Promise.all([
+                        probeVisibilityPath(writer),
+                        probeVisibilityPath(reader),
+                    ]);
+            }
+
+            stage = "wait-for-listing";
+            logStage(stage);
+            [writerListedAt, readerListedAt] = await Promise.all([
+                (async () => {
+                    await waitForFileListed(writer, fileName, 180_000);
+                    return Date.now();
+                })(),
+                (async () => {
+                    await waitForFileListed(reader, fileName, 180_000);
+                    return Date.now();
+                })(),
+            ]);
+
+            stage = "post-upload-monitor";
+            logStage(stage);
+            const deadline = Date.now() + POST_UPLOAD_MONITOR_MS;
+            while (Date.now() < deadline) {
+                const current = await snapshot(`after-${snapshots.length}`);
+                if (
+                    typeof current.writerSeeders === "number" &&
+                    current.writerSeeders < baselineWriterSeeders
+                ) {
+                    dropped = true;
+                }
+                if (
+                    typeof current.readerSeeders === "number" &&
+                    current.readerSeeders < baselineReaderSeeders
+                ) {
+                    dropped = true;
+                }
+                await writer.waitForTimeout(POLL_MS);
+            }
+
+            stage = "complete";
+            logStage(stage);
+            finishedAt = Date.now();
+            const result = {
+                status: "passed",
+                mode: MODE,
+                networkMode: NETWORK_MODE,
+                fileSizeMb: FILE_SIZE_MB,
+                uploadDurationMs: finishedAt - startedAt,
+                postUploadMonitorMs: POST_UPLOAD_MONITOR_MS,
+                pollMs: POLL_MS,
+                uploadTimeoutMs: UPLOAD_TIMEOUT_MS,
+                minReadySeeders: MIN_READY_SEEDERS,
+                baselineWriterSeeders,
+                baselineReaderSeeders,
+                shareUrl,
+                droppedSeeders: dropped,
+                phaseDurationsMs: getPhaseDurations(),
+                writerVisibilityProbe,
+                readerVisibilityProbe,
+                errorCount: errors.length,
+                errors,
+                snapshots,
+                writerDiagnostics: await getDiagnostics(writer),
+                readerDiagnostics: await getDiagnostics(reader),
+            };
+
+            await persistResult(result);
+            console.log(
+                `FILE_SHARE_BENCHMARK_RESULT ${JSON.stringify(result)}`
+            );
+
+            if (dropped) {
+                throw new Error(
+                    `Seeder counts dropped during benchmark: ${JSON.stringify(snapshots)}`
+                );
+            }
+            if (errors.length > 0) {
+                throw new Error(
+                    `Observed transfer/delivery errors: ${JSON.stringify(errors)}`
+                );
+            }
+        } catch (error: any) {
+            await snapshot(`failure-${stage}`).catch(() => {});
+            const result = {
+                status: "failed",
+                mode: MODE,
+                networkMode: NETWORK_MODE,
+                fileSizeMb: FILE_SIZE_MB,
+                stage,
+                uploadDurationMs:
+                    startedAt != null ? Date.now() - startedAt : undefined,
+                postUploadMonitorMs: POST_UPLOAD_MONITOR_MS,
+                pollMs: POLL_MS,
+                uploadTimeoutMs: UPLOAD_TIMEOUT_MS,
+                minReadySeeders: MIN_READY_SEEDERS,
+                baselineWriterSeeders,
+                baselineReaderSeeders,
+                shareUrl,
+                droppedSeeders: dropped,
+                phaseDurationsMs: getPhaseDurations(),
+                writerVisibilityProbe,
+                readerVisibilityProbe,
+                errorCount: errors.length,
+                errors,
+                snapshots,
+                writerDiagnostics: await getDiagnostics(writer),
+                readerDiagnostics: await getDiagnostics(reader),
+                failure: {
+                    message:
+                        typeof error?.message === "string"
+                            ? error.message
+                            : String(error),
+                    stack:
+                        typeof error?.stack === "string"
+                            ? error.stack
+                            : undefined,
+                },
+            };
+            await persistResult(result);
+            console.error(
+                `FILE_SHARE_BENCHMARK_RESULT ${JSON.stringify(result)}`
+            );
+            throw error;
+        } finally {
+            await writerContext.close().catch(() => {});
+            await readerContext.close().catch(() => {});
+            await bootstrap?.stop().catch(() => {});
+        }
+    });
+});

--- a/packages/file-share/frontend/vite.config.remote.ts
+++ b/packages/file-share/frontend/vite.config.remote.ts
@@ -1,10 +1,16 @@
-import { defineConfig, loadEnv } from "vite";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import fs from "fs";
 
 import peerbit from "@peerbit/vite";
 // @ts-ignore
 import tailwindcss from "@tailwindcss/vite";
+
+const workspaceRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const workspaceModule = (specifier: string) =>
+    path.join(workspaceRoot, "node_modules", ...specifier.split("/"));
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -13,7 +19,16 @@ export default defineConfig({
         keepNames: true,
     },
     resolve: {
+        /* peerbit-benchmark-vite */
+        alias: {
+            react: workspaceModule("react"),
+            "react-dom": workspaceModule("react-dom"),
+            "@dao-xyz/borsh": workspaceModule("@dao-xyz/borsh"),
+        },
         dedupe: [
+            "react",
+            "react-dom",
+            "@dao-xyz/borsh",
             "peerbit",
             "@peerbit/crypto",
             "@peerbit/document",

--- a/packages/file-share/frontend/vite.config.ts
+++ b/packages/file-share/frontend/vite.config.ts
@@ -1,8 +1,14 @@
-import { defineConfig, loadEnv } from "vite";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import peerbit from "@peerbit/vite";
 // @ts-ignore
 import tailwindcss from "@tailwindcss/vite";
+
+const workspaceRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const workspaceModule = (specifier: string) =>
+    path.join(workspaceRoot, "node_modules", ...specifier.split("/"));
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -11,7 +17,16 @@ export default defineConfig({
         keepNames: true,
     },
     resolve: {
+        /* peerbit-benchmark-vite */
+        alias: {
+            react: workspaceModule("react"),
+            "react-dom": workspaceModule("react-dom"),
+            "@dao-xyz/borsh": workspaceModule("@dao-xyz/borsh"),
+        },
         dedupe: [
+            "react",
+            "react-dom",
+            "@dao-xyz/borsh",
             "peerbit",
             "@peerbit/crypto",
             "@peerbit/document",

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -476,6 +476,52 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
+        it("scales chunk lookup attempt timeouts for large persisted chunks", async () => {
+            const filestore = await peer.open(new Files());
+            const file = new LargeFile({
+                id: "large-timeout-scale",
+                name: "large timeout scale",
+                size: BigInt(512 * 1024 * 1024),
+                chunkCount: 256,
+                ready: true,
+            });
+            const originalGet = filestore.files.index.get.bind(
+                filestore.files.index
+            );
+
+            (filestore.files.index as any).get = async (
+                id: string,
+                options: unknown
+            ) => {
+                if (id.startsWith(`${file.id}:`)) {
+                    throw new Error("stop after timeout diagnostic");
+                }
+                return originalGet(id as never, options as never);
+            };
+
+            try {
+                await file.writeFile(
+                    filestore,
+                    { write: async () => {} },
+                    { timeout: 60_000 }
+                );
+                expect.fail("expected chunk resolution to fail");
+            } catch (error) {
+                expect((error as Error).message).to.contain(
+                    "stop after timeout diagnostic"
+                );
+            } finally {
+                (filestore.files.index as any).get = originalGet;
+            }
+
+            expect(
+                filestore.lastReadDiagnostics?.chunkAttemptTimeoutMs
+            ).to.be.greaterThan(5_000);
+            expect(
+                filestore.lastReadDiagnostics?.chunkAttemptTimeoutMs
+            ).to.be.lessThanOrEqual(45_000);
+        });
+
         it("falls back to indexed chunk search when direct chunk lookup misses", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -325,6 +325,11 @@ const LARGE_FILE_PENDING_STREAM_MIN_CHUNKS = LARGE_FILE_TARGET_CHUNK_COUNT / 2;
 const LARGE_FILE_PERSISTED_READ_AHEAD = 4;
 const LARGE_FILE_OBSERVER_READ_AHEAD = 2;
 const LARGE_FILE_OBSERVER_PREFETCH_TIMEOUT_MS = 5_000;
+const LARGE_FILE_MIN_CHUNK_ATTEMPT_TIMEOUT_MS = 5_000;
+const LARGE_FILE_MAX_CHUNK_ATTEMPT_TIMEOUT_MS = 45_000;
+const LARGE_FILE_REMOTE_CHUNK_TIMEOUT_OVERHEAD_MS = 5_000;
+const LARGE_FILE_REMOTE_CHUNK_TIMEOUT_SCALE_MIN_BYTES = 1 * 1024 * 1024;
+const LARGE_FILE_REMOTE_CHUNK_MIN_BYTES_PER_SECOND = 128 * 1024;
 const TINY_FILE_SIZE_LIMIT_BIGINT = BigInt(TINY_FILE_SIZE_LIMIT);
 
 const roundUpTo = (value: number, multiple: number) =>
@@ -351,6 +356,39 @@ const getChunkCount = (
     size: number | bigint,
     chunkSize = LARGE_FILE_SEGMENT_SIZE
 ) => Math.ceil(Number(size) / chunkSize);
+const getChunkByteLength = (
+    size: number | bigint,
+    chunkCount: number,
+    index: number
+) => {
+    const total = Number(size);
+    const estimatedChunkSize = Math.ceil(total / Math.max(chunkCount, 1));
+    const start = index * estimatedChunkSize;
+    return Math.max(0, Math.min(estimatedChunkSize, total - start));
+};
+const getChunkLookupAttemptTimeout = (
+    size: number | bigint,
+    chunkCount: number,
+    index: number,
+    totalTimeout: number
+) => {
+    const chunkBytes = getChunkByteLength(size, chunkCount, index);
+    const scaledTimeout =
+        chunkBytes > LARGE_FILE_REMOTE_CHUNK_TIMEOUT_SCALE_MIN_BYTES
+            ? LARGE_FILE_REMOTE_CHUNK_TIMEOUT_OVERHEAD_MS +
+              Math.ceil(
+                  (chunkBytes / LARGE_FILE_REMOTE_CHUNK_MIN_BYTES_PER_SECOND) *
+                      1000
+              )
+            : LARGE_FILE_MIN_CHUNK_ATTEMPT_TIMEOUT_MS;
+    return Math.min(
+        totalTimeout,
+        Math.max(
+            LARGE_FILE_MIN_CHUNK_ATTEMPT_TIMEOUT_MS,
+            Math.min(scaledTimeout, LARGE_FILE_MAX_CHUNK_ATTEMPT_TIMEOUT_MS)
+        )
+    );
+};
 const getChunkId = (parentId: string, index: number) => `${parentId}:${index}`;
 const createUploadId = () => toBase64URL(randomBytes(16));
 const getEntryHash = (entry: unknown) =>
@@ -640,7 +678,12 @@ export class LargeFile extends AbstractFile {
         const totalTimeout =
             properties?.timeout ?? LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS;
         const deadline = Date.now() + totalTimeout;
-        const attemptTimeout = Math.min(totalTimeout, 5_000);
+        const attemptTimeout = getChunkLookupAttemptTimeout(
+            this.size,
+            this.chunkCount,
+            index,
+            totalTimeout
+        );
         if (properties?.debug) {
             properties.debug.chunkAttemptTimeoutMs = attemptTimeout;
         }


### PR DESCRIPTION
Adds a generated Playwright upload benchmark for file-share and exposes benchmark diagnostics from the app so runner artifacts can capture listing, replication, connection, and timing data. Also scales large-file chunk fetch attempt timeouts so public-runner downloads have enough time to materialize multi-MiB chunks without changing the total read timeout.\n\nLocal verification:\n- pnpm --filter @peerbit/please-lib exec vitest run src/__tests__/index.integration.test.ts -t "pipelines persisted chunk reads|scales chunk lookup attempt timeouts"\n- pnpm --filter @peerbit/please-lib test\n- pnpm --filter @peerbit/please-lib build\n- pnpm --filter file-share build\n- pnpm exec prettier --check packages/file-share/library/src/index.ts packages/file-share/library/src/__tests__/index.integration.test.ts packages/file-share/frontend/src/Drop.tsx packages/file-share/frontend/tests/generated.upload-benchmark.e2e.spec.ts packages/file-share/frontend/vite.config.ts packages/file-share/frontend/vite.config.remote.ts\n- pnpm --filter file-share exec playwright test tests/generated.upload-benchmark.e2e.spec.ts --list\n\nRunner verification:\n- File Share Benchmarks on this branch: passed (25089322348)\n- File Share Two-Runner Benchmarks still fails against current deployed master because the workflow targets https://files.dao.xyz and does not deploy PR branches; rerun after merge/deploy will validate this PR in prod.