### PR TITLE
Dial writer directly in file-share two-runner

### DIFF
--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -371,6 +371,11 @@ export const Drop = () => {
                     (connection) =>
                         connection?.remotePeer?.toString?.() ?? "unknown"
                 );
+                const peerAddresses = (
+                    peer?.getMultiaddrs?.() ??
+                    (peer as any)?.libp2p?.getMultiaddrs?.() ??
+                    []
+                ).map((address) => address?.toString?.() ?? String(address));
                 const listedFiles = await Promise.all(
                     list.map(async (file) => ({
                         id: file.id,
@@ -405,6 +410,7 @@ export const Drop = () => {
                         ).__peerbitFileShareRuntimeOpenProfiler?.samples ??
                         null,
                     peerHash: peer?.identity?.publicKey?.hashcode?.() ?? null,
+                    peerAddresses,
                     peerStatus,
                     peerLoading,
                     connectionCount: connections.length,

--- a/packages/file-share/frontend/tests/two-runner.bench.mjs
+++ b/packages/file-share/frontend/tests/two-runner.bench.mjs
@@ -524,6 +524,21 @@ const createFailure = (error) => ({
     stack: typeof error?.stack === "string" ? error.stack : undefined,
 });
 
+const getWriterPeerAddresses = (writer) =>
+    (writer?.writerDiagnostics?.peerAddresses ?? []).filter(
+        (address) => typeof address === "string" && address.length > 0
+    );
+
+const withWriterPeerAddresses = (shareUrl, writer) => {
+    const addresses = getWriterPeerAddresses(writer);
+    if (addresses.length === 0) {
+        return shareUrl;
+    }
+    const url = new URL(shareUrl);
+    url.searchParams.set("peer", addresses.join(","));
+    return url.toString();
+};
+
 const runWriter = async (coordinator) => {
     const browser = await chromium.launch({ headless: true });
     const context = await browser.newContext({ acceptDownloads: true });
@@ -636,6 +651,7 @@ const runReader = async (coordinator) => {
     }
 
     const writer = readyEvent.payload;
+    const shareUrl = withWriterPeerAddresses(writer.shareUrl, writer);
     const browser = await chromium.launch({ headless: true });
     const context = await browser.newContext({ acceptDownloads: true });
     const page = await context.newPage();
@@ -650,7 +666,7 @@ const runReader = async (coordinator) => {
             await installMockSaveFilePicker(page);
         }
         await seedReplicationRole(page, writer.address, readerRoleOptions);
-        await page.goto(writer.shareUrl, { waitUntil: "domcontentloaded" });
+        await page.goto(shareUrl, { waitUntil: "domcontentloaded" });
         const readerReadyAt = Date.now();
         await waitForFileListed(page, writer.fileName, UPLOAD_TIMEOUT_MS);
         const listedAt = Date.now();
@@ -681,7 +697,8 @@ const runReader = async (coordinator) => {
             readerRole: READER_ROLE,
             scenario: "prod",
             baseURL: BASE_URL,
-            shareUrl: writer.shareUrl,
+            shareUrl,
+            writerPeerAddressCount: getWriterPeerAddresses(writer).length,
             fileName: writer.fileName,
             fileSizeMb: FILE_SIZE_MB,
             downloadMode: usesStreamingDownload


### PR DESCRIPTION
## Summary
- Include browser peer multiaddrs in file-share test diagnostics.
- Make the two-runner benchmark open the reader URL with the app's existing `?peer=` override so the reader dials the writer directly.
- Avoid relying only on ambient public bootstrap discovery for the public two-runner benchmark.

## Verification
- node --check packages/file-share/frontend/tests/two-runner.bench.mjs
- pnpm exec prettier --check packages/file-share/frontend/src/Drop.tsx packages/file-share/frontend/tests/two-runner.bench.mjs
- pnpm --filter file-share build
- git diff --check

## Context
After #107 deployed, the public 512 MiB two-runner run failed before download: the reader never listed the file and reported `connectionCount: 0`, while the writer had uploaded all chunks and written the ready manifest. Passing the writer's dialable browser addresses into the reader run should make this benchmark measure file transfer behavior instead of public discovery luck.
