### PR TITLE
Remove file-share log-head fallbacks

### DIFF
--- a/packages/file-share/frontend/tests/two-runner.bench.mjs
+++ b/packages/file-share/frontend/tests/two-runner.bench.mjs
@@ -335,12 +335,6 @@ const compactReadDiagnostics = (diagnostics = {}) => ({
     prefetchedChunkCount: diagnostics.prefetchedChunkCount,
     chunkAttemptsCount: countObjectKeys(diagnostics.chunkAttempts),
     chunkResolvedCount: countObjectKeys(diagnostics.chunkResolved),
-    chunkManifestHeadsCount: countObjectKeys(diagnostics.chunkManifestHeads),
-    chunkIndexedHeadsCount: countObjectKeys(diagnostics.chunkIndexedHeads),
-    chunkHeadGetsCount: countObjectKeys(diagnostics.chunkHeadGets),
-    readyRemoteGetHeadsCount: diagnostics.readyRemoteGetHeads?.length,
-    readyRemoteGetHeads: tail(diagnostics.readyRemoteGetHeads),
-    readyRemoteDecodeFallbacks: tail(diagnostics.readyRemoteDecodeFallbacks),
     chunkFailure: diagnostics.chunkFailure,
     finishedAt: diagnostics.finishedAt,
 });

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -12,7 +12,6 @@ import { delay, waitForResolved } from "@peerbit/time";
 import { sha256Base64Sync } from "@peerbit/crypto";
 import { deserialize, serialize } from "@dao-xyz/borsh";
 import { expect, describe, it, beforeEach, afterEach } from "vitest";
-import { SearchRequestIndexed } from "@peerbit/document";
 
 const getQueryKey = (query: any) =>
     Array.isArray(query?.key) ? query.key.join(".") : query?.key;
