### PR TITLE
Stream pending adaptive file reads

### DIFF
--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -1278,9 +1278,6 @@ export const Drop = () => {
                                                         role === "replicator" &&
                                                         replicationSet.has(x.id)
                                                     }
-                                                    waitForLocalChunksBeforeDownload={
-                                                        role === "replicator"
-                                                    }
                                                 />
                                             </li>
                                         );

--- a/packages/file-share/frontend/src/File.tsx
+++ b/packages/file-share/frontend/src/File.tsx
@@ -10,20 +10,12 @@ const formatFileSize = (size: number | bigint) =>
 
 export const shouldDisableFileDownload = (properties: {
     progress: number | null;
-    largeFileReady?: boolean;
-    waitForLocalChunksBeforeDownload: boolean;
-    replicatedChunksRatio: number;
-}) =>
-    properties.progress != null ||
-    (properties.largeFileReady === false &&
-        properties.waitForLocalChunksBeforeDownload &&
-        properties.replicatedChunksRatio < 100);
+}) => properties.progress != null;
 
 export const File = (properties: {
     files: Files;
     isHost: boolean;
     replicated: boolean;
-    waitForLocalChunksBeforeDownload: boolean;
     file: AbstractFile;
     delete: () => void;
     download: (progress: (progress: number | null) => void) => Promise<void>;
@@ -36,10 +28,6 @@ export const File = (properties: {
     const chunkCount = largeFile?.chunkCount ?? 0;
     const downloadDisabled = shouldDisableFileDownload({
         progress,
-        largeFileReady: largeFile?.ready,
-        waitForLocalChunksBeforeDownload:
-            properties.waitForLocalChunksBeforeDownload,
-        replicatedChunksRatio,
     });
 
     useEffect(() => {

--- a/packages/file-share/frontend/tests/file.unit.test.ts
+++ b/packages/file-share/frontend/tests/file.unit.test.ts
@@ -6,51 +6,14 @@ describe("file download controls", () => {
         expect(
             shouldDisableFileDownload({
                 progress: 0,
-                waitForLocalChunksBeforeDownload: false,
-                replicatedChunksRatio: 0,
-                largeFileReady: true,
             })
         ).to.equal(true);
     });
 
-    it("waits for replicated pending large files to materialize locally", () => {
+    it("does not block pending large files before the read starts", () => {
         expect(
             shouldDisableFileDownload({
                 progress: null,
-                waitForLocalChunksBeforeDownload: true,
-                replicatedChunksRatio: 99,
-                largeFileReady: false,
-            })
-        ).to.equal(true);
-
-        expect(
-            shouldDisableFileDownload({
-                progress: null,
-                waitForLocalChunksBeforeDownload: true,
-                replicatedChunksRatio: 100,
-                largeFileReady: false,
-            })
-        ).to.equal(false);
-    });
-
-    it("keeps observer pending large files downloadable for remote reads", () => {
-        expect(
-            shouldDisableFileDownload({
-                progress: null,
-                waitForLocalChunksBeforeDownload: false,
-                replicatedChunksRatio: 0,
-                largeFileReady: false,
-            })
-        ).to.equal(false);
-    });
-
-    it("enables ready large files even before local chunk badges update", () => {
-        expect(
-            shouldDisableFileDownload({
-                progress: null,
-                waitForLocalChunksBeforeDownload: true,
-                replicatedChunksRatio: 0,
-                largeFileReady: true,
             })
         ).to.equal(false);
     });

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -1262,6 +1262,95 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), expected)).to.be.true;
         });
 
+        it("streams pending manifests with partial local chunks while ready search is still pending", async () => {
+            const filestore = await peer.open(new Files());
+            const fileName = "pending manifest with partial local chunks";
+            const fileId = "pending-ready-search-pending";
+            const chunkCount = 100;
+            const expected = new Uint8Array(chunkCount);
+            for (let index = 0; index < chunkCount; index++) {
+                expected[index] = index % 256;
+                await filestore.files.put(
+                    new TinyFile({
+                        id: `${fileId}:${index}`,
+                        name: `${fileName}/${index}`,
+                        file: new Uint8Array([expected[index]]),
+                        parentId: fileId,
+                        index,
+                    })
+                );
+            }
+            const pendingFile = new LargeFile({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount,
+                ready: false,
+            });
+            const originalSearch = filestore.files.index.search.bind(
+                filestore.files.index
+            );
+            const originalCountLocalChunks =
+                filestore.countLocalChunks.bind(filestore);
+            const originalGetReadPeerHints =
+                filestore.getReadPeerHints.bind(filestore);
+            let countCalls = 0;
+            let remoteReadySearches = 0;
+
+            (filestore as any).getReadPeerHints = async () => ["writer-peer"];
+            (filestore as any).countLocalChunks = async (parent: LargeFile) => {
+                countCalls++;
+                if (countCalls === 1) {
+                    return Math.ceil(parent.chunkCount / 2);
+                }
+                return originalCountLocalChunks(parent);
+            };
+            (filestore.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasRootId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "id" &&
+                        getQueryValue(query) === fileId
+                );
+                if (hasRootId) {
+                    if ((options as any)?.remote) {
+                        remoteReadySearches++;
+                    }
+                    return [pendingFile];
+                }
+                return originalSearch(request as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await pendingFile.writeFile(
+                    filestore,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestore.files.index as any).search = originalSearch;
+                (filestore as any).countLocalChunks = originalCountLocalChunks;
+                (filestore as any).getReadPeerHints = originalGetReadPeerHints;
+            }
+
+            expect(remoteReadySearches).to.be.greaterThan(0);
+            expect(
+                filestore.lastReadDiagnostics?.waitUntilReadyResolvedBy
+            ).to.eq("pending-manifest");
+            expect(equals(concat(streamedChunks), expected)).to.be.true;
+        });
+
         it("uses non-replicating parent search when adaptive exact routes miss", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -303,7 +303,6 @@ const LARGE_FILE_TARGET_CHUNK_COUNT = 256;
 const CHUNK_SIZE_GRANULARITY = 64 * 1024;
 const MAX_LARGE_FILE_SEGMENT_SIZE = 512 * 1024;
 const LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS = 5 * 60 * 1000;
-const LARGE_FILE_PENDING_STREAM_MIN_CHUNKS = LARGE_FILE_TARGET_CHUNK_COUNT / 2;
 const LARGE_FILE_PERSISTED_READ_AHEAD = 4;
 const LARGE_FILE_OBSERVER_READ_AHEAD = 2;
 const LARGE_FILE_OBSERVER_PREFETCH_TIMEOUT_MS = 5_000;
@@ -1202,7 +1201,6 @@ export class LargeFile extends AbstractFile {
                 return localReady;
             }
             let remoteMatches: AbstractFile[] = [];
-            let remoteSearchFailed = false;
             try {
                 remoteMatches = await files.files.index.search(request, {
                     local: false,
@@ -1215,7 +1213,6 @@ export class LargeFile extends AbstractFile {
                     },
                 } as any);
             } catch (error) {
-                remoteSearchFailed = true;
                 if (debug) {
                     (debug.readyRemoteSearchErrors ||= []).push(
                         getErrorMessage(error)
@@ -1295,10 +1292,7 @@ export class LargeFile extends AbstractFile {
                 return countCandidate;
             }
             if (
-                remoteSearchFailed &&
                 files.persistChunkReads &&
-                readinessCandidate.chunkCount >=
-                    LARGE_FILE_PENDING_STREAM_MIN_CHUNKS &&
                 localChunkCount >=
                     Math.max(1, Math.ceil(readinessCandidate.chunkCount / 2))
             ) {


### PR DESCRIPTION
## Summary
- allow adaptive persisted reads to stream a pending large-file manifest once at least half of its chunks are local
- remove the conservative UI gate that waited for 100% local chunks before enabling download
- add a 100-chunk regression test for pending manifests where ready lookup still returns pending metadata

## Verification
- pnpm --filter file-share test:unit
- pnpm --filter @peerbit/please-lib test -- src/__tests__/index.integration.test.ts -t "pending manifests"
- pnpm --filter @peerbit/please-lib build
- pnpm --filter file-share build
- PW_BENCH=1 PW_BENCH_SCENARIO=local PW_FILE_MB=50 PW_UPLOAD_TIMEOUT_MS=900000 PW_DOWNLOAD_TIMEOUT_MS=900000 PW_RESULT_FILE=/tmp/file-share-transfer-50mb-pending-stream.json pnpm --filter file-share test:e2e -- tests/transfer.bench.e2e.spec.ts
