### PR TITLE
Stabilize file-share ready manifests for adaptive reads

### DIFF
--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -247,6 +247,53 @@ describe("index", () => {
             expect(equals(file!.bytes, largeFile)).to.be.true;
         });
 
+        it("links streamed ready manifests after pending upload manifests", async () => {
+            const filestore = await peer.open(new Files());
+            const originalPut = filestore.files.put.bind(filestore.files);
+            let pendingHead: string | undefined;
+            let readyNext: unknown[] | undefined;
+
+            (filestore.files as any).put = async (
+                entry: unknown,
+                options: unknown
+            ) => {
+                const result = await originalPut(
+                    entry as never,
+                    options as never
+                );
+                if (entry instanceof LargeFile && entry.ready === false) {
+                    pendingHead = result.entry.hash;
+                }
+                if (entry instanceof LargeFile && entry.ready === true) {
+                    readyNext = result.entry.meta.next;
+                }
+                return result;
+            };
+
+            try {
+                const largeFile = crypto.randomBytes(6 * 1e6) as Uint8Array;
+                const fileId = await filestore.add(
+                    "linked streamed ready manifest",
+                    new Blob([largeFile])
+                );
+                const listed = await filestore.list();
+                const listedFile = listed.find((file) => file.id === fileId);
+
+                expect(pendingHead).to.be.a("string");
+                expect(
+                    readyNext?.some((next: any) =>
+                        typeof next === "string"
+                            ? next === pendingHead
+                            : next?.hash === pendingHead
+                    )
+                ).to.be.true;
+                expect(listedFile).to.be.instanceOf(LargeFile);
+                expect((listedFile as LargeFile).ready).to.be.true;
+            } finally {
+                (filestore.files as any).put = originalPut;
+            }
+        });
+
         it("streams downloaded files chunk by chunk", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
@@ -520,6 +567,28 @@ describe("index", () => {
             expect(
                 filestore.lastReadDiagnostics?.chunkAttemptTimeoutMs
             ).to.be.lessThanOrEqual(45_000);
+        });
+
+        it("caps large file chunks to browser transport-safe payloads", async () => {
+            const filestore = await peer.open(new Files());
+            let observedChunkSize: number | undefined;
+
+            try {
+                await filestore.addSource("transport-safe chunks", {
+                    size: BigInt(512 * 1024 * 1024),
+                    readChunks: async function* (chunkSize: number) {
+                        observedChunkSize = chunkSize;
+                        yield new Uint8Array(0);
+                    },
+                });
+                expect.fail("expected source size mismatch");
+            } catch (error) {
+                expect((error as Error).message).to.contain(
+                    "Source size changed during upload"
+                );
+            }
+
+            expect(observedChunkSize).to.eq(512 * 1024);
         });
 
         it("falls back to indexed chunk search when direct chunk lookup misses", async () => {
@@ -2904,7 +2973,7 @@ describe("index", () => {
             expect(decodedIndexable.size).to.eq(size);
         });
 
-        it("scales chunk sizes for multi-gigabyte sources", async () => {
+        it("caps chunk sizes for multi-gigabyte browser sources", async () => {
             const filestore = await peer.open(new Files());
             let requestedChunkSize = 0;
             let error: any;
@@ -2922,11 +2991,10 @@ describe("index", () => {
             }
 
             expect(error?.message).to.eq("stop-after-measuring");
-            expect(requestedChunkSize).to.be.greaterThan(500_000);
-            expect(requestedChunkSize).to.be.greaterThan(4_000_000);
+            expect(requestedChunkSize).to.eq(512 * 1024);
         });
 
-        it("keeps runner-sized uploads to a bounded chunk count", async () => {
+        it("keeps runner-sized uploads to browser-safe chunks", async () => {
             const filestore = await peer.open(new Files());
             let requestedChunkSize = 0;
             let error: any;
@@ -2944,9 +3012,7 @@ describe("index", () => {
             }
 
             expect(error?.message).to.eq("stop-after-measuring");
-            expect(requestedChunkSize).to.be.greaterThanOrEqual(
-                2 * 1024 * 1024
-            );
+            expect(requestedChunkSize).to.eq(512 * 1024);
         });
 
         it("exposes large file metadata before chunk upload finishes", async () => {

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -319,7 +319,7 @@ const TINY_FILE_SIZE_LIMIT = 5 * 1e6; // 6mb
 const LARGE_FILE_SEGMENT_SIZE = TINY_FILE_SIZE_LIMIT / 10;
 const LARGE_FILE_TARGET_CHUNK_COUNT = 256;
 const CHUNK_SIZE_GRANULARITY = 64 * 1024;
-const MAX_LARGE_FILE_SEGMENT_SIZE = TINY_FILE_SIZE_LIMIT - 256 * 1024;
+const MAX_LARGE_FILE_SEGMENT_SIZE = 512 * 1024;
 const LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS = 5 * 60 * 1000;
 const LARGE_FILE_PENDING_STREAM_MIN_CHUNKS = LARGE_FILE_TARGET_CHUNK_COUNT / 2;
 const LARGE_FILE_PERSISTED_READ_AHEAD = 4;
@@ -2484,7 +2484,7 @@ export class Files extends Program<Args> {
             ready: false,
         });
 
-        await this.files.put(manifest);
+        const pendingManifest = await this.files.put(manifest);
         const hasher = new SHA256();
         try {
             let uploadedBytes = 0n;
@@ -2518,7 +2518,8 @@ export class Files extends Program<Args> {
                     ready: true,
                     finalHash: toBase64(hasher.digest()),
                     chunkEntryHeads,
-                })
+                }),
+                { meta: { next: [pendingManifest.entry] } }
             );
         } catch (error) {
             await this.cleanupChunkedUpload(uploadId).catch(() => {});
@@ -2593,7 +2594,7 @@ export class Files extends Program<Args> {
         });
 
         diagnostics.manifestStartedAt = Date.now();
-        await this.files.put(manifest);
+        const pendingManifest = await this.files.put(manifest);
         diagnostics.manifestFinishedAt = Date.now();
         const hasher = new SHA256();
         try {
@@ -2653,7 +2654,8 @@ export class Files extends Program<Args> {
                     ready: true,
                     finalHash: toBase64(hasher.digest()),
                     chunkEntryHeads,
-                })
+                }),
+                { meta: { next: [pendingManifest.entry] } }
             );
             diagnostics.readyManifestFinishedAt = Date.now();
         } catch (error) {


### PR DESCRIPTION
## Summary
- Link ready upload manifests explicitly after the pending manifest entry so adaptive readers do not see stale pending roots as concurrent winners.
- Cap large-file chunk payloads at 512 KiB to avoid multi-megabyte browser block responses during public runner transfers.
- Add regression coverage for ready-manifest ancestry and browser-safe chunk sizing.

## Verification
- pnpm --filter @peerbit/please-lib exec vitest run src/__tests__/index.integration.test.ts -t "links streamed ready manifests|caps large file chunks|keeps runner-sized uploads"
- pnpm --filter @peerbit/please-lib test
- pnpm --filter @peerbit/please-lib build
- pnpm --filter file-share build
- pnpm exec prettier --check packages/file-share/library/src/index.ts packages/file-share/library/src/__tests__/index.integration.test.ts
- git diff --check
- pnpm --filter file-share exec playwright test tests/generated.upload-benchmark.e2e.spec.ts --list

## Notes
The deployed 128 MiB two-runner probe failed before this fix because readers repeatedly saw a pending root and never resolved a ready manifest within the app download timeout. The 512 MiB deployed run also confirmed the timeout-scaling code was active, then failed on remote chunk materialization for 2 MiB chunks. This PR addresses both observed paths without changing adaptive replication to fixed-size replication.