### PR TITLE
Wait for local chunks before replicator downloads

### DIFF
--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -1278,6 +1278,9 @@ export const Drop = () => {
                                                         role === "replicator" &&
                                                         replicationSet.has(x.id)
                                                     }
+                                                    waitForLocalChunksBeforeDownload={
+                                                        role === "replicator"
+                                                    }
                                                 />
                                             </li>
                                         );

--- a/packages/file-share/frontend/src/File.tsx
+++ b/packages/file-share/frontend/src/File.tsx
@@ -11,18 +11,19 @@ const formatFileSize = (size: number | bigint) =>
 export const shouldDisableFileDownload = (properties: {
     progress: number | null;
     largeFileReady?: boolean;
-    replicated: boolean;
+    waitForLocalChunksBeforeDownload: boolean;
     replicatedChunksRatio: number;
 }) =>
     properties.progress != null ||
     (properties.largeFileReady === false &&
-        properties.replicated &&
+        properties.waitForLocalChunksBeforeDownload &&
         properties.replicatedChunksRatio < 100);
 
 export const File = (properties: {
     files: Files;
     isHost: boolean;
     replicated: boolean;
+    waitForLocalChunksBeforeDownload: boolean;
     file: AbstractFile;
     delete: () => void;
     download: (progress: (progress: number | null) => void) => Promise<void>;
@@ -36,7 +37,8 @@ export const File = (properties: {
     const downloadDisabled = shouldDisableFileDownload({
         progress,
         largeFileReady: largeFile?.ready,
-        replicated: properties.replicated,
+        waitForLocalChunksBeforeDownload:
+            properties.waitForLocalChunksBeforeDownload,
         replicatedChunksRatio,
     });
 

--- a/packages/file-share/frontend/tests/file.unit.test.ts
+++ b/packages/file-share/frontend/tests/file.unit.test.ts
@@ -6,7 +6,7 @@ describe("file download controls", () => {
         expect(
             shouldDisableFileDownload({
                 progress: 0,
-                replicated: false,
+                waitForLocalChunksBeforeDownload: false,
                 replicatedChunksRatio: 0,
                 largeFileReady: true,
             })
@@ -17,7 +17,7 @@ describe("file download controls", () => {
         expect(
             shouldDisableFileDownload({
                 progress: null,
-                replicated: true,
+                waitForLocalChunksBeforeDownload: true,
                 replicatedChunksRatio: 99,
                 largeFileReady: false,
             })
@@ -26,18 +26,18 @@ describe("file download controls", () => {
         expect(
             shouldDisableFileDownload({
                 progress: null,
-                replicated: true,
+                waitForLocalChunksBeforeDownload: true,
                 replicatedChunksRatio: 100,
                 largeFileReady: false,
             })
         ).to.equal(false);
     });
 
-    it("keeps non-replicated pending large files downloadable for remote reads", () => {
+    it("keeps observer pending large files downloadable for remote reads", () => {
         expect(
             shouldDisableFileDownload({
                 progress: null,
-                replicated: false,
+                waitForLocalChunksBeforeDownload: false,
                 replicatedChunksRatio: 0,
                 largeFileReady: false,
             })
@@ -48,7 +48,7 @@ describe("file download controls", () => {
         expect(
             shouldDisableFileDownload({
                 progress: null,
-                replicated: true,
+                waitForLocalChunksBeforeDownload: true,
                 replicatedChunksRatio: 0,
                 largeFileReady: true,
             })


### PR DESCRIPTION
## Summary
- gate pending large-file downloads using the actual reader role instead of the seedling badge state
- adaptive/replicator readers now wait until local chunk materialization reaches 100% before enabling download
- observer/non-replicator readers still keep remote-read behavior for pending files

## Verification
- pnpm --filter file-share test:unit
- pnpm --filter file-share build
- PW_BENCH=1 PW_BENCH_SCENARIO=local PW_FILE_MB=50 PW_UPLOAD_TIMEOUT_MS=900000 PW_DOWNLOAD_TIMEOUT_MS=900000 PW_RESULT_FILE=/tmp/file-share-transfer-50mb-role-gate.json pnpm --filter file-share test:e2e -- tests/transfer.bench.e2e.spec.ts
