### PR TITLE
Gate pending replicated file downloads

### DIFF
--- a/packages/file-share/frontend/src/File.tsx
+++ b/packages/file-share/frontend/src/File.tsx
@@ -8,6 +8,17 @@ import { DocumentsChange } from "@peerbit/document";
 const formatFileSize = (size: number | bigint) =>
     `${Math.round(Number(size) / 1000)} kb`;
 
+export const shouldDisableFileDownload = (properties: {
+    progress: number | null;
+    largeFileReady?: boolean;
+    replicated: boolean;
+    replicatedChunksRatio: number;
+}) =>
+    properties.progress != null ||
+    (properties.largeFileReady === false &&
+        properties.replicated &&
+        properties.replicatedChunksRatio < 100);
+
 export const File = (properties: {
     files: Files;
     isHost: boolean;
@@ -22,7 +33,12 @@ export const File = (properties: {
     const largeFile =
         properties.file instanceof LargeFile ? properties.file : undefined;
     const chunkCount = largeFile?.chunkCount ?? 0;
-    const downloadDisabled = progress != null;
+    const downloadDisabled = shouldDisableFileDownload({
+        progress,
+        largeFileReady: largeFile?.ready,
+        replicated: properties.replicated,
+        replicatedChunksRatio,
+    });
 
     useEffect(() => {
         if (!properties.files) {

--- a/packages/file-share/frontend/tests/file.unit.test.ts
+++ b/packages/file-share/frontend/tests/file.unit.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { shouldDisableFileDownload } from "../src/File";
+
+describe("file download controls", () => {
+    it("disables while a download is in progress", () => {
+        expect(
+            shouldDisableFileDownload({
+                progress: 0,
+                replicated: false,
+                replicatedChunksRatio: 0,
+                largeFileReady: true,
+            })
+        ).to.equal(true);
+    });
+
+    it("waits for replicated pending large files to materialize locally", () => {
+        expect(
+            shouldDisableFileDownload({
+                progress: null,
+                replicated: true,
+                replicatedChunksRatio: 99,
+                largeFileReady: false,
+            })
+        ).to.equal(true);
+
+        expect(
+            shouldDisableFileDownload({
+                progress: null,
+                replicated: true,
+                replicatedChunksRatio: 100,
+                largeFileReady: false,
+            })
+        ).to.equal(false);
+    });
+
+    it("keeps non-replicated pending large files downloadable for remote reads", () => {
+        expect(
+            shouldDisableFileDownload({
+                progress: null,
+                replicated: false,
+                replicatedChunksRatio: 0,
+                largeFileReady: false,
+            })
+        ).to.equal(false);
+    });
+
+    it("enables ready large files even before local chunk badges update", () => {
+        expect(
+            shouldDisableFileDownload({
+                progress: null,
+                replicated: true,
+                replicatedChunksRatio: 0,
+                largeFileReady: true,
+            })
+        ).to.equal(false);
+    });
+});


### PR DESCRIPTION
## Summary
- disable download for replicated pending large files until local chunk materialization reaches 100%
- keep observer/non-replicated pending files downloadable so remote reads still work
- add unit coverage for the download gating rules

## Verification
- pnpm --filter file-share test:unit
- pnpm --filter file-share build
- PW_BENCH=1 PW_BENCH_SCENARIO=local PW_FILE_MB=50 PW_UPLOAD_TIMEOUT_MS=900000 PW_DOWNLOAD_TIMEOUT_MS=900000 PW_RESULT_FILE=/tmp/file-share-transfer-50mb-download-gate.json pnpm --filter file-share test:e2e -- tests/transfer.bench.e2e.spec.ts