@@ -439,7 +438,7 @@ describe("index", () => {
             let sawChunkWaitFor = false;
             let indexedChunkGets = 0;
             let resolvedRemoteChunkGets = 0;
-            const indexedChunks = new Set<string>();
+            const resolvedChunks = new Set<string>();
             const retainedChunkId = `${fileId}:1`;
             const retainedWriterChunk = await filestore.files.index.get(
                 retainedChunkId,
@@ -491,7 +490,6 @@ describe("index", () => {
                         getOptions.remote !== false
                     ) {
                         indexedChunkGets++;
-                        indexedChunks.add(id);
                         if (id === retainedChunkId) {
                             retainedBeforeIndexedReplication = await (
                                 filestoreReader.files.log as any
@@ -502,6 +500,12 @@ describe("index", () => {
                         getOptions.remote !== false
                     ) {
                         resolvedRemoteChunkGets++;
+                        resolvedChunks.add(id);
+                        if (id === retainedChunkId) {
+                            retainedBeforeIndexedReplication = await (
+                                filestoreReader.files.log as any
+                            ).keep(retainedWriterEntry);
+                        }
                     }
                     directChunkGets++;
                     inflightChunkGets++;
@@ -511,7 +515,7 @@ describe("index", () => {
                     );
                     await delay(25);
                     inflightChunkGets--;
-                    if (getOptions.remote === false && !indexedChunks.has(id)) {
+                    if (getOptions.remote === false && !resolvedChunks.has(id)) {
                         return undefined;
                     }
                 }
@@ -535,8 +539,8 @@ describe("index", () => {
                 filestoreReader.lastReadDiagnostics?.chunkAttemptTimeoutMs
             ).to.eq(5_000);
             expect(sawChunkWaitFor).to.be.false;
-            expect(indexedChunkGets).to.be.greaterThan(1);
-            expect(resolvedRemoteChunkGets).to.eq(0);
+            expect(indexedChunkGets).to.eq(0);
+            expect(resolvedRemoteChunkGets).to.be.greaterThan(1);
             expect(retainedBeforeIndexedReplication).to.be.true;
             expect(maxInflightChunkGets).to.be.lessThanOrEqual(readAhead);
             expect(
@@ -623,10 +627,10 @@ describe("index", () => {
             expect(observedChunkSize).to.eq(512 * 1024);
         });
 
-        it("falls back to indexed chunk search when direct chunk lookup misses", async () => {
+        it("uses indexed chunk search when direct chunk lookup misses", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const fileName = "streamed download with indexed chunk fallback";
+            const fileName = "streamed download with indexed chunk search";
             const fileId = await filestore.add(fileName, largeFile);
 
             const filestoreReader = await peer2.open<Files>(filestore.address);
@@ -698,10 +702,10 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
-        it("falls back to non-replicating chunk reads when persisted and precise lookups miss", async () => {
+        it("uses non-replicating chunk reads when persisted and precise lookups miss", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const fileName = "streamed download with non-replicating fallback";
+            const fileName = "streamed download with non-replicating read";
             const fileId = await filestore.add(fileName, largeFile);
 
             const filestoreReader = await peer2.open<Files>(filestore.address);
@@ -784,10 +788,10 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
-        it("falls back to resolved precise search when adaptive indexed chunks do not materialize", async () => {
+        it("uses resolved precise search when adaptive exact routes miss", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const fileName = "streamed download with resolved precise fallback";
+            const fileName = "streamed download with resolved precise search";
             const fileId = await filestore.add(fileName, largeFile);
 
             const filestoreReader = await peer2.open<Files>(filestore.address);
@@ -809,23 +813,10 @@ describe("index", () => {
             const originalGet = filestoreReader.files.index.get.bind(
                 filestoreReader.files.index
             );
-            const originalLogGet = filestoreReader.files.log.log.get.bind(
-                filestoreReader.files.log.log
-            );
             const delayedChunkId = `${fileId}:1`;
-            const writerIndexed = await filestore.files.index.get(
-                delayedChunkId,
-                {
-                    resolve: false,
-                    local: true,
-                    remote: false,
-                } as any
-            );
-            const writerHead = (writerIndexed as any)?.__context?.head;
-            let indexedChunkGets = 0;
-            let indexedHeadGets = 0;
+            let directChunkGets = 0;
             let exactNonReplicatingGets = 0;
-            let indexedPreciseSearches = 0;
+            let replicatingPreciseSearches = 0;
             let resolvedPreciseSearches = 0;
             let parentChunkSearches = 0;
 
@@ -851,10 +842,7 @@ describe("index", () => {
                         exactNonReplicatingGets++;
                         return undefined;
                     }
-                    if (options?.resolve === false) {
-                        indexedChunkGets++;
-                        return originalGet(id as never, options as never);
-                    }
+                    directChunkGets++;
                     return undefined;
                 }
                 return originalGet(id as never, options as never);
@@ -894,7 +882,7 @@ describe("index", () => {
                             options as never
                         );
                     }
-                    indexedPreciseSearches++;
+                    replicatingPreciseSearches++;
                     return [];
                 }
                 if (hasParentId) {
@@ -905,17 +893,6 @@ describe("index", () => {
                 return originalSearch(request as never, options as never);
             };
 
-            (filestoreReader.files.log.log as any).get = async (
-                hash: string,
-                options: { remote?: unknown }
-            ) => {
-                if (hash === writerHead && options?.remote) {
-                    indexedHeadGets++;
-                    return undefined;
-                }
-                return originalLogGet(hash as never, options as never);
-            };
-
             const streamedChunks: Uint8Array[] = [];
 
             try {
@@ -929,644 +906,18 @@ describe("index", () => {
                     { timeout: 20_000 }
                 );
             } finally {
-                (filestoreReader.files.log.log as any).get = originalLogGet;
+                (filestoreReader.files.index as any).get = originalGet;
+                (filestoreReader.files.index as any).search = originalSearch;
             }
 
-            expect(indexedChunkGets).to.be.greaterThan(0);
-            expect(indexedHeadGets).to.be.greaterThan(0);
-            expect(indexedPreciseSearches).to.be.greaterThan(0);
+            expect(directChunkGets).to.be.greaterThan(0);
+            expect(replicatingPreciseSearches).to.be.greaterThan(0);
             expect(exactNonReplicatingGets).to.be.greaterThan(0);
             expect(resolvedPreciseSearches).to.be.greaterThan(0);
             expect(parentChunkSearches).to.eq(0);
             expect(
                 filestoreReader.lastReadDiagnostics?.chunkResolved?.[1]
             ).to.eq("resolved-search");
-            expect(streamedChunks.length).to.be.greaterThan(1);
-            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
-        });
-
-        it("materializes an adaptive indexed chunk from its entry head", async () => {
-            const filestore = await peer.open(new Files());
-            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const fileName = "streamed download with indexed head fallback";
-            const fileId = await filestore.add(fileName, largeFile);
-            const delayedChunkId = `${fileId}:1`;
-            const writerIndexed = await filestore.files.index.get(
-                delayedChunkId,
-                {
-                    resolve: false,
-                    local: true,
-                    remote: false,
-                } as any
-            );
-            const writerHead = (writerIndexed as any)?.__context?.head;
-            const writerEntry = writerHead
-                ? await filestore.files.log.log.get(writerHead)
-                : undefined;
-            expect(writerIndexed).to.be.instanceOf(IndexableFile);
-            expect(writerHead).to.be.a("string");
-            expect(writerEntry).to.exist;
-
-            const filestoreReader = await peer2.open<Files>(filestore.address);
-            await filestoreReader.files.log.waitForReplicator(
-                peer.identity.publicKey
-            );
-
-            const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
-            stripChunkEntryHeads(file);
-
-            const writerHash = peer.identity.publicKey.hashcode();
-            (filestoreReader as any).getReadPeerHints = async () => [
-                writerHash,
-            ];
-            const originalSearch = filestoreReader.files.index.search.bind(
-                filestoreReader.files.index
-            );
-            const originalGet = filestoreReader.files.index.get.bind(
-                filestoreReader.files.index
-            );
-            const originalLogGet = filestoreReader.files.log.log.get.bind(
-                filestoreReader.files.log.log
-            );
-            const originalIterate =
-                filestoreReader.files.log.log.entryIndex.iterate.bind(
-                    filestoreReader.files.log.log.entryIndex
-                );
-            let indexedChunkGets = 0;
-            let headChunkGets = 0;
-            let preciseSearches = 0;
-
-            (filestoreReader.files.index as any).get = async (
-                id: string,
-                options: {
-                    resolve?: boolean;
-                    remote?:
-                        | {
-                              replicate?: boolean;
-                          }
-                        | false;
-                }
-            ) => {
-                if (id === delayedChunkId) {
-                    if (options?.remote === false) {
-                        return undefined;
-                    }
-                    if (options?.resolve === false) {
-                        indexedChunkGets++;
-                        return writerIndexed;
-                    }
-                    return undefined;
-                }
-                return originalGet(id as never, options as never);
-            };
-
-            (filestoreReader.files.index as any).search = async (
-                request: { query: unknown | unknown[] },
-                options: unknown
-            ) => {
-                const queries = Array.isArray(request.query)
-                    ? request.query
-                    : [request.query];
-                if (
-                    queries.some(
-                        (query: any) =>
-                            getQueryKey(query) === "parentId" &&
-                            getQueryValue(query) === fileId
-                    ) &&
-                    queries.some(
-                        (query: any) =>
-                            getQueryKey(query) === "name" &&
-                            getQueryValue(query) === `${fileName}/1`
-                    )
-                ) {
-                    preciseSearches++;
-                    return [];
-                }
-                return originalSearch(request as never, options as never);
-            };
-
-            (filestoreReader.files.log.log as any).get = async (
-                hash: string,
-                options: { remote?: unknown }
-            ) => {
-                if (hash === writerHead && options?.remote) {
-                    headChunkGets++;
-                    return writerEntry;
-                }
-                return originalLogGet(hash as never, options as never);
-            };
-
-            (filestoreReader.files.log.log.entryIndex as any).iterate = () => ({
-                done: () => true,
-                next: async () => [],
-                all: async () => [],
-                close: async () => {},
-            });
-
-            const streamedChunks: Uint8Array[] = [];
-
-            try {
-                await file!.writeFile(
-                    filestoreReader,
-                    {
-                        write: async (chunk) => {
-                            streamedChunks.push(chunk);
-                        },
-                    },
-                    { timeout: 20_000 }
-                );
-            } finally {
-                (filestoreReader.files.index as any).get = originalGet;
-                (filestoreReader.files.index as any).search = originalSearch;
-                (filestoreReader.files.log.log as any).get = originalLogGet;
-                (filestoreReader.files.log.log.entryIndex as any).iterate =
-                    originalIterate;
-            }
-
-            expect(indexedChunkGets).to.be.greaterThan(0);
-            expect(headChunkGets).to.be.greaterThan(0);
-            expect(preciseSearches).to.eq(0);
-            expect(
-                filestoreReader.lastReadDiagnostics?.chunkResolved?.[1]
-            ).to.eq("indexed-head-get");
-            expect(streamedChunks.length).to.be.greaterThan(1);
-            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
-        });
-
-        it("materializes a locally joined chunk entry when the document index lags", async () => {
-            const filestore = await peer.open(new Files());
-            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const fileName = "streamed download with local metadata fallback";
-            const fileId = await filestore.add(fileName, largeFile);
-            const delayedChunkId = `${fileId}:1`;
-            const writerIndexed = await filestore.files.index.get(
-                delayedChunkId,
-                {
-                    resolve: false,
-                    local: true,
-                    remote: false,
-                } as any
-            );
-            const writerHead = (writerIndexed as any)?.__context?.head;
-            const writerEntry = writerHead
-                ? await filestore.files.log.log.get(writerHead)
-                : undefined;
-            const writerShallow = writerHead
-                ? await filestore.files.log.log.getShallow(writerHead)
-                : undefined;
-            expect(writerHead).to.be.a("string");
-            expect(writerEntry).to.exist;
-            expect(writerShallow?.meta.data?.byteLength).to.be.greaterThan(0);
-
-            const filestoreReader = await peer2.open<Files>(filestore.address);
-            await filestoreReader.files.log.waitForReplicator(
-                peer.identity.publicKey
-            );
-
-            const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
-            stripChunkEntryHeads(file);
-
-            const writerHash = peer.identity.publicKey.hashcode();
-            (filestoreReader as any).getReadPeerHints = async () => [
-                writerHash,
-            ];
-            const originalSearch = filestoreReader.files.index.search.bind(
-                filestoreReader.files.index
-            );
-            const originalGet = filestoreReader.files.index.get.bind(
-                filestoreReader.files.index
-            );
-            const originalLogGet = filestoreReader.files.log.log.get.bind(
-                filestoreReader.files.log.log
-            );
-            const originalIterate =
-                filestoreReader.files.log.log.entryIndex.iterate.bind(
-                    filestoreReader.files.log.log.entryIndex
-                );
-            let directChunkGets = 0;
-            let metadataScans = 0;
-            let metadataHeadGets = 0;
-            let preciseSearches = 0;
-
-            (filestoreReader.files.index as any).get = async (
-                id: string,
-                options: unknown
-            ) => {
-                if (id === delayedChunkId) {
-                    directChunkGets++;
-                    return undefined;
-                }
-                return originalGet(id as never, options as never);
-            };
-
-            (filestoreReader.files.index as any).search = async (
-                request: { query: unknown | unknown[] },
-                options: unknown
-            ) => {
-                const queries = Array.isArray(request.query)
-                    ? request.query
-                    : [request.query];
-                if (
-                    queries.some(
-                        (query: any) =>
-                            getQueryKey(query) === "parentId" &&
-                            getQueryValue(query) === fileId
-                    )
-                ) {
-                    preciseSearches++;
-                    return [];
-                }
-                return originalSearch(request as never, options as never);
-            };
-
-            (filestoreReader.files.log.log.entryIndex as any).iterate = () => {
-                metadataScans++;
-                let returned = false;
-                return {
-                    done: () => returned,
-                    next: async () => {
-                        if (returned) {
-                            return [];
-                        }
-                        returned = true;
-                        return [writerShallow];
-                    },
-                    all: async () => [writerShallow],
-                    close: async () => {},
-                };
-            };
-
-            (filestoreReader.files.log.log as any).get = async (
-                hash: string,
-                options: unknown
-            ) => {
-                if (hash === writerHead) {
-                    metadataHeadGets++;
-                    return writerEntry;
-                }
-                return originalLogGet(hash as never, options as never);
-            };
-
-            const streamedChunks: Uint8Array[] = [];
-
-            try {
-                await file!.writeFile(
-                    filestoreReader,
-                    {
-                        write: async (chunk) => {
-                            streamedChunks.push(chunk);
-                        },
-                    },
-                    { timeout: 20_000 }
-                );
-            } finally {
-                (filestoreReader.files.index as any).get = originalGet;
-                (filestoreReader.files.index as any).search = originalSearch;
-                (filestoreReader.files.log.log as any).get = originalLogGet;
-                (filestoreReader.files.log.log.entryIndex as any).iterate =
-                    originalIterate;
-            }
-
-            expect(directChunkGets).to.be.greaterThan(0);
-            expect(metadataScans).to.be.greaterThan(0);
-            expect(metadataHeadGets).to.be.greaterThan(0);
-            expect(preciseSearches).to.be.greaterThan(0);
-            expect(
-                filestoreReader.lastReadDiagnostics?.chunkResolved?.[1]
-            ).to.eq("local-entry-head");
-            expect(streamedChunks.length).to.be.greaterThan(1);
-            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
-        });
-
-        it("materializes an adaptive chunk from its ready manifest entry head when indexes miss", async () => {
-            const filestore = await peer.open(new Files());
-            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const fileName = "streamed download with manifest head fallback";
-            const fileId = await filestore.add(fileName, largeFile);
-            const delayedChunkId = `${fileId}:1`;
-            const writerIndexed = await filestore.files.index.get(
-                delayedChunkId,
-                {
-                    resolve: false,
-                    local: true,
-                    remote: false,
-                } as any
-            );
-            const writerHead = (writerIndexed as any)?.__context?.head;
-            const writerEntry = writerHead
-                ? await filestore.files.log.log.get(writerHead)
-                : undefined;
-            expect(writerHead).to.be.a("string");
-            expect(writerEntry).to.exist;
-
-            const filestoreReader = await peer2.open<Files>(filestore.address);
-            await filestoreReader.files.log.waitForReplicator(
-                peer.identity.publicKey
-            );
-
-            const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
-
-            const writerHash = peer.identity.publicKey.hashcode();
-            (filestoreReader as any).getReadPeerHints = async () => [
-                writerHash,
-            ];
-            const originalSearch = filestoreReader.files.index.search.bind(
-                filestoreReader.files.index
-            );
-            const originalGet = filestoreReader.files.index.get.bind(
-                filestoreReader.files.index
-            );
-            const originalCountLocalChunks =
-                filestoreReader.countLocalChunks.bind(filestoreReader);
-            const originalLogGet = filestoreReader.files.log.log.get.bind(
-                filestoreReader.files.log.log
-            );
-            const originalIterate =
-                filestoreReader.files.log.log.entryIndex.iterate.bind(
-                    filestoreReader.files.log.log.entryIndex
-                );
-            let localChunkGets = 0;
-            let remoteChunkGets = 0;
-            let preciseSearches = 0;
-            let parentSearches = 0;
-            let manifestHeadGets = 0;
-
-            (filestoreReader as any).countLocalChunks = async () => 0;
-            (filestoreReader.files.index as any).get = async (
-                id: string,
-                options: unknown
-            ) => {
-                if (id === delayedChunkId) {
-                    if ((options as { remote?: unknown })?.remote) {
-                        remoteChunkGets++;
-                    } else {
-                        localChunkGets++;
-                    }
-                    return undefined;
-                }
-                return originalGet(id as never, options as never);
-            };
-
-            (filestoreReader.files.index as any).search = async (
-                request: { query: unknown | unknown[] },
-                options: unknown
-            ) => {
-                const queries = Array.isArray(request.query)
-                    ? request.query
-                    : [request.query];
-                const hasParentId = queries.some(
-                    (query: any) =>
-                        getQueryKey(query) === "parentId" &&
-                        getQueryValue(query) === fileId
-                );
-                const hasChunkName = queries.some(
-                    (query: any) =>
-                        getQueryKey(query) === "name" &&
-                        getQueryValue(query) === `${fileName}/1`
-                );
-                if (hasParentId) {
-                    if (hasChunkName) {
-                        preciseSearches++;
-                    } else {
-                        parentSearches++;
-                    }
-                    return [];
-                }
-                return originalSearch(request as never, options as never);
-            };
-
-            (filestoreReader.files.log.log.entryIndex as any).iterate = () => ({
-                done: () => true,
-                next: async () => [],
-                all: async () => [],
-                close: async () => {},
-            });
-
-            (filestoreReader.files.log.log as any).get = async (
-                hash: string,
-                options: { remote?: unknown }
-            ) => {
-                if (hash === writerHead && options?.remote) {
-                    manifestHeadGets++;
-                    return writerEntry;
-                }
-                return originalLogGet(hash as never, options as never);
-            };
-
-            const streamedChunks: Uint8Array[] = [];
-
-            try {
-                await file!.writeFile(
-                    filestoreReader,
-                    {
-                        write: async (chunk) => {
-                            streamedChunks.push(chunk);
-                        },
-                    },
-                    { timeout: 20_000 }
-                );
-            } finally {
-                (filestoreReader.files.index as any).get = originalGet;
-                (filestoreReader.files.index as any).search = originalSearch;
-                (filestoreReader as any).countLocalChunks =
-                    originalCountLocalChunks;
-                (filestoreReader.files.log.log as any).get = originalLogGet;
-                (filestoreReader.files.log.log.entryIndex as any).iterate =
-                    originalIterate;
-            }
-
-            expect(localChunkGets).to.be.greaterThan(0);
-            expect(remoteChunkGets).to.eq(0);
-            expect(preciseSearches).to.eq(0);
-            expect(parentSearches).to.eq(0);
-            expect(manifestHeadGets).to.be.greaterThan(0);
-            expect(
-                filestoreReader.lastReadDiagnostics?.chunkManifestHeads?.[1]
-            ).to.eq(writerHead);
-            expect(
-                filestoreReader.lastReadDiagnostics?.chunkResolved?.[1]
-            ).to.eq("manifest-head-get");
-            expect(streamedChunks.length).to.be.greaterThan(1);
-            expect(equals(concat(streamedChunks), largeFile)).to.be.true;
-        });
-
-        it("uses ready manifest entry heads when streaming a pending adaptive manifest", async () => {
-            const filestore = await peer.open(new Files());
-            const filestoreReader = await peer2.open<Files>(filestore.address);
-            await filestoreReader.files.log.waitForReplicator(
-                peer.identity.publicKey
-            );
-
-            const fileName = "pending adaptive manifest head fallback";
-            const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const originalPut = filestore.files.put.bind(filestore.files);
-            let uploadId: string | undefined;
-
-            (filestore.files as any).put = async (entry: unknown) => {
-                if (entry instanceof LargeFile && !entry.ready) {
-                    uploadId = entry.id;
-                }
-                if (entry instanceof TinyFile && entry.parentId != null) {
-                    await delay(250);
-                }
-                return originalPut(entry as never);
-            };
-
-            const addPromise = filestore.add(fileName, largeFile);
-            let pendingFile: LargeFile | undefined;
-            await waitForResolved(
-                async () => {
-                    expect(uploadId).to.be.ok;
-                    const match = await filestoreReader.resolveById(uploadId!, {
-                        replicate: true,
-                        timeout: 1_000,
-                    });
-                    expect(match).to.be.instanceOf(LargeFile);
-                    expect((match as LargeFile).ready).to.be.false;
-                    pendingFile = match as LargeFile;
-                },
-                { timeout: 30_000, delayInterval: 200 }
-            );
-
-            const fileId = await addPromise;
-            (filestore.files as any).put = originalPut;
-
-            const delayedChunkId = `${fileId}:1`;
-            const writerIndexed = await filestore.files.index.get(
-                delayedChunkId,
-                {
-                    resolve: false,
-                    local: true,
-                    remote: false,
-                } as any
-            );
-            const writerHead = (writerIndexed as any)?.__context?.head;
-            const writerEntry = writerHead
-                ? await filestore.files.log.log.get(writerHead)
-                : undefined;
-            expect(writerHead).to.be.a("string");
-            expect(writerEntry).to.exist;
-            (pendingFile as any).chunkEntryHeads = [];
-            (pendingFile as any).chunkEntryHeads[1] = writerHead;
-
-            const writerHash = peer.identity.publicKey.hashcode();
-            (filestoreReader as any).getReadPeerHints = async () => [
-                writerHash,
-            ];
-            const originalSearch = filestoreReader.files.index.search.bind(
-                filestoreReader.files.index
-            );
-            const originalGet = filestoreReader.files.index.get.bind(
-                filestoreReader.files.index
-            );
-            const originalLogGet = filestoreReader.files.log.log.get.bind(
-                filestoreReader.files.log.log
-            );
-            const originalIterate =
-                filestoreReader.files.log.log.entryIndex.iterate.bind(
-                    filestoreReader.files.log.log.entryIndex
-                );
-            let localChunkGets = 0;
-            let remoteChunkGets = 0;
-            let preciseSearches = 0;
-            let parentSearches = 0;
-            let manifestHeadGets = 0;
-
-            (filestoreReader.files.index as any).get = async (
-                id: string,
-                options: unknown
-            ) => {
-                if (id === delayedChunkId) {
-                    if ((options as { remote?: unknown })?.remote) {
-                        remoteChunkGets++;
-                    } else {
-                        localChunkGets++;
-                    }
-                    return undefined;
-                }
-                return originalGet(id as never, options as never);
-            };
-
-            (filestoreReader.files.index as any).search = async (
-                request: { query: unknown | unknown[] },
-                options: unknown
-            ) => {
-                const queries = Array.isArray(request.query)
-                    ? request.query
-                    : [request.query];
-                const hasParentId = queries.some(
-                    (query: any) =>
-                        getQueryKey(query) === "parentId" &&
-                        getQueryValue(query) === fileId
-                );
-                const hasChunkName = queries.some(
-                    (query: any) =>
-                        getQueryKey(query) === "name" &&
-                        getQueryValue(query) === `${fileName}/1`
-                );
-                if (hasParentId) {
-                    if (hasChunkName) {
-                        preciseSearches++;
-                    } else {
-                        parentSearches++;
-                    }
-                    return [];
-                }
-                return originalSearch(request as never, options as never);
-            };
-
-            (filestoreReader.files.log.log.entryIndex as any).iterate = () => ({
-                done: () => true,
-                next: async () => [],
-                all: async () => [],
-                close: async () => {},
-            });
-
-            (filestoreReader.files.log.log as any).get = async (
-                hash: string,
-                options: { remote?: unknown }
-            ) => {
-                if (hash === writerHead && options?.remote) {
-                    manifestHeadGets++;
-                    return writerEntry;
-                }
-                return originalLogGet(hash as never, options as never);
-            };
-
-            const streamedChunks: Uint8Array[] = [];
-
-            try {
-                await pendingFile!.writeFile(
-                    filestoreReader,
-                    {
-                        write: async (chunk) => {
-                            streamedChunks.push(chunk);
-                        },
-                    },
-                    { timeout: 20_000 }
-                );
-            } finally {
-                (filestoreReader.files.index as any).get = originalGet;
-                (filestoreReader.files.index as any).search = originalSearch;
-                (filestoreReader.files.log.log as any).get = originalLogGet;
-                (filestoreReader.files.log.log.entryIndex as any).iterate =
-                    originalIterate;
-            }
-
-            expect(localChunkGets).to.be.greaterThan(0);
-            expect(remoteChunkGets).to.eq(0);
-            expect(preciseSearches).to.eq(0);
-            expect(parentSearches).to.eq(0);
-            expect(manifestHeadGets).to.be.greaterThan(0);
-            expect(
-                filestoreReader.lastReadDiagnostics?.chunkManifestHeads?.[1]
-            ).to.eq(writerHead);
-            expect(
-                filestoreReader.lastReadDiagnostics?.chunkResolved?.[1]
-            ).to.eq("manifest-head-get");
             expect(streamedChunks.length).to.be.greaterThan(1);
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
@@ -1799,471 +1150,6 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
-        it("uses direct ready manifest gets when hinted ready search fails", async () => {
-            const filestore = await peer.open(new Files());
-            const fileName = "ready manifest get fallback";
-            const fileId = "ready-manifest-get-fallback";
-            const chunkCount = 128;
-            const expected = new Uint8Array(chunkCount);
-            const chunkEntryHeads: string[] = [];
-            for (let index = 0; index < chunkCount; index++) {
-                expected[index] = index % 256;
-                const appended = await filestore.files.put(
-                    new TinyFile({
-                        id: `${fileId}:${index}`,
-                        name: `${fileName}/${index}`,
-                        file: new Uint8Array([expected[index]]),
-                        parentId: fileId,
-                        index,
-                    })
-                );
-                chunkEntryHeads[index] = appended.entry.hash;
-            }
-            const pendingFile = new LargeFile({
-                id: fileId,
-                name: fileName,
-                size: BigInt(expected.byteLength),
-                chunkCount,
-                ready: false,
-            });
-            const readyFile = new LargeFileWithChunkHeads({
-                id: fileId,
-                name: fileName,
-                size: BigInt(expected.byteLength),
-                chunkCount,
-                ready: true,
-                chunkEntryHeads,
-            });
-            const readyPut = await filestore.files.put(readyFile);
-            const readyHead = readyPut.entry.hash;
-            const readyIndexed = await filestore.files.index.get(fileId, {
-                resolve: false,
-                local: true,
-                remote: false,
-            } as any);
-            const readyEntry = await filestore.files.log.log.get(readyHead);
-            expect(readyIndexed).to.exist;
-            expect(readyEntry).to.exist;
-            (readyIndexed as any).__context ??= {};
-            (readyIndexed as any).__context.head = readyHead;
-            const originalSearch = filestore.files.index.search.bind(
-                filestore.files.index
-            );
-            const originalGet = filestore.files.index.get.bind(
-                filestore.files.index
-            );
-            const originalLogGet = filestore.files.log.log.get.bind(
-                filestore.files.log.log
-            );
-            const originalCountLocalChunks =
-                filestore.countLocalChunks.bind(filestore);
-            const originalGetReadPeerHints =
-                filestore.getReadPeerHints.bind(filestore);
-            let remoteReadyFailures = 0;
-            let remoteReadyGets = 0;
-            let remoteReadyHeadGets = 0;
-            const delayedChunkId = `${fileId}:1`;
-
-            (filestore as any).getReadPeerHints = async () => [
-                "ready-manifest-peer",
-            ];
-            (filestore as any).countLocalChunks = async () => 0;
-            (filestore.files.index as any).search = async (
-                request: { query: unknown | unknown[] },
-                options: unknown
-            ) => {
-                const queries = Array.isArray(request.query)
-                    ? request.query
-                    : [request.query];
-                const hasRootId = queries.some(
-                    (query: any) =>
-                        getQueryKey(query) === "id" &&
-                        getQueryValue(query) === fileId
-                );
-                if (hasRootId) {
-                    if ((options as any)?.local === true) {
-                        return [pendingFile];
-                    }
-                    if ((options as any)?.remote) {
-                        remoteReadyFailures++;
-                        throw new Error("remote ready search failed");
-                    }
-                    return [];
-                }
-                return originalSearch(request as never, options as never);
-            };
-            (filestore.files.index as any).get = async (
-                id: string,
-                options: unknown
-            ) => {
-                if (id === fileId && (options as any)?.remote) {
-                    remoteReadyGets++;
-                    return readyIndexed;
-                }
-                if (id === delayedChunkId) {
-                    return undefined;
-                }
-                return originalGet(id as never, options as never);
-            };
-            (filestore.files.log.log as any).get = async (
-                hash: string,
-                options: unknown
-            ) => {
-                if (hash === readyHead && (options as any)?.remote) {
-                    remoteReadyHeadGets++;
-                    return readyEntry;
-                }
-                return originalLogGet(hash as never, options as never);
-            };
-
-            const streamedChunks: Uint8Array[] = [];
-
-            try {
-                await pendingFile.writeFile(
-                    filestore,
-                    {
-                        write: async (chunk) => {
-                            streamedChunks.push(chunk);
-                        },
-                    },
-                    { timeout: 20_000 }
-                );
-            } finally {
-                (filestore.files.index as any).search = originalSearch;
-                (filestore.files.index as any).get = originalGet;
-                (filestore.files.log.log as any).get = originalLogGet;
-                (filestore as any).countLocalChunks = originalCountLocalChunks;
-                (filestore as any).getReadPeerHints = originalGetReadPeerHints;
-            }
-
-            expect(remoteReadyFailures).to.be.greaterThan(0);
-            expect(remoteReadyGets).to.be.greaterThan(0);
-            expect(remoteReadyHeadGets).to.be.greaterThan(0);
-            expect(
-                filestore.lastReadDiagnostics?.readyRemoteSearchErrors?.[0]
-            ).to.eq("remote ready search failed");
-            expect(
-                filestore.lastReadDiagnostics?.readyRemoteGetHeads?.[0]
-            ).to.eq(readyHead);
-            expect(
-                filestore.lastReadDiagnostics?.waitUntilReadyResolvedBy
-            ).to.eq("ready-manifest-head-get");
-            expect(
-                filestore.lastReadDiagnostics?.chunkManifestHeads?.[1]
-            ).to.eq(chunkEntryHeads[1]);
-            expect(filestore.lastReadDiagnostics?.chunkResolved?.[1]).to.eq(
-                "manifest-head-get"
-            );
-            expect(equals(concat(streamedChunks), expected)).to.be.true;
-        });
-
-        it("uses indexed ready manifest heads when resolved ready search returns pending", async () => {
-            const filestore = await peer.open(new Files());
-            const fileName = "ready manifest stale resolved search fallback";
-            const fileId = "ready-manifest-stale-resolved-search-fallback";
-            const chunkCount = 4;
-            const expected = new Uint8Array(chunkCount);
-            const chunkEntryHeads: string[] = [];
-            for (let index = 0; index < chunkCount; index++) {
-                expected[index] = index % 256;
-                const appended = await filestore.files.put(
-                    new TinyFile({
-                        id: `${fileId}:${index}`,
-                        name: `${fileName}/${index}`,
-                        file: new Uint8Array([expected[index]]),
-                        parentId: fileId,
-                        index,
-                    })
-                );
-                chunkEntryHeads[index] = appended.entry.hash;
-            }
-            const pendingFile = new LargeFile({
-                id: fileId,
-                name: fileName,
-                size: BigInt(expected.byteLength),
-                chunkCount,
-                ready: false,
-            });
-            const readyFile = new LargeFileWithChunkHeads({
-                id: fileId,
-                name: fileName,
-                size: BigInt(expected.byteLength),
-                chunkCount,
-                ready: true,
-                finalHash: sha256Base64Sync(expected),
-                chunkEntryHeads,
-            });
-            const readyPut = await filestore.files.put(readyFile);
-            const readyHead = readyPut.entry.hash;
-            const readyIndexed = await filestore.files.index.get(fileId, {
-                resolve: false,
-                local: true,
-                remote: false,
-            } as any);
-            const readyEntry = await filestore.files.log.log.get(readyHead);
-            expect(readyIndexed).to.exist;
-            expect(readyEntry).to.exist;
-            (readyIndexed as any).__context ??= {};
-            (readyIndexed as any).__context.head = readyHead;
-            const originalSearch = filestore.files.index.search.bind(
-                filestore.files.index
-            );
-            const originalGet = filestore.files.index.get.bind(
-                filestore.files.index
-            );
-            const originalLogGet = filestore.files.log.log.get.bind(
-                filestore.files.log.log
-            );
-            const originalCountLocalChunks =
-                filestore.countLocalChunks.bind(filestore);
-            const originalGetReadPeerHints =
-                filestore.getReadPeerHints.bind(filestore);
-            let staleRemoteSearches = 0;
-            let directReadyGets = 0;
-            let indexedReadySearches = 0;
-            let remoteReadyHeadGets = 0;
-
-            (filestore as any).getReadPeerHints = async () => [
-                "ready-manifest-peer",
-            ];
-            (filestore as any).countLocalChunks = async () => 0;
-            (filestore.files.index as any).search = async (
-                request: { query: unknown | unknown[] },
-                options: unknown
-            ) => {
-                const queries = Array.isArray(request.query)
-                    ? request.query
-                    : [request.query];
-                const hasRootId = queries.some(
-                    (query: any) =>
-                        getQueryKey(query) === "id" &&
-                        getQueryValue(query) === fileId
-                );
-                if (hasRootId) {
-                    if ((options as any)?.local === true) {
-                        return [pendingFile];
-                    }
-                    if ((options as any)?.remote) {
-                        if ((options as any)?.resolve === false) {
-                            expect(request).to.be.instanceOf(
-                                SearchRequestIndexed
-                            );
-                            indexedReadySearches++;
-                            return [readyIndexed];
-                        }
-                        staleRemoteSearches++;
-                        return [pendingFile];
-                    }
-                    return [];
-                }
-                return originalSearch(request as never, options as never);
-            };
-            (filestore.files.index as any).get = async (
-                id: string,
-                options: unknown
-            ) => {
-                if (id === fileId && (options as any)?.remote) {
-                    directReadyGets++;
-                    return pendingFile;
-                }
-                return originalGet(id as never, options as never);
-            };
-            (filestore.files.log.log as any).get = async (
-                hash: string,
-                options: unknown
-            ) => {
-                if (hash === readyHead && (options as any)?.remote) {
-                    remoteReadyHeadGets++;
-                    return readyEntry;
-                }
-                return originalLogGet(hash as never, options as never);
-            };
-
-            const streamedChunks: Uint8Array[] = [];
-
-            try {
-                await pendingFile.writeFile(
-                    filestore,
-                    {
-                        write: async (chunk) => {
-                            streamedChunks.push(chunk);
-                        },
-                    },
-                    { timeout: 20_000 }
-                );
-            } finally {
-                (filestore.files.index as any).search = originalSearch;
-                (filestore.files.index as any).get = originalGet;
-                (filestore.files.log.log as any).get = originalLogGet;
-                (filestore as any).countLocalChunks = originalCountLocalChunks;
-                (filestore as any).getReadPeerHints = originalGetReadPeerHints;
-            }
-
-            expect(staleRemoteSearches).to.be.greaterThan(0);
-            expect(directReadyGets).to.be.greaterThan(0);
-            expect(indexedReadySearches).to.be.greaterThan(0);
-            expect(remoteReadyHeadGets).to.be.greaterThan(0);
-            expect(
-                filestore.lastReadDiagnostics?.waitUntilReadyResolvedBy
-            ).to.eq("ready-manifest-head-search");
-            expect(equals(concat(streamedChunks), expected)).to.be.true;
-        });
-
-        it("uses indexed ready manifest heads when hinted ready search fails", async () => {
-            const filestore = await peer.open(new Files());
-            const fileName = "ready manifest indexed head fallback";
-            const fileId = "ready-manifest-indexed-head-fallback";
-            const chunkCount = 4;
-            const expected = new Uint8Array(chunkCount);
-            const chunkEntryHeads: string[] = [];
-            for (let index = 0; index < chunkCount; index++) {
-                expected[index] = index % 256;
-                const appended = await filestore.files.put(
-                    new TinyFile({
-                        id: `${fileId}:${index}`,
-                        name: `${fileName}/${index}`,
-                        file: new Uint8Array([expected[index]]),
-                        parentId: fileId,
-                        index,
-                    })
-                );
-                chunkEntryHeads[index] = appended.entry.hash;
-            }
-            const pendingFile = new LargeFile({
-                id: fileId,
-                name: fileName,
-                size: BigInt(expected.byteLength),
-                chunkCount,
-                ready: false,
-            });
-            const readyFile = new LargeFileWithChunkHeads({
-                id: fileId,
-                name: fileName,
-                size: BigInt(expected.byteLength),
-                chunkCount,
-                ready: true,
-                chunkEntryHeads,
-            });
-            const readyPut = await filestore.files.put(readyFile);
-            const readyHead = readyPut.entry.hash;
-            const readyIndexed = await filestore.files.index.get(fileId, {
-                resolve: false,
-                local: true,
-                remote: false,
-            } as any);
-            const readyEntry = await filestore.files.log.log.get(readyHead);
-            expect(readyIndexed).to.exist;
-            expect(readyEntry).to.exist;
-            (readyIndexed as any).__context ??= {};
-            (readyIndexed as any).__context.head = readyHead;
-            const originalSearch = filestore.files.index.search.bind(
-                filestore.files.index
-            );
-            const originalGet = filestore.files.index.get.bind(
-                filestore.files.index
-            );
-            const originalLogGet = filestore.files.log.log.get.bind(
-                filestore.files.log.log
-            );
-            const originalCountLocalChunks =
-                filestore.countLocalChunks.bind(filestore);
-            const originalGetReadPeerHints =
-                filestore.getReadPeerHints.bind(filestore);
-            let remoteReadyFailures = 0;
-            let indexedReadySearches = 0;
-            let remoteReadyHeadGets = 0;
-            const delayedChunkId = `${fileId}:1`;
-
-            (filestore as any).getReadPeerHints = async () => [
-                "ready-manifest-peer",
-            ];
-            (filestore as any).countLocalChunks = async () => 0;
-            (filestore.files.index as any).search = async (
-                request: { query: unknown | unknown[] },
-                options: unknown
-            ) => {
-                const queries = Array.isArray(request.query)
-                    ? request.query
-                    : [request.query];
-                const hasRootId = queries.some(
-                    (query: any) =>
-                        getQueryKey(query) === "id" &&
-                        getQueryValue(query) === fileId
-                );
-                if (hasRootId) {
-                    if ((options as any)?.local === true) {
-                        return [pendingFile];
-                    }
-                    if ((options as any)?.remote) {
-                        if ((options as any)?.resolve === false) {
-                            expect(request).to.be.instanceOf(
-                                SearchRequestIndexed
-                            );
-                            indexedReadySearches++;
-                            return [readyIndexed];
-                        }
-                        remoteReadyFailures++;
-                        throw new Error("remote ready search failed");
-                    }
-                    return [];
-                }
-                return originalSearch(request as never, options as never);
-            };
-            (filestore.files.index as any).get = async (
-                id: string,
-                options: unknown
-            ) => {
-                if (id === delayedChunkId) {
-                    return undefined;
-                }
-                return originalGet(id as never, options as never);
-            };
-            (filestore.files.log.log as any).get = async (
-                hash: string,
-                options: unknown
-            ) => {
-                if (hash === readyHead && (options as any)?.remote) {
-                    remoteReadyHeadGets++;
-                    return readyEntry;
-                }
-                return originalLogGet(hash as never, options as never);
-            };
-
-            const streamedChunks: Uint8Array[] = [];
-
-            try {
-                await pendingFile.writeFile(
-                    filestore,
-                    {
-                        write: async (chunk) => {
-                            streamedChunks.push(chunk);
-                        },
-                    },
-                    { timeout: 20_000 }
-                );
-            } finally {
-                (filestore.files.index as any).search = originalSearch;
-                (filestore.files.index as any).get = originalGet;
-                (filestore.files.log.log as any).get = originalLogGet;
-                (filestore as any).countLocalChunks = originalCountLocalChunks;
-                (filestore as any).getReadPeerHints = originalGetReadPeerHints;
-            }
-
-            expect(remoteReadyFailures).to.be.greaterThan(0);
-            expect(indexedReadySearches).to.be.greaterThan(0);
-            expect(remoteReadyHeadGets).to.be.greaterThan(0);
-            expect(
-                filestore.lastReadDiagnostics?.waitUntilReadyResolvedBy
-            ).to.eq("ready-manifest-head-search");
-            expect(
-                filestore.lastReadDiagnostics?.chunkManifestHeads?.[1]
-            ).to.eq(chunkEntryHeads[1]);
-            expect(filestore.lastReadDiagnostics?.chunkResolved?.[1]).to.eq(
-                "manifest-head-get"
-            );
-            expect(equals(concat(streamedChunks), expected)).to.be.true;
-        });
-
         it("streams pending manifests when hinted ready search fails", async () => {
             const filestore = await peer.open(new Files());
             const fileName = "pending manifest with failing ready search";
@@ -2362,10 +1248,10 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), expected)).to.be.true;
         });
 
-        it("falls back to non-replicating parent search when adaptive exact routes miss", async () => {
+        it("uses non-replicating parent search when adaptive exact routes miss", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const fileName = "streamed download with parent fallback";
+            const fileName = "streamed download with parent search";
             const fileId = await filestore.add(fileName, largeFile);
 
             const filestoreReader = await peer2.open<Files>(filestore.address);
@@ -2387,23 +1273,10 @@ describe("index", () => {
             const originalGet = filestoreReader.files.index.get.bind(
                 filestoreReader.files.index
             );
-            const originalLogGet = filestoreReader.files.log.log.get.bind(
-                filestoreReader.files.log.log
-            );
             const delayedChunkId = `${fileId}:1`;
-            const writerIndexed = await filestore.files.index.get(
-                delayedChunkId,
-                {
-                    resolve: false,
-                    local: true,
-                    remote: false,
-                } as any
-            );
-            const writerHead = (writerIndexed as any)?.__context?.head;
-            let indexedChunkGets = 0;
-            let indexedHeadGets = 0;
+            let directChunkGets = 0;
             let exactNonReplicatingGets = 0;
-            let indexedPreciseSearches = 0;
+            let replicatingPreciseSearches = 0;
             let resolvedPreciseSearches = 0;
             let persistedParentSearches = 0;
             let nonReplicatingParentSearches = 0;
@@ -2430,10 +1303,7 @@ describe("index", () => {
                         exactNonReplicatingGets++;
                         return undefined;
                     }
-                    if (options?.resolve === false) {
-                        indexedChunkGets++;
-                        return originalGet(id as never, options as never);
-                    }
+                    directChunkGets++;
                     return undefined;
                 }
                 return originalGet(id as never, options as never);
@@ -2469,7 +1339,7 @@ describe("index", () => {
                     ) {
                         resolvedPreciseSearches++;
                     } else {
-                        indexedPreciseSearches++;
+                        replicatingPreciseSearches++;
                     }
                     return [];
                 }
@@ -2493,17 +1363,6 @@ describe("index", () => {
                 return originalSearch(request as never, options as never);
             };
 
-            (filestoreReader.files.log.log as any).get = async (
-                hash: string,
-                options: { remote?: unknown }
-            ) => {
-                if (hash === writerHead && options?.remote) {
-                    indexedHeadGets++;
-                    return undefined;
-                }
-                return originalLogGet(hash as never, options as never);
-            };
-
             const streamedChunks: Uint8Array[] = [];
 
             try {
@@ -2517,12 +1376,12 @@ describe("index", () => {
                     { timeout: 20_000 }
                 );
             } finally {
-                (filestoreReader.files.log.log as any).get = originalLogGet;
+                (filestoreReader.files.index as any).get = originalGet;
+                (filestoreReader.files.index as any).search = originalSearch;
             }
 
-            expect(indexedChunkGets).to.be.greaterThan(0);
-            expect(indexedHeadGets).to.be.greaterThan(0);
-            expect(indexedPreciseSearches).to.be.greaterThan(0);
+            expect(directChunkGets).to.be.greaterThan(0);
+            expect(replicatingPreciseSearches).to.be.greaterThan(0);
             expect(exactNonReplicatingGets).to.be.greaterThan(0);
             expect(resolvedPreciseSearches).to.be.greaterThan(0);
             expect(persistedParentSearches).to.be.greaterThan(0);
@@ -2534,10 +1393,10 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
-        it("tries hinted non-replicating chunk reads when unhinted fallback misses", async () => {
+        it("keeps hinted chunk reads after unhinted non-replicating misses", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const fileName = "streamed download with hinted exact fallback";
+            const fileName = "streamed download with hinted exact read";
             const fileId = await filestore.add(fileName, largeFile);
 
             const filestoreReader = await peer2.open<Files>(filestore.address);
@@ -2664,12 +1523,11 @@ describe("index", () => {
                 );
             const delayedChunkId = `${fileId}:1`;
             let directChunkGets = 0;
-            let hintedDirectGetsAfterFallback = 0;
-            let unhintedDirectGetsAfterFallback = 0;
-            let nonReplicatingFallbacks = 0;
+            let hintedDirectGetsAfterNonReplicatingRead = 0;
+            let unhintedDirectGetsAfterNonReplicatingRead = 0;
+            let nonReplicatingReads = 0;
             let preciseChunkSearches = 0;
             let parentChunkSearches = 0;
-            const indexedChunks = new Set<string>();
 
             (filestoreReader.files.index as any).get = async (
                 id: string,
@@ -2687,31 +1545,27 @@ describe("index", () => {
                 if (id === delayedChunkId) {
                     const remote = options?.remote;
                     if (remote === false) {
-                        return indexedChunks.has(id)
-                            ? originalGet(id as never, options as never)
-                            : undefined;
+                        return undefined;
                     }
                     if (remote?.replicate === false) {
-                        nonReplicatingFallbacks++;
+                        nonReplicatingReads++;
                         return undefined;
                     }
                     directChunkGets++;
-                    if (nonReplicatingFallbacks > 0) {
+                    if (nonReplicatingReads > 0) {
                         if (remote?.from?.includes(writerHash)) {
-                            hintedDirectGetsAfterFallback++;
+                            hintedDirectGetsAfterNonReplicatingRead++;
                         } else {
-                            unhintedDirectGetsAfterFallback++;
+                            unhintedDirectGetsAfterNonReplicatingRead++;
                         }
                     }
                     if (directChunkGets <= 4) {
                         return undefined;
                     }
                     if (
-                        options?.resolve === false &&
                         remote?.from?.includes(writerHash) &&
                         remote.strategy === "always"
                     ) {
-                        indexedChunks.add(id);
                         return originalGet(id as never, options as never);
                     }
                     return undefined;
@@ -2768,16 +1622,17 @@ describe("index", () => {
                     { timeout: 20_000 }
                 );
             } finally {
+                (filestoreReader.files.index as any).get = originalGet;
+                (filestoreReader.files.index as any).search = originalSearch;
                 (filestoreReader.files.log.log.entryIndex as any).iterate =
                     originalIterate;
             }
 
             expect(directChunkGets).to.be.greaterThan(4);
             expect(preciseChunkSearches).to.be.greaterThan(0);
-            expect(parentChunkSearches).to.be.greaterThan(0);
-            expect(nonReplicatingFallbacks).to.be.greaterThan(0);
-            expect(hintedDirectGetsAfterFallback).to.be.greaterThan(0);
-            expect(unhintedDirectGetsAfterFallback).to.eq(0);
+            expect(nonReplicatingReads).to.be.greaterThan(0);
+            expect(hintedDirectGetsAfterNonReplicatingRead).to.be.greaterThan(0);
+            expect(unhintedDirectGetsAfterNonReplicatingRead).to.eq(0);
             expect(
                 filestoreReader.lastReadDiagnostics?.initialReadPeerHints
             ).to.deep.eq([writerHash]);
@@ -2787,10 +1642,10 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
-        it("falls back to parent chunk search when exact chunk routes miss", async () => {
+        it("uses parent chunk search when exact chunk routes miss", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
-            const fileName = "streamed download with parent search fallback";
+            const fileName = "streamed download with parent search";
             const fileId = await filestore.add(fileName, largeFile);
 
             const filestoreReader = await peer2.open<Files>(filestore.address);
@@ -2957,11 +1812,11 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
-        it("falls back to chunk-id lookups when observer chunk searches miss available chunks", async () => {
+        it("uses chunk-id lookups when observer chunk searches miss available chunks", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
             const fileId = await filestore.add(
-                "observer download falls back to chunk-id lookups",
+                "observer download uses chunk-id lookups",
                 largeFile
             );
 

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -10,7 +10,6 @@ import { Program, ProgramHandler } from "@peerbit/program";
 import {
     Documents,
     SearchRequest,
-    SearchRequestIndexed,
     StringMatch,
     StringMatchMethod,
     IsNull,
@@ -695,7 +694,6 @@ export class LargeFile extends AbstractFile {
         let directMisses = 0;
         let retryableFailures = 0;
         let nextNonReplicatingReadAfterFailures = 3;
-        const indexedChunkPending = Symbol("indexed-chunk-pending");
         const materializeLocalChunk = async (
             resolvedBy: string
         ): Promise<TinyFile | undefined> => {
@@ -716,222 +714,6 @@ export class LargeFile extends AbstractFile {
                 return chunk;
             }
         };
-        const rememberChunkEntryHead = (head: string | undefined) => {
-            if (!head) {
-                return;
-            }
-            files.retainChunkEntryHead(head);
-            properties?.debug &&
-                ((properties.debug.chunkIndexedHeads ||= {})[index] = head);
-        };
-        const matchesChunkIndex = (candidate: unknown) =>
-            candidate instanceof IndexableFile &&
-            candidate.id === chunkId &&
-            candidate.parentId === this.id &&
-            candidate.name === `${this.name}/${index}`;
-        const materializeChunkEntryHead = async (
-            head: string | undefined,
-            remoteFrom: string[] | undefined,
-            resolvedBy: string,
-            replicate = files.persistChunkReads
-        ): Promise<TinyFile | undefined> => {
-            if (!head) {
-                return;
-            }
-            rememberChunkEntryHead(head);
-            properties?.debug &&
-                ((properties.debug.chunkHeadGets ||= {})[index] =
-                    ((properties.debug.chunkHeadGets ||= {})[index] ?? 0) + 1);
-            const entry = await files.files.log.log.get(head, {
-                remote: {
-                    timeout: attemptTimeout,
-                    throwOnMissing: false,
-                    retryMissingResponses: true,
-                    replicate,
-                    from: remoteFrom,
-                } as any,
-            });
-            if (!entry) {
-                return;
-            }
-            files.retainChunkEntryHead(head);
-            const operation = await entry.getPayloadValue();
-            if (!isPutOperation(operation)) {
-                return;
-            }
-            const chunk = files.files.index.valueEncoding.decoder(
-                operation.data
-            );
-            if (
-                chunk instanceof TinyFile &&
-                chunk.parentId === this.id &&
-                chunk.index === index
-            ) {
-                knownChunks.set(index, chunk);
-                files.retainChunkRead(chunk.id);
-                if (replicate) {
-                    try {
-                        await files.files.log.join([entry], {
-                            replicate: { assumeSynced: true },
-                        });
-                    } catch (error) {
-                        properties?.debug &&
-                            ((properties.debug.chunkHeadJoinErrors ||= {})[
-                                index
-                            ] = getErrorMessage(error));
-                    }
-                }
-                properties?.debug &&
-                    ((properties.debug.chunkResolved ||= {})[index] =
-                        resolvedBy);
-                return chunk;
-            }
-        };
-        const scanLocalChunkEntryHeads = async () => {
-            properties?.debug &&
-                ((properties.debug.chunkLocalEntryScans ||= {})[index] =
-                    ((properties.debug.chunkLocalEntryScans ||= {})[index] ??
-                        0) + 1);
-            const heads = new Map<string, string>();
-            const candidateHeads: string[] = [];
-            const iterator = files.files.log.log.entryIndex.iterate(
-                [],
-                undefined,
-                false
-            );
-            try {
-                while (!iterator.done()) {
-                    const entries = await iterator.next(128);
-                    for (const entry of entries) {
-                        const metadata = getEntryMetadata(entry);
-                        if (metadata?.id && !heads.has(metadata.id)) {
-                            heads.set(metadata.id, entry.hash);
-                        }
-                        candidateHeads.push(entry.hash);
-                    }
-                }
-            } finally {
-                await iterator.close();
-            }
-
-            if (!heads.has(chunkId)) {
-                for (const head of candidateHeads) {
-                    const entry = await files.files.log.log.get(head);
-                    if (!entry) {
-                        continue;
-                    }
-                    try {
-                        const operation = await entry.getPayloadValue();
-                        if (!isPutOperation(operation)) {
-                            continue;
-                        }
-                        const file = files.files.index.valueEncoding.decoder(
-                            operation.data
-                        );
-                        if (
-                            file instanceof TinyFile &&
-                            file.parentId === this.id &&
-                            !heads.has(file.id)
-                        ) {
-                            heads.set(file.id, head);
-                        }
-                    } catch {
-                        continue;
-                    }
-                }
-            }
-
-            readContext.localChunkEntryHeads = heads;
-            return heads;
-        };
-        const getLocalChunkEntryHeads = async (refresh = false) => {
-            if (readContext.localChunkEntryHeadsScan) {
-                return readContext.localChunkEntryHeadsScan;
-            }
-            if (!refresh && readContext.localChunkEntryHeads) {
-                return readContext.localChunkEntryHeads;
-            }
-            const scan = scanLocalChunkEntryHeads().finally(() => {
-                if (readContext.localChunkEntryHeadsScan === scan) {
-                    readContext.localChunkEntryHeadsScan = undefined;
-                }
-            });
-            readContext.localChunkEntryHeadsScan = scan;
-            return scan;
-        };
-        const resolveChunkByLocalEntryMetadata = async (
-            remoteFrom: string[] | undefined,
-            refresh = false
-        ): Promise<TinyFile | undefined> => {
-            const localHead = (await getLocalChunkEntryHeads(refresh)).get(
-                chunkId
-            );
-            if (!localHead) {
-                return;
-            }
-            properties?.debug &&
-                ((properties.debug.chunkLocalEntryHeads ||= {})[index] =
-                    localHead);
-            return materializeChunkEntryHead(
-                localHead,
-                remoteFrom,
-                "local-entry-head",
-                files.persistChunkReads
-            );
-        };
-        const resolveChunkByManifestEntryHead = async (
-            remoteFrom: string[] | undefined
-        ): Promise<TinyFile | undefined> => {
-            const heads = (this as { chunkEntryHeads?: unknown })
-                .chunkEntryHeads;
-            const head = Array.isArray(heads) ? heads[index] : undefined;
-            if (typeof head !== "string") {
-                return;
-            }
-            properties?.debug &&
-                ((properties.debug.chunkManifestHeads ||= {})[index] = head);
-            return materializeChunkEntryHead(
-                head,
-                remoteFrom,
-                "manifest-head-get",
-                files.persistChunkReads
-            );
-        };
-        const syncChunkByExactIndex = async (
-            remoteFrom: string[] | undefined
-        ): Promise<TinyFile | typeof indexedChunkPending | undefined> => {
-            properties?.debug &&
-                ((properties.debug.chunkIndexedGets ||= {})[index] =
-                    ((properties.debug.chunkIndexedGets ||= {})[index] ?? 0) +
-                    1);
-            const indexed = await files.files.index.get(chunkId, {
-                resolve: false,
-                local: false,
-                remote: {
-                    timeout: attemptTimeout,
-                    strategy: "always" as any,
-                    throwOnMissing: false,
-                    retryMissingResponses: true,
-                    replicate: true,
-                    from: remoteFrom,
-                },
-            });
-            if (matchesChunkIndex(indexed)) {
-                files.retainResolvedChunk(indexed);
-                const indexedHead = getContextHead(indexed);
-                rememberChunkEntryHead(indexedHead);
-                return (
-                    (await materializeLocalChunk("indexed-get")) ??
-                    (await materializeChunkEntryHead(
-                        indexedHead,
-                        remoteFrom,
-                        "indexed-head-get",
-                        true
-                    )) ??
-                    indexedChunkPending
-                );
-            }
-        };
         const resolveChunkByIndexedFields = async (
             remoteFrom: string[] | undefined
         ): Promise<TinyFile | undefined> => {
@@ -939,54 +721,6 @@ export class LargeFile extends AbstractFile {
                 ((properties.debug.chunkIndexedSearches ||= {})[index] =
                     ((properties.debug.chunkIndexedSearches ||= {})[index] ??
                         0) + 1);
-            if (files.persistChunkReads) {
-                const chunks = await files.files.index.search(
-                    new SearchRequestIndexed({
-                        query: [
-                            new StringMatch({
-                                key: "parentId",
-                                value: this.id,
-                                caseInsensitive: false,
-                                method: StringMatchMethod.exact,
-                            }),
-                            new StringMatch({
-                                key: "name",
-                                value: `${this.name}/${index}`,
-                                caseInsensitive: false,
-                                method: StringMatchMethod.exact,
-                            }),
-                        ],
-                        fetch: 1,
-                    }),
-                    {
-                        resolve: false,
-                        local: false,
-                        remote: {
-                            timeout: attemptTimeout,
-                            throwOnMissing: false,
-                            retryMissingResponses: true,
-                            replicate: true,
-                            from: remoteFrom,
-                        },
-                    } as any
-                );
-                const indexed = chunks.find(matchesChunkIndex);
-                if (indexed) {
-                    files.retainResolvedChunk(indexed);
-                    const indexedHead = getContextHead(indexed);
-                    rememberChunkEntryHead(indexedHead);
-                    return (
-                        (await materializeLocalChunk("indexed-search")) ??
-                        (await materializeChunkEntryHead(
-                            indexedHead,
-                            remoteFrom,
-                            "indexed-search-head-get",
-                            true
-                        ))
-                    );
-                }
-                return;
-            }
             const chunks = await files.files.index.search(
                 new SearchRequest({
                     query: [
@@ -1219,57 +953,18 @@ export class LargeFile extends AbstractFile {
             }
 
             try {
-                const chunk = await resolveChunkByManifestEntryHead(remoteFrom);
-                if (chunk) {
-                    return chunk;
-                }
-            } catch (error) {
-                if (!isRetryableChunkLookupError(error)) {
-                    properties?.debug &&
-                        (properties.debug.chunkFailure = {
-                            index,
-                            type: "non-retryable-manifest-head",
-                            message: getErrorMessage(error),
-                        });
-                    throw error;
-                }
-                if (remoteFrom && shouldRetryChunkLookupWithoutHints(error)) {
-                    hintedDeliveryFailures += 1;
-                }
-                retryableFailures += 1;
-                properties?.debug &&
-                    ((properties.debug.chunkRetryableManifestHeadErrors ||= {})[
-                        index
-                    ] = getErrorMessage(error));
-            }
-
-            try {
-                const chunk = files.persistChunkReads
-                    ? await syncChunkByExactIndex(remoteFrom)
-                    : await resolveChunkByDirectGet(remoteFrom, false);
+                const chunk = await resolveChunkByDirectGet(
+                    remoteFrom,
+                    files.persistChunkReads
+                );
                 if (chunk instanceof TinyFile) {
                     return chunk;
                 }
-                if (chunk === indexedChunkPending) {
-                    properties?.debug &&
-                        ((properties.debug.chunkGetMisses ||= {})[index] =
-                            ((properties.debug.chunkGetMisses ||= {})[index] ??
-                                0) + 1);
-                    directMisses += 1;
-                    if (
-                        directMisses + retryableFailures <
-                        nextNonReplicatingReadAfterFailures
-                    ) {
-                        await sleep(250);
-                        continue;
-                    }
-                } else {
-                    properties?.debug &&
-                        ((properties.debug.chunkGetMisses ||= {})[index] =
-                            ((properties.debug.chunkGetMisses ||= {})[index] ??
-                                0) + 1);
-                    directMisses += 1;
-                }
+                properties?.debug &&
+                    ((properties.debug.chunkGetMisses ||= {})[index] =
+                        ((properties.debug.chunkGetMisses ||= {})[index] ??
+                            0) + 1);
+                directMisses += 1;
             } catch (error) {
                 if (!isRetryableChunkLookupError(error)) {
                     properties?.debug &&
@@ -1320,18 +1015,18 @@ export class LargeFile extends AbstractFile {
             ) {
                 // A miss is not evidence that a peer hint is stale. Keep using
                 // the known writer/replicator hint for direct reads unless a
-                // delivery error specifically tells us to fall back without it.
-                const fallbackHints =
+                // delivery error specifically tells us to try without it.
+                const sourceHints =
                     remoteFrom ??
                     readContext.lastReadPeerHints ??
                     (await files.getReadPeerHints());
-                const fallbackSources = fallbackHints
-                    ? [undefined, fallbackHints]
+                const remoteSources = sourceHints
+                    ? [undefined, sourceHints]
                     : [undefined];
-                for (const fallbackFrom of fallbackSources) {
+                for (const sourceFrom of remoteSources) {
                     try {
                         const chunk =
-                            await resolveChunkWithoutPersisting(fallbackFrom);
+                            await resolveChunkWithoutPersisting(sourceFrom);
                         if (chunk) {
                             return chunk;
                         }
@@ -1346,7 +1041,7 @@ export class LargeFile extends AbstractFile {
                             throw error;
                         }
                         if (
-                            fallbackFrom &&
+                            sourceFrom &&
                             shouldRetryChunkLookupWithoutHints(error)
                         ) {
                             hintedDeliveryFailures += 1;
@@ -1357,10 +1052,10 @@ export class LargeFile extends AbstractFile {
                                 {})[index] = getErrorMessage(error));
                     }
                 }
-                for (const fallbackFrom of fallbackSources) {
+                for (const sourceFrom of remoteSources) {
                     try {
                         const chunk =
-                            await resolveChunkByResolvedFields(fallbackFrom);
+                            await resolveChunkByResolvedFields(sourceFrom);
                         if (chunk) {
                             return chunk;
                         }
@@ -1375,7 +1070,7 @@ export class LargeFile extends AbstractFile {
                             throw error;
                         }
                         if (
-                            fallbackFrom &&
+                            sourceFrom &&
                             shouldRetryChunkLookupWithoutHints(error)
                         ) {
                             hintedDeliveryFailures += 1;
@@ -1386,10 +1081,10 @@ export class LargeFile extends AbstractFile {
                                 {})[index] = getErrorMessage(error));
                     }
                 }
-                for (const fallbackFrom of fallbackSources) {
+                for (const sourceFrom of remoteSources) {
                     try {
                         const chunk =
-                            await resolveChunksByParentSearch(fallbackFrom);
+                            await resolveChunksByParentSearch(sourceFrom);
                         if (chunk) {
                             return chunk;
                         }
@@ -1404,7 +1099,7 @@ export class LargeFile extends AbstractFile {
                             throw error;
                         }
                         if (
-                            fallbackFrom &&
+                            sourceFrom &&
                             shouldRetryChunkLookupWithoutHints(error)
                         ) {
                             hintedDeliveryFailures += 1;
@@ -1416,10 +1111,10 @@ export class LargeFile extends AbstractFile {
                     }
                 }
                 if (files.persistChunkReads) {
-                    for (const fallbackFrom of fallbackSources) {
+                    for (const sourceFrom of remoteSources) {
                         try {
                             const chunk = await resolveChunksByParentSearch(
-                                fallbackFrom,
+                                sourceFrom,
                                 {
                                     replicate: false,
                                     resolvedBy: "non-replicating-parent-search",
@@ -1439,7 +1134,7 @@ export class LargeFile extends AbstractFile {
                                 throw error;
                             }
                             if (
-                                fallbackFrom &&
+                                sourceFrom &&
                                 shouldRetryChunkLookupWithoutHints(error)
                             ) {
                                 hintedDeliveryFailures += 1;
@@ -1449,66 +1144,6 @@ export class LargeFile extends AbstractFile {
                                 ((properties.debug.chunkRetryableNonReplicatingParentSearchErrors ||=
                                     {})[index] = getErrorMessage(error));
                         }
-                    }
-                }
-                for (const fallbackFrom of fallbackSources) {
-                    try {
-                        const chunk =
-                            await resolveChunkByManifestEntryHead(fallbackFrom);
-                        if (chunk) {
-                            return chunk;
-                        }
-                    } catch (error) {
-                        if (!isRetryableChunkLookupError(error)) {
-                            properties?.debug &&
-                                (properties.debug.chunkFailure = {
-                                    index,
-                                    type: "non-retryable-manifest-head",
-                                    message: getErrorMessage(error),
-                                });
-                            throw error;
-                        }
-                        if (
-                            fallbackFrom &&
-                            shouldRetryChunkLookupWithoutHints(error)
-                        ) {
-                            hintedDeliveryFailures += 1;
-                        }
-                        retryableFailures += 1;
-                        properties?.debug &&
-                            ((properties.debug.chunkRetryableManifestHeadErrors ||=
-                                {})[index] = getErrorMessage(error));
-                    }
-                }
-                for (const fallbackFrom of fallbackSources) {
-                    try {
-                        const chunk = await resolveChunkByLocalEntryMetadata(
-                            fallbackFrom,
-                            true
-                        );
-                        if (chunk) {
-                            return chunk;
-                        }
-                    } catch (error) {
-                        if (!isRetryableChunkLookupError(error)) {
-                            properties?.debug &&
-                                (properties.debug.chunkFailure = {
-                                    index,
-                                    type: "non-retryable-local-metadata-head",
-                                    message: getErrorMessage(error),
-                                });
-                            throw error;
-                        }
-                        if (
-                            fallbackFrom &&
-                            shouldRetryChunkLookupWithoutHints(error)
-                        ) {
-                            hintedDeliveryFailures += 1;
-                        }
-                        retryableFailures += 1;
-                        properties?.debug &&
-                            ((properties.debug.chunkRetryableLocalMetadataErrors ||=
-                                {})[index] = getErrorMessage(error));
                     }
                 }
                 nextNonReplicatingReadAfterFailures *= 2;
@@ -1598,109 +1233,6 @@ export class LargeFile extends AbstractFile {
                 }
                 return localReady;
             }
-            const materializeReadyManifestHead = async (
-                head: string | undefined
-            ): Promise<LargeFile | undefined> => {
-                if (!head) {
-                    return;
-                }
-                files.retainChunkEntryHead(head);
-                if (debug) {
-                    (debug.readyRemoteGetHeads ||= []).push(head);
-                }
-                const entry = await files.files.log.log.get(head, {
-                    remote: {
-                        timeout: attemptTimeout,
-                        throwOnMissing: false,
-                        retryMissingResponses: true,
-                        replicate: files.persistChunkReads,
-                        from: remoteFrom,
-                    } as any,
-                });
-                if (!entry) {
-                    return;
-                }
-                files.retainChunkEntryHead(head);
-                const operation = await entry.getPayloadValue();
-                if (!isPutOperation(operation)) {
-                    return;
-                }
-                try {
-                    return toReadableLargeFile(
-                        files.files.index.valueEncoding.decoder(operation.data)
-                    );
-                } catch (error) {
-                    if (debug) {
-                        (debug.readyRemoteDecodeFallbacks ||= []).push(
-                            getErrorMessage(error)
-                        );
-                    }
-                    return decodeLargeFileWithChunkHeads(operation.data);
-                }
-            };
-            const searchReadyManifestEntryHeads = async (): Promise<
-                LargeFile[]
-            > => {
-                try {
-                    const indexedMatches = await files.files.index.search(
-                        new SearchRequestIndexed({
-                            query: request.query,
-                            fetch: request.fetch,
-                            sort: request.sort,
-                        }),
-                        {
-                            resolve: false,
-                            local: false,
-                            remote: {
-                                timeout: attemptTimeout,
-                                throwOnMissing: false,
-                                retryMissingResponses: true,
-                                replicate: files.persistChunkReads,
-                                from: remoteFrom,
-                            },
-                        } as any
-                    );
-                    const materializedMatches: LargeFile[] = [];
-                    for (const indexedMatch of indexedMatches) {
-                        try {
-                            const materialized =
-                                await materializeReadyManifestHead(
-                                    getContextHead(indexedMatch)
-                                );
-                            if (materialized) {
-                                materializedMatches.push(materialized);
-                            }
-                        } catch (headError) {
-                            if (debug) {
-                                (debug.readyRemoteIndexedHeadErrors ||=
-                                    []).push(getErrorMessage(headError));
-                            }
-                        }
-                    }
-                    return materializedMatches;
-                } catch (indexedError) {
-                    if (debug) {
-                        (debug.readyRemoteIndexedSearchErrors ||= []).push(
-                            getErrorMessage(indexedError)
-                        );
-                    }
-                    return [];
-                }
-            };
-            const resolveReadyManifestEntryHeads = async (
-                source: string
-            ): Promise<LargeFile | undefined> => {
-                const matches = await searchReadyManifestEntryHeads();
-                const latest = toReadableLargeFile(
-                    pickLatest(matches as AbstractFile[])
-                );
-                if (latest?.ready) {
-                    if (debug) {
-                        debug.waitUntilReadyResolvedBy = source;
-                    }
-                    return latest;
-                }
-            };
             let remoteMatches: AbstractFile[] = [];
             let remoteSearchFailed = false;
             try {
@@ -1721,18 +1253,6 @@ export class LargeFile extends AbstractFile {
                         getErrorMessage(error)
                     );
                 }
-                const indexedMatches = await searchReadyManifestEntryHeads();
-                const indexedReady = toReadableLargeFile(
-                    pickLatest(indexedMatches as AbstractFile[])
-                );
-                if (indexedReady?.ready) {
-                    if (debug) {
-                        debug.waitUntilReadyResolvedBy =
-                            "ready-manifest-head-search";
-                    }
-                    return indexedReady;
-                }
-                remoteMatches = indexedMatches as AbstractFile[];
             }
             const remoteLatest = pickLatest(remoteMatches);
             let remoteReady = toReadableLargeFile(remoteLatest);
@@ -1748,7 +1268,6 @@ export class LargeFile extends AbstractFile {
             }
             try {
                 const directRemote = await files.files.index.get(this.id, {
-                    resolve: false,
                     local: false,
                     remote: {
                         timeout: attemptTimeout,
@@ -1761,12 +1280,6 @@ export class LargeFile extends AbstractFile {
                 });
                 let directReady = toReadableLargeFile(directRemote);
                 let directReadySource = "ready-manifest-get";
-                if (!directReady) {
-                    directReady = await materializeReadyManifestHead(
-                        getContextHead(directRemote)
-                    );
-                    directReadySource = "ready-manifest-head-get";
-                }
                 if (debug?.lastReadyProbe && isLargeFileLike(directRemote)) {
                     debug.lastReadyProbe.ready = directRemote.ready;
                 }
@@ -1792,14 +1305,6 @@ export class LargeFile extends AbstractFile {
                     (debug.readyRemoteGetErrors ||= []).push(
                         getErrorMessage(error)
                     );
-                }
-            }
-            if (!remoteReady?.ready) {
-                const indexedReady = await resolveReadyManifestEntryHeads(
-                    "ready-manifest-head-search"
-                );
-                if (indexedReady) {
-                    return indexedReady;
                 }
             }
             const countCandidate =
@@ -2097,56 +1602,6 @@ const toReadableLargeFile = (value: unknown): LargeFile | undefined => {
         ready: value.ready,
         finalHash: value.finalHash,
     });
-};
-
-const readBorshStringVector = (data: Uint8Array, offset: number) => {
-    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-    if (offset + 4 > data.byteLength) {
-        return [];
-    }
-    const decoder = new TextDecoder();
-    const count = view.getUint32(offset, true);
-    offset += 4;
-    const values: string[] = [];
-    for (let i = 0; i < count; i++) {
-        if (offset + 4 > data.byteLength) {
-            throw new Error("Malformed chunk head vector");
-        }
-        const byteLength = view.getUint32(offset, true);
-        offset += 4;
-        if (offset + byteLength > data.byteLength) {
-            throw new Error("Malformed chunk head string");
-        }
-        values.push(decoder.decode(data.subarray(offset, offset + byteLength)));
-        offset += byteLength;
-    }
-    return values;
-};
-
-const decodeLargeFileWithChunkHeads = (data: Uint8Array) => {
-    const base = deserialize(data, LargeFile, { unchecked: true });
-    const baseBytes = serialize(
-        new LargeFile({
-            id: base.id,
-            name: base.name,
-            size: base.size,
-            chunkCount: base.chunkCount,
-            ready: base.ready,
-            finalHash: base.finalHash,
-        })
-    );
-    return new LargeFileWithChunkHeads({
-        id: base.id,
-        name: base.name,
-        size: base.size,
-        chunkCount: base.chunkCount,
-        ready: base.ready,
-        finalHash: base.finalHash,
-        chunkEntryHeads:
-            baseBytes.byteLength < data.byteLength
-                ? readBorshStringVector(data, baseBytes.byteLength)
-                : [],
-    }) as unknown as LargeFile;
 };
 
 const preferListCandidate = (


### PR DESCRIPTION
## Summary
- remove file-share read paths that manually scan log entry indexes or materialize chunk/manifest log heads
- keep reads on the normal Peerbit document index APIs now that peerbit 5.2.8 contains the lower-level adaptive routing fixes
- remove benchmark diagnostics for the deleted log-head paths

## Validation
- pnpm --filter @peerbit/please-lib exec vitest run src/__tests__/index.integration.test.ts
- pnpm --filter @peerbit/please-lib test
- pnpm --filter @peerbit/please-lib build
- pnpm --filter file-share build
- node --check packages/file-share/frontend/tests/two-runner.bench.mjs
- git diff --check