### PR TITLE
Improve file-share root listing latency

### DIFF
--- a/packages/file-share/frontend/package.json
+++ b/packages/file-share/frontend/package.json
@@ -12,6 +12,7 @@
         "build": "tsc && vite build",
         "preview": "vite preview",
         "deploy": "pnpm run build && NODE_DEBUG=gh-pages gh-pages -d dist",
+        "test:unit": "vitest run -c vitest.config.ts",
         "test:e2e": "playwright test -c playwright.config.ts",
         "test:e2e:headed": "playwright test -c playwright.config.ts --headed"
     },

--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -16,6 +16,13 @@ import { useNetworkUsage } from "./NetworkUsage";
 import { GraphExplorer } from "./Graphs";
 import * as Progress from "@radix-ui/react-progress";
 import { ReplicationOptions } from "@peerbit/shared-log";
+import {
+    applyRootFileChangeToList,
+    getReadyLargeFileSignature,
+    getRootFileChange,
+    shouldRefreshRootListForFileChange,
+    sortRootFilesForDisplay,
+} from "./root-list";
 
 const saveRoleLocalStorage = (files: Files, role: string) => {
     localStorage.setItem(files.address + "-role", role); // Save role in localstorage for next time
@@ -70,6 +77,8 @@ type ListingDiagnostics = {
     lastAdaptiveRefreshError: string | null;
     fileChangeEventCount: number;
     rootFileChangeEventCount: number;
+    rootChangeDirectAddCount: number;
+    rootChangeDirectRemoveCount: number;
     skippedChildFileChangeEventCount: number;
     activeTransferCount: number;
     skippedActiveTransferRefreshCount: number;
@@ -97,39 +106,6 @@ const getStreamingDownloadThresholdBytes = () => {
 
 const getFileSizeBigInt = (file: AbstractFile) =>
     typeof file.size === "bigint" ? file.size : BigInt(file.size);
-
-const getReadyLargeFileSignature = (files: AbstractFile[]) => {
-    const readyFiles = files
-        .filter(
-            (file): file is LargeFile =>
-                file instanceof LargeFile && file.ready && !!file.finalHash
-        )
-        .map(
-            (file) =>
-                `${file.id}:${file.size.toString()}:${file.chunkCount}:${file.finalHash}`
-        )
-        .sort();
-    return readyFiles.length > 0 ? readyFiles.join("|") : null;
-};
-
-type FileChangeDetail = {
-    added?: Array<Pick<AbstractFile, "parentId">>;
-    removed?: Array<Pick<AbstractFile, "parentId">>;
-};
-
-export const shouldRefreshRootListForFileChange = (event: Event) => {
-    const detail = (event as CustomEvent<FileChangeDetail>).detail;
-    if (!detail) {
-        return true;
-    }
-
-    const changed = [...(detail.added ?? []), ...(detail.removed ?? [])];
-    if (changed.length === 0) {
-        return false;
-    }
-
-    return changed.some((file) => file?.parentId == null);
-};
 
 const createListingDiagnostics = (
     shareAddress: string | undefined,
@@ -168,6 +144,8 @@ const createListingDiagnostics = (
     lastAdaptiveRefreshError: null,
     fileChangeEventCount: 0,
     rootFileChangeEventCount: 0,
+    rootChangeDirectAddCount: 0,
+    rootChangeDirectRemoveCount: 0,
     skippedChildFileChangeEventCount: 0,
     activeTransferCount: 0,
     skippedActiveTransferRefreshCount: 0,
@@ -205,7 +183,12 @@ export const Drop = () => {
 
     const [_, forceUpdate] = useReducer((x) => x + 1, 0);
     const params = useParams();
-    const [list, setList] = useState<AbstractFile[]>([]);
+    const [list, setListState] = useState<AbstractFile[]>([]);
+    const listRef = useRef<AbstractFile[]>([]);
+    const setRootList = (rootFiles: AbstractFile[]) => {
+        listRef.current = rootFiles;
+        setListState(rootFiles);
+    };
 
     const [replicationSet, setReplicationSet] = useState<Set<string>>(
         new Set()
@@ -233,6 +216,7 @@ export const Drop = () => {
             shareAddress,
             storedRole
         );
+        setRootList([]);
         adaptiveRefreshRef.current = null;
         adaptiveRefreshSignatureRef.current = null;
         // Reset diagnostics only when we enter a different share. Role changes
@@ -489,7 +473,7 @@ export const Drop = () => {
         files.program?.closed,
         isHost,
         left,
-        list.length,
+        list,
         peer?.identity?.publicKey,
         replicationSet.size,
     ]);
@@ -544,6 +528,27 @@ export const Drop = () => {
             }
 
             diagnosticsRef.current.rootFileChangeEventCount += 1;
+            const rootChange = getRootFileChange(event);
+            if (rootChange.added.length > 0 || rootChange.removed.length > 0) {
+                diagnosticsRef.current.rootChangeDirectAddCount +=
+                    rootChange.added.length;
+                diagnosticsRef.current.rootChangeDirectRemoveCount +=
+                    rootChange.removed.length;
+                const nextList = applyRootFileChangeToList(
+                    listRef.current,
+                    rootChange
+                );
+                setRootList(nextList);
+                const readyLargeFileSignature =
+                    getReadyLargeFileSignature(nextList);
+                if (readyLargeFileSignature) {
+                    scheduleAdaptiveRefresh(
+                        "ready-change:event",
+                        readyLargeFileSignature
+                    );
+                }
+                forceUpdate();
+            }
             updateListDebounced(event);
         };
 
@@ -683,12 +688,17 @@ export const Drop = () => {
                 diagnosticsRef.current.firstListDurationMs =
                     finishedAt - startedAt;
             }
-            const rootFiles = list
-                .filter((x) => !x.parentId)
-                .sort((a, b) => a.name.localeCompare(b.name));
-            setList(rootFiles);
+            const rootFiles = sortRootFilesForDisplay(
+                list.filter((x) => !x.parentId)
+            );
+            const displayRootFiles = applyRootFileChangeToList(
+                listRef.current,
+                { added: rootFiles, removed: [] }
+            );
+            updateListStats.displayListCount = displayRootFiles.length;
+            setRootList(displayRootFiles);
             const readyLargeFileSignature =
-                getReadyLargeFileSignature(rootFiles);
+                getReadyLargeFileSignature(displayRootFiles);
             if (readyLargeFileSignature) {
                 scheduleAdaptiveRefresh(
                     `ready-list:${source}`,

--- a/packages/file-share/frontend/src/root-list.ts
+++ b/packages/file-share/frontend/src/root-list.ts
@@ -1,0 +1,114 @@
+import { AbstractFile, LargeFile } from "@peerbit/please-lib";
+
+type FileChangeRoot = Pick<AbstractFile, "id" | "parentId">;
+
+type FileChangeDetail = {
+    added?: AbstractFile[];
+    removed?: FileChangeRoot[];
+};
+
+export type RootFileChange = {
+    added: AbstractFile[];
+    removed: FileChangeRoot[];
+};
+
+const isRootFile = <T extends Pick<AbstractFile, "parentId">>(
+    file: T | undefined | null
+): file is T => Boolean(file) && file.parentId == null;
+
+const hasChangedFiles = (detail: FileChangeDetail) =>
+    (detail.added?.length ?? 0) > 0 || (detail.removed?.length ?? 0) > 0;
+
+const isReadyLargeFile = (file: AbstractFile): file is LargeFile =>
+    file instanceof LargeFile && file.ready;
+
+const hasFinalLargeFileHash = (file: AbstractFile) =>
+    file instanceof LargeFile && !!file.finalHash;
+
+const shouldPreferRootCandidate = (
+    candidate: AbstractFile,
+    current: AbstractFile
+) => {
+    if (isReadyLargeFile(current) && !isReadyLargeFile(candidate)) {
+        return false;
+    }
+    if (isReadyLargeFile(candidate) && !isReadyLargeFile(current)) {
+        return true;
+    }
+    if (hasFinalLargeFileHash(current) && !hasFinalLargeFileHash(candidate)) {
+        return false;
+    }
+    return true;
+};
+
+export const sortRootFilesForDisplay = (files: AbstractFile[]) =>
+    [...files].sort((a, b) => a.name.localeCompare(b.name));
+
+export const getReadyLargeFileSignature = (files: AbstractFile[]) => {
+    const readyFiles = files
+        .filter(
+            (file): file is LargeFile =>
+                file instanceof LargeFile && file.ready && !!file.finalHash
+        )
+        .map(
+            (file) =>
+                `${file.id}:${file.size.toString()}:${file.chunkCount}:${file.finalHash}`
+        )
+        .sort();
+    return readyFiles.length > 0 ? readyFiles.join("|") : null;
+};
+
+export const getRootFileChange = (event: Event): RootFileChange => {
+    const detail = (event as CustomEvent<FileChangeDetail>).detail;
+    if (!detail) {
+        return { added: [], removed: [] };
+    }
+    return {
+        added: (detail.added ?? []).filter(isRootFile),
+        removed: (detail.removed ?? []).filter(isRootFile),
+    };
+};
+
+export const shouldRefreshRootListForFileChange = (event: Event) => {
+    const detail = (event as CustomEvent<FileChangeDetail>).detail;
+    if (!detail) {
+        return true;
+    }
+    if (!hasChangedFiles(detail)) {
+        return false;
+    }
+    return (
+        (detail.added ?? []).some(isRootFile) ||
+        (detail.removed ?? []).some(isRootFile)
+    );
+};
+
+export const applyRootFileChangeToList = (
+    current: AbstractFile[],
+    change: RootFileChange
+) => {
+    const removedIds = new Set(
+        change.removed
+            .map((file) => file.id)
+            .filter((id): id is string => typeof id === "string")
+    );
+    const byId = new Map<string, AbstractFile>();
+
+    for (const file of current) {
+        if (!removedIds.has(file.id)) {
+            byId.set(file.id, file);
+        }
+    }
+
+    for (const file of change.added) {
+        if (removedIds.has(file.id)) {
+            continue;
+        }
+        const existing = byId.get(file.id);
+        if (!existing || shouldPreferRootCandidate(file, existing)) {
+            byId.set(file.id, file);
+        }
+    }
+
+    return sortRootFilesForDisplay([...byId.values()]);
+};

--- a/packages/file-share/frontend/tests/root-list.unit.test.ts
+++ b/packages/file-share/frontend/tests/root-list.unit.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { LargeFile, TinyFile } from "@peerbit/please-lib";
+import {
+    applyRootFileChangeToList,
+    getRootFileChange,
+    shouldRefreshRootListForFileChange,
+} from "../src/root-list";
+
+const largeFile = (properties: {
+    id: string;
+    name: string;
+    ready?: boolean;
+    finalHash?: string;
+}) =>
+    new LargeFile({
+        id: properties.id,
+        name: properties.name,
+        size: 1024n,
+        chunkCount: 2,
+        ready: properties.ready ?? false,
+        finalHash: properties.finalHash,
+    });
+
+describe("root list change handling", () => {
+    it("extracts root file changes while ignoring chunk-only changes", () => {
+        const root = largeFile({ id: "root", name: "root.bin" });
+        const chunk = new TinyFile({
+            id: "chunk",
+            name: "root.bin/0",
+            parentId: "root",
+            file: new Uint8Array([1]),
+            index: 0,
+        });
+        const event = new CustomEvent("change", {
+            detail: { added: [chunk, root], removed: [] },
+        });
+
+        expect(shouldRefreshRootListForFileChange(event)).to.equal(true);
+        expect(getRootFileChange(event).added.map((file) => file.id)).to.deep.eq(
+            ["root"]
+        );
+    });
+
+    it("does not refresh for child-only change batches", () => {
+        const chunk = new TinyFile({
+            id: "chunk",
+            name: "root.bin/0",
+            parentId: "root",
+            file: new Uint8Array([1]),
+            index: 0,
+        });
+        const event = new CustomEvent("change", {
+            detail: { added: [chunk], removed: [] },
+        });
+
+        expect(shouldRefreshRootListForFileChange(event)).to.equal(false);
+        expect(getRootFileChange(event).added).to.deep.eq([]);
+    });
+
+    it("adds roots from change payloads before full list queries catch up", () => {
+        const root = largeFile({ id: "root", name: "root.bin" });
+
+        expect(
+            applyRootFileChangeToList([], { added: [root], removed: [] }).map(
+                (file) => file.name
+            )
+        ).to.deep.eq(["root.bin"]);
+    });
+
+    it("keeps ready root metadata over older pending metadata", () => {
+        const pending = largeFile({ id: "root", name: "root.bin" });
+        const ready = largeFile({
+            id: "root",
+            name: "root.bin",
+            ready: true,
+            finalHash: "final",
+        });
+
+        const withReady = applyRootFileChangeToList([pending], {
+            added: [ready],
+            removed: [],
+        });
+        expect((withReady[0] as LargeFile).ready).to.equal(true);
+
+        const stillReady = applyRootFileChangeToList(withReady, {
+            added: [pending],
+            removed: [],
+        });
+        expect((stillReady[0] as LargeFile).ready).to.equal(true);
+    });
+
+    it("removes roots from explicit root removal events", () => {
+        const root = largeFile({ id: "root", name: "root.bin" });
+        const next = applyRootFileChangeToList([root], {
+            added: [],
+            removed: [{ id: "root", parentId: undefined }],
+        });
+
+        expect(next).to.deep.eq([]);
+    });
+});

--- a/packages/file-share/frontend/vitest.config.ts
+++ b/packages/file-share/frontend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        environment: "happy-dom",
+        include: ["tests/**/*.unit.test.ts"],
+    },
+});


### PR DESCRIPTION
## Summary
- update file-share to apply root document change payloads directly to the visible list
- keep full `program.list()` reconciliation, but merge it into known root state so temporarily empty remote shard queries do not hide roots that were already delivered by change events
- add focused unit coverage for root event extraction, pending/ready replacement, and explicit removal handling

## Verification
- `pnpm --filter file-share test:unit`
- `pnpm --filter file-share build`
- `pnpm --filter @peerbit/please-lib test`
- `PW_BENCH=1 PW_BENCH_SCENARIO=local PW_FILE_MB=10 PW_UPLOAD_TIMEOUT_MS=600000 PW_DOWNLOAD_TIMEOUT_MS=600000 PW_RESULT_FILE=/tmp/file-share-transfer-10mb-root-list.json pnpm --filter file-share test:e2e -- tests/transfer.bench.e2e.spec.ts`

Local 10 MiB benchmark result: discovery `1.832s`, upload `388ms`, download `1013ms`; reader diagnostics reported `rootChangeDirectAddCount: 1`.
