### PR TITLE
Avoid relisting file-share chunks during upload

### DIFF
--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -68,6 +68,11 @@ type ListingDiagnostics = {
     lastAdaptiveRefreshStartedAt: number | null;
     lastAdaptiveRefreshFinishedAt: number | null;
     lastAdaptiveRefreshError: string | null;
+    fileChangeEventCount: number;
+    rootFileChangeEventCount: number;
+    skippedChildFileChangeEventCount: number;
+    activeTransferCount: number;
+    skippedActiveTransferRefreshCount: number;
 };
 
 type SaveFilePickerWindow = Window & {
@@ -107,6 +112,25 @@ const getReadyLargeFileSignature = (files: AbstractFile[]) => {
     return readyFiles.length > 0 ? readyFiles.join("|") : null;
 };
 
+type FileChangeDetail = {
+    added?: Array<Pick<AbstractFile, "parentId">>;
+    removed?: Array<Pick<AbstractFile, "parentId">>;
+};
+
+export const shouldRefreshRootListForFileChange = (event: Event) => {
+    const detail = (event as CustomEvent<FileChangeDetail>).detail;
+    if (!detail) {
+        return true;
+    }
+
+    const changed = [...(detail.added ?? []), ...(detail.removed ?? [])];
+    if (changed.length === 0) {
+        return false;
+    }
+
+    return changed.some((file) => file?.parentId == null);
+};
+
 const createListingDiagnostics = (
     shareAddress: string | undefined,
     storedRole: ReplicationOptions | undefined
@@ -142,6 +166,11 @@ const createListingDiagnostics = (
     lastAdaptiveRefreshStartedAt: null,
     lastAdaptiveRefreshFinishedAt: null,
     lastAdaptiveRefreshError: null,
+    fileChangeEventCount: 0,
+    rootFileChangeEventCount: 0,
+    skippedChildFileChangeEventCount: 0,
+    activeTransferCount: 0,
+    skippedActiveTransferRefreshCount: 0,
 });
 
 export const useDebouncedEffect = (effect, deps, delay) => {
@@ -245,6 +274,22 @@ export const Drop = () => {
     );
     const [limitCPU, setLimitCPU] = useState<number | undefined>(1);
     const [uploadProgress, setUploadProgress] = useState<number | null>(null);
+    const activeTransferCountRef = useRef(0);
+
+    const startActiveTransfer = () => {
+        activeTransferCountRef.current += 1;
+        diagnosticsRef.current.activeTransferCount =
+            activeTransferCountRef.current;
+    };
+
+    const finishActiveTransfer = () => {
+        activeTransferCountRef.current = Math.max(
+            0,
+            activeTransferCountRef.current - 1
+        );
+        diagnosticsRef.current.activeTransferCount =
+            activeTransferCountRef.current;
+    };
 
     // we exclude the string type 'replicator' | 'observer' from the roleOptions so that we can easily serialize it with JSON
     const updateRole = async (roleOptions?: ReplicationOptions) => {
@@ -480,6 +525,10 @@ export const Drop = () => {
 
         const updateListDebounced = callEvenInterval(updateList, 500);
         const refresh = setInterval(() => {
+            if (activeTransferCountRef.current > 0) {
+                diagnosticsRef.current.skippedActiveTransferRefreshCount += 1;
+                return;
+            }
             updateListDebounced();
         }, 5000);
         files.program.files.log.events.addEventListener("join", updateList);
@@ -487,9 +536,20 @@ export const Drop = () => {
             "leave",
             updateListDebounced
         );
+        const filesChangeListener = (event: Event) => {
+            diagnosticsRef.current.fileChangeEventCount += 1;
+            if (!shouldRefreshRootListForFileChange(event)) {
+                diagnosticsRef.current.skippedChildFileChangeEventCount += 1;
+                return;
+            }
+
+            diagnosticsRef.current.rootFileChangeEventCount += 1;
+            updateListDebounced(event);
+        };
+
         files.program.files.events.addEventListener(
             "change",
-            updateListDebounced
+            filesChangeListener
         );
 
         const replicatorsChangeListener = async () => {
@@ -577,7 +637,7 @@ export const Drop = () => {
             );
             files.program.files.events.removeEventListener(
                 "change",
-                updateListDebounced
+                filesChangeListener
             );
             files.program.files.log.events.removeEventListener(
                 "replication:change",
@@ -640,7 +700,10 @@ export const Drop = () => {
                 try {
                     const metadataStartedAt = performance.now();
                     const [allFiles, replicators] = await Promise.all([
-                        files.program.files.index.search(new SearchRequest({})),
+                        files.program.files.index.search(
+                            new SearchRequest({}),
+                            { local: true, remote: false }
+                        ),
                         files.program.files.log.getReplicators(),
                     ]);
                     updateListStats.metadataMs =
@@ -688,6 +751,7 @@ export const Drop = () => {
             file instanceof LargeFile
                 ? Math.max(60_000, Math.ceil(Number(file.size) / 1e6) * 1_000)
                 : 10_000;
+        startActiveTransfer();
         try {
             if (file instanceof LargeFile) {
                 files.program?.retainFileRead(file);
@@ -737,6 +801,7 @@ export const Drop = () => {
                 window.URL.revokeObjectURL(url);
             }, 60_000);
         } finally {
+            finishActiveTransfer();
             progress(null);
         }
     };
@@ -778,6 +843,10 @@ export const Drop = () => {
     const addFile = (filesToAdd: FileList | File[], endProgress = true) => {
         return new Promise<void>((resolve, reject) => {
             let promises: Promise<any>[] = [];
+            const transferStarted = filesToAdd.length > 0;
+            if (transferStarted) {
+                startActiveTransfer();
+            }
 
             // there will just by one file here in practice
             for (const file of filesToAdd) {
@@ -809,6 +878,11 @@ export const Drop = () => {
                     })
                     .catch((e) => {
                         reject(e);
+                    })
+                    .finally(() => {
+                        if (transferStarted) {
+                            finishActiveTransfer();
+                        }
                     });
             }
         });

--- a/packages/file-share/frontend/tests/two-runner.bench.mjs
+++ b/packages/file-share/frontend/tests/two-runner.bench.mjs
@@ -645,6 +645,20 @@ const runReader = async (coordinator) => {
         COORDINATION_TIMEOUT_MS
     );
     if (readyEvent.kind === "writer-failed") {
+        const failure = createFailure(
+            new Error(
+                `Writer failed before reader started: ${readyEvent.payload?.message || "unknown error"}`
+            )
+        );
+        await persistResult({
+            status: "failed",
+            role: "reader",
+            readerRole: READER_ROLE,
+            scenario: "prod",
+            fileSizeMb: FILE_SIZE_MB,
+            failure,
+            writerFailure: readyEvent.payload,
+        });
         throw new Error(
             `Writer failed before reader started: ${readyEvent.payload?.message || "unknown error"}`
         );

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -135,6 +135,35 @@ describe("index", () => {
             }
         });
 
+        it("keeps shallow root entries during adaptive pruning", async () => {
+            const writer = await peer.open(new Files());
+            const reader = await peer2.open<Files>(writer.address);
+            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
+            const fileId = await writer.add("metadata retained root", largeFile);
+            const indexedRoot = await writer.files.index.get(fileId, {
+                resolve: false,
+                local: true,
+                remote: false,
+            } as any);
+            const rootHead = (indexedRoot as any).__context.head;
+            const shallowEntry =
+                await writer.files.log.log.getShallow(rootHead);
+            const originalGet = reader.files.log.log.get.bind(
+                reader.files.log.log
+            );
+
+            (reader.files.log.log as any).get = async () => {
+                throw new Error("full root payload should not be required");
+            };
+
+            try {
+                expect(await (reader as any).shouldKeepFileEntry(shallowEntry))
+                    .to.be.true;
+            } finally {
+                (reader.files.log.log as any).get = originalGet;
+            }
+        });
+
         it("keeps ready root manifests during adaptive pruning", async () => {
             const writer = await peer.open(new Files());
             const reader = await peer2.open<Files>(writer.address);
@@ -1599,84 +1628,92 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
-        it("streams a pending manifest when remote boundary chunks prove the upload is complete", async () => {
+        it("keeps pending adaptive manifests blocked without ready or complete local chunks", async () => {
             const filestore = await peer.open(new Files());
-            const filestoreReader = await peer2.open<Files>(filestore.address, {
-                args: {
-                    replicate: { limits: { cpu: { max: 1 } } },
-                },
+            const fileName = "pending manifest with arbitrary local chunks";
+            const fileId = "pending-manifest-arbitrary-local-chunks";
+            const pendingFile = new LargeFile({
+                id: fileId,
+                name: fileName,
+                size: 2n * 1024n * 1024n,
+                chunkCount: 4,
+                ready: false,
             });
-            await filestoreReader.files.log.waitForReplicator(
-                peer.identity.publicKey
+            const originalSearch = filestore.files.index.search.bind(
+                filestore.files.index
             );
-
-            const fileId = "pending-boundary-chunks";
-            const fileName = "pending-boundary-chunks.bin";
-            const chunks = [
-                new Uint8Array([1, 2, 3]),
-                new Uint8Array([4, 5, 6]),
-                new Uint8Array([7, 8, 9]),
-                new Uint8Array([10, 11, 12]),
-            ];
-            const expected = concat(chunks);
-            await filestore.files.put(
-                new LargeFile({
-                    id: fileId,
-                    name: fileName,
-                    size: BigInt(expected.byteLength),
-                    chunkCount: chunks.length,
-                    ready: false,
-                })
+            const originalGet = filestore.files.index.get.bind(
+                filestore.files.index
             );
-            for (let index = 0; index < chunks.length; index++) {
-                await filestore.files.put(
-                    new TinyFile({
-                        id: `${fileId}:${index}`,
-                        name: `${fileName}/${index}`,
-                        file: chunks[index],
-                        parentId: fileId,
-                        index,
-                    })
-                );
-            }
-
-            let pendingFile: LargeFile | undefined;
-            await waitForResolved(
-                async () => {
-                    const match = await filestoreReader.resolveById(fileId, {
-                        replicate: true,
-                        timeout: 1_000,
-                    });
-                    expect(match).to.be.instanceOf(LargeFile);
-                    expect((match as LargeFile).ready).to.be.false;
-                    pendingFile = match as LargeFile;
-                },
-                { timeout: 30_000, delayInterval: 200 }
-            );
-
             const originalCountLocalChunks =
-                filestoreReader.countLocalChunks.bind(filestoreReader);
-            (filestoreReader as any).countLocalChunks = async () => 0;
-            const streamedChunks: Uint8Array[] = [];
-            try {
-                await pendingFile!.writeFile(
-                    filestoreReader,
-                    {
-                        write: async (chunk) => {
-                            streamedChunks.push(chunk);
-                        },
-                    },
-                    { timeout: 20_000 }
+                filestore.countLocalChunks.bind(filestore);
+            const originalGetReadPeerHints =
+                filestore.getReadPeerHints.bind(filestore);
+
+            (filestore as any).getReadPeerHints = async () => ["writer-peer"];
+            (filestore as any).countLocalChunks = async () => 1;
+            (filestore.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasRootId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "id" &&
+                        getQueryValue(query) === fileId
                 );
+                if (hasRootId) {
+                    return [pendingFile];
+                }
+                return [];
+            };
+            (filestore.files.index as any).get = async (
+                id: unknown,
+                options: any
+            ) => {
+                if (
+                    id === fileId &&
+                    options?.remote &&
+                    options.remote !== false
+                ) {
+                    return pendingFile;
+                }
+                if (typeof id === "string" && id.startsWith(`${fileId}:`)) {
+                    return undefined;
+                }
+                return originalGet(id as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await expect(
+                    pendingFile.writeFile(
+                        filestore,
+                        {
+                            write: async (chunk) => {
+                                streamedChunks.push(chunk);
+                            },
+                        },
+                        { timeout: 500 }
+                    )
+                ).rejects.toThrow(/still uploading/);
             } finally {
-                (filestoreReader as any).countLocalChunks =
-                    originalCountLocalChunks;
+                (filestore.files.index as any).search = originalSearch;
+                (filestore.files.index as any).get = originalGet;
+                (filestore as any).countLocalChunks = originalCountLocalChunks;
+                (filestore as any).getReadPeerHints = originalGetReadPeerHints;
             }
 
             expect(
-                filestoreReader.lastReadDiagnostics?.waitUntilReadyResolvedBy
-            ).to.eq("pending-manifest-boundary-chunks");
-            expect(equals(concat(streamedChunks), expected)).to.be.true;
+                filestore.lastReadDiagnostics?.waitUntilReadyResolvedBy
+            ).not.to.eq("pending-manifest-local-chunks");
+            expect(
+                filestore.lastReadDiagnostics?.lastReadyProbe?.localChunkCount
+            ).to.eq(1);
+            expect(streamedChunks).to.have.length(0);
         });
 
         it("checks local complete chunks while read peer hints are present", async () => {
@@ -1917,6 +1954,158 @@ describe("index", () => {
             expect(filestore.lastReadDiagnostics?.chunkResolved?.[1]).to.eq(
                 "manifest-head-get"
             );
+            expect(equals(concat(streamedChunks), expected)).to.be.true;
+        });
+
+        it("uses indexed ready manifest heads when resolved ready search returns pending", async () => {
+            const filestore = await peer.open(new Files());
+            const fileName = "ready manifest stale resolved search fallback";
+            const fileId = "ready-manifest-stale-resolved-search-fallback";
+            const chunkCount = 4;
+            const expected = new Uint8Array(chunkCount);
+            const chunkEntryHeads: string[] = [];
+            for (let index = 0; index < chunkCount; index++) {
+                expected[index] = index % 256;
+                const appended = await filestore.files.put(
+                    new TinyFile({
+                        id: `${fileId}:${index}`,
+                        name: `${fileName}/${index}`,
+                        file: new Uint8Array([expected[index]]),
+                        parentId: fileId,
+                        index,
+                    })
+                );
+                chunkEntryHeads[index] = appended.entry.hash;
+            }
+            const pendingFile = new LargeFile({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount,
+                ready: false,
+            });
+            const readyFile = new LargeFileWithChunkHeads({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount,
+                ready: true,
+                finalHash: sha256Base64Sync(expected),
+                chunkEntryHeads,
+            });
+            const readyPut = await filestore.files.put(readyFile);
+            const readyHead = readyPut.entry.hash;
+            const readyIndexed = await filestore.files.index.get(fileId, {
+                resolve: false,
+                local: true,
+                remote: false,
+            } as any);
+            const readyEntry = await filestore.files.log.log.get(readyHead);
+            expect(readyIndexed).to.exist;
+            expect(readyEntry).to.exist;
+            (readyIndexed as any).__context ??= {};
+            (readyIndexed as any).__context.head = readyHead;
+            const originalSearch = filestore.files.index.search.bind(
+                filestore.files.index
+            );
+            const originalGet = filestore.files.index.get.bind(
+                filestore.files.index
+            );
+            const originalLogGet = filestore.files.log.log.get.bind(
+                filestore.files.log.log
+            );
+            const originalCountLocalChunks =
+                filestore.countLocalChunks.bind(filestore);
+            const originalGetReadPeerHints =
+                filestore.getReadPeerHints.bind(filestore);
+            let staleRemoteSearches = 0;
+            let directReadyGets = 0;
+            let indexedReadySearches = 0;
+            let remoteReadyHeadGets = 0;
+
+            (filestore as any).getReadPeerHints = async () => [
+                "ready-manifest-peer",
+            ];
+            (filestore as any).countLocalChunks = async () => 0;
+            (filestore.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasRootId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "id" &&
+                        getQueryValue(query) === fileId
+                );
+                if (hasRootId) {
+                    if ((options as any)?.local === true) {
+                        return [pendingFile];
+                    }
+                    if ((options as any)?.remote) {
+                        if ((options as any)?.resolve === false) {
+                            expect(request).to.be.instanceOf(
+                                SearchRequestIndexed
+                            );
+                            indexedReadySearches++;
+                            return [readyIndexed];
+                        }
+                        staleRemoteSearches++;
+                        return [pendingFile];
+                    }
+                    return [];
+                }
+                return originalSearch(request as never, options as never);
+            };
+            (filestore.files.index as any).get = async (
+                id: string,
+                options: unknown
+            ) => {
+                if (id === fileId && (options as any)?.remote) {
+                    directReadyGets++;
+                    return pendingFile;
+                }
+                return originalGet(id as never, options as never);
+            };
+            (filestore.files.log.log as any).get = async (
+                hash: string,
+                options: unknown
+            ) => {
+                if (hash === readyHead && (options as any)?.remote) {
+                    remoteReadyHeadGets++;
+                    return readyEntry;
+                }
+                return originalLogGet(hash as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await pendingFile.writeFile(
+                    filestore,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestore.files.index as any).search = originalSearch;
+                (filestore.files.index as any).get = originalGet;
+                (filestore.files.log.log as any).get = originalLogGet;
+                (filestore as any).countLocalChunks = originalCountLocalChunks;
+                (filestore as any).getReadPeerHints = originalGetReadPeerHints;
+            }
+
+            expect(staleRemoteSearches).to.be.greaterThan(0);
+            expect(directReadyGets).to.be.greaterThan(0);
+            expect(indexedReadySearches).to.be.greaterThan(0);
+            expect(remoteReadyHeadGets).to.be.greaterThan(0);
+            expect(
+                filestore.lastReadDiagnostics?.waitUntilReadyResolvedBy
+            ).to.eq("ready-manifest-head-search");
             expect(equals(concat(streamedChunks), expected)).to.be.true;
         });
 

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -1568,47 +1568,6 @@ export class LargeFile extends AbstractFile {
                 (file as any).chunkEntryHeads.some(
                     (head: unknown) => typeof head === "string"
                 );
-            const hasIndexedChunk = (
-                candidate: unknown,
-                file: LargeFile,
-                index: number
-            ) => {
-                const chunk = candidate as Partial<TinyFile> &
-                    Partial<IndexableFile>;
-                const chunkId = getChunkId(file.id, index);
-                return candidate instanceof TinyFile ||
-                    candidate instanceof IndexableFile ||
-                    (candidate != null && typeof candidate === "object")
-                    ? chunk.parentId === file.id &&
-                          chunk.id === chunkId &&
-                          (chunk.index === index ||
-                              chunk.name === `${file.name}/${index}`)
-                    : false;
-            };
-            const hasBoundaryChunks = async (file: LargeFile) => {
-                const indexes =
-                    file.chunkCount <= 1 ? [0] : [0, file.chunkCount - 1];
-                for (const index of indexes) {
-                    const chunkId = getChunkId(file.id, index);
-                    const chunk = await files.files.index.get(chunkId, {
-                        resolve: false,
-                        local: true,
-                        remote: {
-                            timeout: attemptTimeout,
-                            strategy: "always" as any,
-                            throwOnMissing: false,
-                            retryMissingResponses: true,
-                            replicate: files.persistChunkReads,
-                            from: remoteFrom,
-                        },
-                    });
-                    if (!hasIndexedChunk(chunk, file, index)) {
-                        return false;
-                    }
-                    files.retainResolvedChunk(chunk);
-                }
-                return true;
-            };
             const localMatches = await files.files.index.search(request, {
                 local: true,
                 remote: false,
@@ -1679,26 +1638,9 @@ export class LargeFile extends AbstractFile {
                     return decodeLargeFileWithChunkHeads(operation.data);
                 }
             };
-            let remoteMatches: AbstractFile[] = [];
-            let remoteSearchFailed = false;
-            try {
-                remoteMatches = await files.files.index.search(request, {
-                    local: false,
-                    remote: {
-                        timeout: attemptTimeout,
-                        throwOnMissing: false,
-                        retryMissingResponses: true,
-                        replicate: files.persistChunkReads,
-                        from: remoteFrom,
-                    },
-                } as any);
-            } catch (error) {
-                remoteSearchFailed = true;
-                if (debug) {
-                    (debug.readyRemoteSearchErrors ||= []).push(
-                        getErrorMessage(error)
-                    );
-                }
+            const searchReadyManifestEntryHeads = async (): Promise<
+                LargeFile[]
+            > => {
                 try {
                     const indexedMatches = await files.files.index.search(
                         new SearchRequestIndexed({
@@ -1735,24 +1677,62 @@ export class LargeFile extends AbstractFile {
                             }
                         }
                     }
-                    const indexedReady = materializedMatches.find(
-                        (match) => match.ready
-                    );
-                    if (indexedReady) {
-                        if (debug) {
-                            debug.waitUntilReadyResolvedBy =
-                                "ready-manifest-head-search";
-                        }
-                        return indexedReady;
-                    }
-                    remoteMatches = materializedMatches as AbstractFile[];
+                    return materializedMatches;
                 } catch (indexedError) {
                     if (debug) {
                         (debug.readyRemoteIndexedSearchErrors ||= []).push(
                             getErrorMessage(indexedError)
                         );
                     }
+                    return [];
                 }
+            };
+            const resolveReadyManifestEntryHeads = async (
+                source: string
+            ): Promise<LargeFile | undefined> => {
+                const matches = await searchReadyManifestEntryHeads();
+                const latest = toReadableLargeFile(
+                    pickLatest(matches as AbstractFile[])
+                );
+                if (latest?.ready) {
+                    if (debug) {
+                        debug.waitUntilReadyResolvedBy = source;
+                    }
+                    return latest;
+                }
+            };
+            let remoteMatches: AbstractFile[] = [];
+            let remoteSearchFailed = false;
+            try {
+                remoteMatches = await files.files.index.search(request, {
+                    local: false,
+                    remote: {
+                        timeout: attemptTimeout,
+                        throwOnMissing: false,
+                        retryMissingResponses: true,
+                        replicate: files.persistChunkReads,
+                        from: remoteFrom,
+                    },
+                } as any);
+            } catch (error) {
+                remoteSearchFailed = true;
+                if (debug) {
+                    (debug.readyRemoteSearchErrors ||= []).push(
+                        getErrorMessage(error)
+                    );
+                }
+                const indexedMatches = await searchReadyManifestEntryHeads();
+                const indexedReady = toReadableLargeFile(
+                    pickLatest(indexedMatches as AbstractFile[])
+                );
+                if (indexedReady?.ready) {
+                    if (debug) {
+                        debug.waitUntilReadyResolvedBy =
+                            "ready-manifest-head-search";
+                    }
+                    return indexedReady;
+                }
+                remoteMatches = indexedMatches as AbstractFile[];
             }
             const remoteLatest = pickLatest(remoteMatches);
             let remoteReady = toReadableLargeFile(remoteLatest);
@@ -1814,6 +1794,14 @@ export class LargeFile extends AbstractFile {
                     );
                 }
             }
+            if (!remoteReady?.ready) {
+                const indexedReady = await resolveReadyManifestEntryHeads(
+                    "ready-manifest-head-search"
+                );
+                if (indexedReady) {
+                    return indexedReady;
+                }
+            }
             const countCandidate =
                 remoteReady &&
                 (remoteReady.ready ||
@@ -1846,26 +1834,6 @@ export class LargeFile extends AbstractFile {
                 }
                 return readinessCandidate;
             }
-            if (
-                files.persistChunkReads &&
-                countCandidate.chunkCount > 0 &&
-                !countCandidate.ready &&
-                (await hasBoundaryChunks(countCandidate).catch((error) => {
-                    if (debug) {
-                        (debug.readyBoundaryChunkErrors ||= []).push(
-                            getErrorMessage(error)
-                        );
-                    }
-                    return false;
-                }))
-            ) {
-                if (debug) {
-                    debug.waitUntilReadyResolvedBy =
-                        "pending-manifest-boundary-chunks";
-                }
-                return countCandidate;
-            }
-
             await sleep(250);
         }
 
@@ -2380,7 +2348,7 @@ export class Files extends Program<Args> {
                       ? ((await this.files.log.log.get(hash)) as typeof entry)
                       : undefined;
         } catch {
-            return false;
+            return hash != null;
         }
 
         if (isSignedBySelf(getEntrySignatures(entry))) {
@@ -2402,9 +2370,16 @@ export class Files extends Program<Args> {
             }
             return true;
         }
+        if (resolvedMetadata && !resolvedMetadata.id.includes(":")) {
+            const entryHash = hash ?? getEntryHash(entry);
+            if (entryHash) {
+                this.retainedChunkEntryHeads.add(entryHash);
+            }
+            return true;
+        }
 
         if (!entry) {
-            return false;
+            return hash != null;
         }
 
         if (!this.persistChunkReads) {


### PR DESCRIPTION
## Summary
- skip full root-list refreshes for child chunk document changes in the file-share UI
- keep file-share metadata refresh local-only and suppress periodic root-list refresh while uploads/downloads are active
- resolve stale pending adaptive manifests through indexed ready-manifest entry heads, so readers can materialize the ready manifest even when normal ready search/direct get returns the old pending root
- keep pending adaptive manifests blocked unless readiness is proven by a ready manifest, complete local chunks, or the older half-local fallback after remote ready search failure
- retain shallow file-log heads during adaptive pruning so ready roots and chunk heads can be materialized later without forcing payload storage
- persist a reader artifact when the two-runner writer fails before reader startup

## Why
The public two-runner rerun on master (25093993696) failed before reader transfer because the writer only wrote 359/1024 chunks in 30 minutes. Diagnostics showed 360 list refreshes during that upload, while the previous public run wrote all 1024 chunks with only 37 list calls. The frontend was treating each child chunk document change as a reason to relist and rescan metadata.

The next branch runs showed upload recovering, but adaptive download exposed deeper readiness issues. A reader could discover a pending root and some local adaptive shards while ready-manifest lookup still returned the stale pending root. Starting from arbitrary partial chunks was not a correctness proof, and the 50 MiB/512 MiB artifacts also showed that boundary chunks were not enough: first/last availability did not guarantee interior chunk resolution.

The library now tries the indexed entry-head ready-manifest path even when normal remote ready search does not throw but returns a pending manifest. It also keeps shallow log heads during adaptive pruning, which preserves the small routing/index records needed to materialize ready roots and chunks later without retaining chunk payload bytes.

## Verification
- pnpm --filter @peerbit/please-lib test
- pnpm --filter @peerbit/please-lib exec vitest run src/__tests__/index.integration.test.ts -t "shallow root|pending manifest|ready manifest|adaptive"
- pnpm --filter @peerbit/please-lib build
- pnpm --filter file-share build
- node --check packages/file-share/frontend/tests/two-runner.bench.mjs
- git diff --check
- GitHub File Share Benchmarks, 50 MiB adaptive: 25099225960 passed
- GitHub File Share Benchmarks, 256 MiB adaptive streaming: 25099525115 passed
- GitHub File Share Benchmarks, 512 MiB adaptive streaming: 25100107021 passed

512 MiB artifact summary: upload 37.3 Mbps, download 44.6 Mbps, 1024/1024 chunks resolved, no chunk failure.
