### PR TITLE
Stabilize file-share pending manifest streaming

### DIFF
--- a/packages/file-share/frontend/tests/two-runner.bench.mjs
+++ b/packages/file-share/frontend/tests/two-runner.bench.mjs
@@ -315,6 +315,103 @@ const parseEventBody = (body) => {
     }
 };
 
+const countObjectKeys = (value) =>
+    value && typeof value === "object" && !Array.isArray(value)
+        ? Object.keys(value).length
+        : undefined;
+
+const tail = (value, count = 5) =>
+    Array.isArray(value)
+        ? value.slice(Math.max(0, value.length - count))
+        : value;
+
+const compactReadDiagnostics = (diagnostics = {}) => ({
+    waitUntilReadyResolvedBy: diagnostics.waitUntilReadyResolvedBy,
+    waitUntilReadyResolvedReady: diagnostics.waitUntilReadyResolvedReady,
+    waitUntilReadyAttempts: diagnostics.waitUntilReadyAttempts,
+    lastReadyProbe: diagnostics.lastReadyProbe,
+    chunkAttemptTimeoutMs: diagnostics.chunkAttemptTimeoutMs,
+    readAhead: diagnostics.readAhead,
+    prefetchedChunkCount: diagnostics.prefetchedChunkCount,
+    chunkAttemptsCount: countObjectKeys(diagnostics.chunkAttempts),
+    chunkResolvedCount: countObjectKeys(diagnostics.chunkResolved),
+    chunkManifestHeadsCount: countObjectKeys(diagnostics.chunkManifestHeads),
+    chunkIndexedHeadsCount: countObjectKeys(diagnostics.chunkIndexedHeads),
+    chunkHeadGetsCount: countObjectKeys(diagnostics.chunkHeadGets),
+    readyRemoteGetHeadsCount: diagnostics.readyRemoteGetHeads?.length,
+    readyRemoteGetHeads: tail(diagnostics.readyRemoteGetHeads),
+    readyRemoteDecodeFallbacks: tail(diagnostics.readyRemoteDecodeFallbacks),
+    chunkFailure: diagnostics.chunkFailure,
+    finishedAt: diagnostics.finishedAt,
+});
+
+const compactDiagnostics = (diagnostics) => {
+    if (!diagnostics || typeof diagnostics !== "object") {
+        return diagnostics;
+    }
+    return {
+        programAddress: diagnostics.programAddress,
+        programClosed: diagnostics.programClosed,
+        persistChunkReads: diagnostics.persistChunkReads,
+        peerHash: diagnostics.peerHash,
+        peerStatus: diagnostics.peerStatus,
+        connectionCount: diagnostics.connectionCount,
+        connectionPeers: tail(diagnostics.connectionPeers),
+        replicatorCount: diagnostics.replicatorCount,
+        listCount: diagnostics.listCount,
+        listedFiles: diagnostics.listedFiles,
+        replicationSetSize: diagnostics.replicationSetSize,
+        lastUploadDiagnostics: diagnostics.lastUploadDiagnostics,
+        lastReadDiagnostics: compactReadDiagnostics(
+            diagnostics.lastReadDiagnostics
+        ),
+        benchmarkStats: diagnostics.benchmarkStats
+            ? {
+                  updateListCalls: tail(
+                      diagnostics.benchmarkStats.updateListCalls
+                  ),
+              }
+            : diagnostics.benchmarkStats,
+        timings: diagnostics.timings,
+    };
+};
+
+const compactCoordinationPayload = (payload) => {
+    if (!payload || typeof payload !== "object") {
+        return payload;
+    }
+    return {
+        ...payload,
+        writerDiagnostics: compactDiagnostics(payload.writerDiagnostics),
+        readerDiagnostics: compactDiagnostics(payload.readerDiagnostics),
+        reader: compactCoordinationPayload(payload.reader),
+    };
+};
+
+const minimalCoordinationPayload = (payload) => {
+    if (!payload || typeof payload !== "object") {
+        return payload;
+    }
+    return {
+        status: payload.status,
+        role: payload.role,
+        readerRole: payload.readerRole,
+        scenario: payload.scenario,
+        baseURL: payload.baseURL,
+        shareUrl: payload.shareUrl,
+        address: payload.address,
+        fileName: payload.fileName,
+        fileSizeMb: payload.fileSizeMb,
+        sizeBytes: payload.sizeBytes,
+        uploadDurationMs: payload.uploadDurationMs,
+        uploadMbps: payload.uploadMbps,
+        downloadDurationMs: payload.downloadDurationMs,
+        downloadMbps: payload.downloadMbps,
+        listingWaitMs: payload.listingWaitMs,
+        failure: payload.failure,
+    };
+};
+
 const createFileCoordinator = (filePath) => ({
     async publish(kind, payload) {
         await mkdir(path.dirname(filePath), { recursive: true });
@@ -376,13 +473,17 @@ const githubRequest = async (url, init = {}) => {
 
 const createGithubCoordinator = () => {
     const issueUrl = `https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${COORDINATION_ISSUE}/comments?per_page=100`;
+    const makeBody = (kind, payload) =>
+        `${marker(kind)}\n\`\`\`json\n${JSON.stringify(payload, null, 2)}\n\`\`\``;
     return {
         async publish(kind, payload) {
-            const body = `${marker(kind)}\n\`\`\`json\n${JSON.stringify(
-                payload,
-                null,
-                2
-            )}\n\`\`\``;
+            let body = makeBody(kind, payload);
+            if (body.length > 60_000) {
+                body = makeBody(kind, compactCoordinationPayload(payload));
+            }
+            if (body.length > 60_000) {
+                body = makeBody(kind, minimalCoordinationPayload(payload));
+            }
             await githubRequest(issueUrl, {
                 method: "POST",
                 body: JSON.stringify({ body }),

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -289,6 +289,9 @@ describe("index", () => {
                 ).to.be.true;
                 expect(listedFile).to.be.instanceOf(LargeFile);
                 expect((listedFile as LargeFile).ready).to.be.true;
+                expect(
+                    filestore.lastUploadDiagnostics?.readyManifestFinishedAt
+                ).to.be.a("number");
             } finally {
                 (filestore.files as any).put = originalPut;
             }
@@ -1594,6 +1597,86 @@ describe("index", () => {
             ).to.eq("complete-chunks");
             expect(streamedChunks.length).to.be.greaterThan(1);
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
+        it("streams a pending manifest when remote boundary chunks prove the upload is complete", async () => {
+            const filestore = await peer.open(new Files());
+            const filestoreReader = await peer2.open<Files>(filestore.address, {
+                args: {
+                    replicate: { limits: { cpu: { max: 1 } } },
+                },
+            });
+            await filestoreReader.files.log.waitForReplicator(
+                peer.identity.publicKey
+            );
+
+            const fileId = "pending-boundary-chunks";
+            const fileName = "pending-boundary-chunks.bin";
+            const chunks = [
+                new Uint8Array([1, 2, 3]),
+                new Uint8Array([4, 5, 6]),
+                new Uint8Array([7, 8, 9]),
+                new Uint8Array([10, 11, 12]),
+            ];
+            const expected = concat(chunks);
+            await filestore.files.put(
+                new LargeFile({
+                    id: fileId,
+                    name: fileName,
+                    size: BigInt(expected.byteLength),
+                    chunkCount: chunks.length,
+                    ready: false,
+                })
+            );
+            for (let index = 0; index < chunks.length; index++) {
+                await filestore.files.put(
+                    new TinyFile({
+                        id: `${fileId}:${index}`,
+                        name: `${fileName}/${index}`,
+                        file: chunks[index],
+                        parentId: fileId,
+                        index,
+                    })
+                );
+            }
+
+            let pendingFile: LargeFile | undefined;
+            await waitForResolved(
+                async () => {
+                    const match = await filestoreReader.resolveById(fileId, {
+                        replicate: true,
+                        timeout: 1_000,
+                    });
+                    expect(match).to.be.instanceOf(LargeFile);
+                    expect((match as LargeFile).ready).to.be.false;
+                    pendingFile = match as LargeFile;
+                },
+                { timeout: 30_000, delayInterval: 200 }
+            );
+
+            const originalCountLocalChunks =
+                filestoreReader.countLocalChunks.bind(filestoreReader);
+            (filestoreReader as any).countLocalChunks = async () => 0;
+            const streamedChunks: Uint8Array[] = [];
+            try {
+                await pendingFile!.writeFile(
+                    filestoreReader,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestoreReader as any).countLocalChunks =
+                    originalCountLocalChunks;
+            }
+
+            expect(
+                filestoreReader.lastReadDiagnostics?.waitUntilReadyResolvedBy
+            ).to.eq("pending-manifest-boundary-chunks");
+            expect(equals(concat(streamedChunks), expected)).to.be.true;
         });
 
         it("checks local complete chunks while read peer hints are present", async () => {

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -1568,6 +1568,47 @@ export class LargeFile extends AbstractFile {
                 (file as any).chunkEntryHeads.some(
                     (head: unknown) => typeof head === "string"
                 );
+            const hasIndexedChunk = (
+                candidate: unknown,
+                file: LargeFile,
+                index: number
+            ) => {
+                const chunk = candidate as Partial<TinyFile> &
+                    Partial<IndexableFile>;
+                const chunkId = getChunkId(file.id, index);
+                return candidate instanceof TinyFile ||
+                    candidate instanceof IndexableFile ||
+                    (candidate != null && typeof candidate === "object")
+                    ? chunk.parentId === file.id &&
+                          chunk.id === chunkId &&
+                          (chunk.index === index ||
+                              chunk.name === `${file.name}/${index}`)
+                    : false;
+            };
+            const hasBoundaryChunks = async (file: LargeFile) => {
+                const indexes =
+                    file.chunkCount <= 1 ? [0] : [0, file.chunkCount - 1];
+                for (const index of indexes) {
+                    const chunkId = getChunkId(file.id, index);
+                    const chunk = await files.files.index.get(chunkId, {
+                        resolve: false,
+                        local: true,
+                        remote: {
+                            timeout: attemptTimeout,
+                            strategy: "always" as any,
+                            throwOnMissing: false,
+                            retryMissingResponses: true,
+                            replicate: files.persistChunkReads,
+                            from: remoteFrom,
+                        },
+                    });
+                    if (!hasIndexedChunk(chunk, file, index)) {
+                        return false;
+                    }
+                    files.retainResolvedChunk(chunk);
+                }
+                return true;
+            };
             const localMatches = await files.files.index.search(request, {
                 local: true,
                 remote: false,
@@ -1804,6 +1845,25 @@ export class LargeFile extends AbstractFile {
                     debug.waitUntilReadyResolvedBy = "pending-manifest";
                 }
                 return readinessCandidate;
+            }
+            if (
+                files.persistChunkReads &&
+                countCandidate.chunkCount > 0 &&
+                !countCandidate.ready &&
+                (await hasBoundaryChunks(countCandidate).catch((error) => {
+                    if (debug) {
+                        (debug.readyBoundaryChunkErrors ||= []).push(
+                            getErrorMessage(error)
+                        );
+                    }
+                    return false;
+                }))
+            ) {
+                if (debug) {
+                    debug.waitUntilReadyResolvedBy =
+                        "pending-manifest-boundary-chunks";
+                }
+                return countCandidate;
             }
 
             await sleep(250);
@@ -2476,15 +2536,44 @@ export class Files extends Program<Args> {
         const size = source.size;
         const chunkSize = getLargeFileSegmentSize(size);
         const uploadId = createUploadId();
+        const expectedChunkCount = getChunkCount(size, chunkSize);
+        const diagnostics: UploadDiagnostics = {
+            uploadId,
+            fileName: name,
+            sizeBytes: Number(size),
+            chunkSize,
+            chunkCount: expectedChunkCount,
+            startedAt: Date.now(),
+            manifestStartedAt: null,
+            manifestFinishedAt: null,
+            firstChunkStartedAt: null,
+            firstChunkFinishedAt: null,
+            lastChunkFinishedAt: null,
+            chunkPutCount: 0,
+            chunkReadTotalMs: 0,
+            chunkReadMaxMs: 0,
+            chunkPutTotalMs: 0,
+            chunkPutMaxMs: 0,
+            slowestChunkIndex: null,
+            slowestChunkPutMs: null,
+            readyManifestStartedAt: null,
+            readyManifestFinishedAt: null,
+            finishedAt: null,
+            failureAt: null,
+            failureMessage: null,
+        };
+        this.lastUploadDiagnostics = diagnostics;
         const manifest = new LargeFile({
             id: uploadId,
             name,
             size,
-            chunkCount: getChunkCount(size, chunkSize),
+            chunkCount: expectedChunkCount,
             ready: false,
         });
 
+        diagnostics.manifestStartedAt = Date.now();
         const pendingManifest = await this.files.put(manifest);
+        diagnostics.manifestFinishedAt = Date.now();
         const hasher = new SHA256();
         try {
             let uploadedBytes = 0n;
@@ -2492,6 +2581,8 @@ export class Files extends Program<Args> {
             const chunkEntryHeads: string[] = [];
             for await (const chunkBytes of source.readChunks(chunkSize)) {
                 hasher.update(chunkBytes);
+                const putStartedAt = Date.now();
+                diagnostics.firstChunkStartedAt ??= putStartedAt;
                 const chunk = new TinyFile({
                     name: name + "/" + chunkCount,
                     file: chunkBytes,
@@ -2504,11 +2595,29 @@ export class Files extends Program<Args> {
                 });
                 this.retainAuthoredChunk(chunk, appended.entry.hash);
                 chunkEntryHeads[chunkCount] = appended.entry.hash;
+                const putFinishedAt = Date.now();
+                const putDurationMs = putFinishedAt - putStartedAt;
+                diagnostics.firstChunkFinishedAt ??= putFinishedAt;
+                diagnostics.lastChunkFinishedAt = putFinishedAt;
+                diagnostics.chunkPutCount += 1;
+                diagnostics.chunkPutTotalMs += putDurationMs;
+                diagnostics.chunkPutMaxMs = Math.max(
+                    diagnostics.chunkPutMaxMs,
+                    putDurationMs
+                );
+                if (
+                    diagnostics.slowestChunkPutMs == null ||
+                    putDurationMs > diagnostics.slowestChunkPutMs
+                ) {
+                    diagnostics.slowestChunkPutMs = putDurationMs;
+                    diagnostics.slowestChunkIndex = chunkCount;
+                }
                 uploadedBytes += BigInt(chunkBytes.byteLength);
                 chunkCount++;
                 progress?.(Number(uploadedBytes) / Math.max(Number(size), 1));
             }
             ensureSourceSize(uploadedBytes, source.size);
+            diagnostics.readyManifestStartedAt = Date.now();
             await this.files.put(
                 new LargeFileWithChunkHeads({
                     id: uploadId,
@@ -2521,12 +2630,18 @@ export class Files extends Program<Args> {
                 }),
                 { meta: { next: [pendingManifest.entry] } }
             );
+            diagnostics.readyManifestFinishedAt = Date.now();
+            diagnostics.chunkCount = chunkCount;
         } catch (error) {
+            diagnostics.failureAt = Date.now();
+            diagnostics.failureMessage =
+                error instanceof Error ? error.message : String(error);
             await this.cleanupChunkedUpload(uploadId).catch(() => {});
             await this.files.del(uploadId).catch(() => {});
             throw error;
         }
 
+        diagnostics.finishedAt = Date.now();
         progress?.(1);
         return uploadId;
     }


### PR DESCRIPTION
## Summary
- Compact GitHub issue-comment coordination payloads when two-runner diagnostics exceed GitHub's 65,536 character comment limit.
- Keep full writer/reader diagnostics in uploaded JSON artifacts.
- Allow adaptive readers to stream a pending large-file manifest once first and last chunk records are reachable, so a missing/stale ready root no longer blocks chunk reads forever.
- Record upload diagnostics for streamed browser Blob uploads, including ready-manifest timing.

## Verification
- pnpm --filter @peerbit/please-lib exec vitest run src/__tests__/index.integration.test.ts -t "links streamed ready manifests|remote boundary chunks|complete chunk set"
- pnpm --filter @peerbit/please-lib exec vitest run src/__tests__/index.integration.test.ts -t "streams pending manifests when hinted ready search fails|remote boundary chunks"
- pnpm --filter @peerbit/please-lib test
- pnpm --filter @peerbit/please-lib build
- pnpm --filter file-share build
- pnpm exec prettier --check packages/file-share/library/src/index.ts packages/file-share/library/src/__tests__/index.integration.test.ts packages/file-share/frontend/tests/two-runner.bench.mjs
- git diff --check
- pnpm --filter file-share exec playwright test tests/generated.upload-benchmark.e2e.spec.ts --list

## Context
After #106, one public 512 MiB two-runner run completed chunk resolution but failed publishing oversized diagnostics. A later run with compact coordination showed the deeper remaining adaptive case: the reader had a pending root and remote chunks, but no ready root, so it timed out in readiness waiting before trying chunk reads. This PR keeps the coordination fix and adds a regression-tested readiness path for that adaptive state.
