### PR TITLE
Prioritize recent file-share adaptive sync heads

### DIFF
--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -174,6 +174,18 @@ describe("index", () => {
             expect(chunkReplicas).to.eq(rootReplicas);
         });
 
+        it("prioritizes newer heads during adaptive sync", async () => {
+            const filestore = await peer.open(new Files());
+            const syncOptions =
+                (filestore.files.log as any).syncronizer?.properties?.sync ??
+                (filestore.files.log as any).syncronizer?.syncOptions;
+
+            expect(syncOptions?.maxSimpleEntries).to.eq(128);
+            expect(syncOptions?.priority?.({ wallTime: 20n })).to.be.greaterThan(
+                syncOptions?.priority?.({ wallTime: 10n })
+            );
+        });
+
         it("keeps ready root manifests during adaptive pruning", async () => {
             const writer = await peer.open(new Files());
             const reader = await peer2.open<Files>(writer.address);

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -312,6 +312,12 @@ const LARGE_FILE_REMOTE_CHUNK_TIMEOUT_OVERHEAD_MS = 5_000;
 const LARGE_FILE_REMOTE_CHUNK_TIMEOUT_SCALE_MIN_BYTES = 1 * 1024 * 1024;
 const LARGE_FILE_REMOTE_CHUNK_MIN_BYTES_PER_SECOND = 128 * 1024;
 const TINY_FILE_SIZE_LIMIT_BIGINT = BigInt(TINY_FILE_SIZE_LIMIT);
+const ADAPTIVE_SYNC_SIMPLE_ENTRY_BUDGET = 128;
+
+const getAdaptiveSyncPriority = (entry: { wallTime?: bigint | number }) => {
+    const wallTime = Number(entry.wallTime);
+    return Number.isFinite(wallTime) ? wallTime : 0;
+};
 
 const roundUpTo = (value: number, multiple: number) =>
     Math.ceil(value / multiple) * multiple;
@@ -2439,6 +2445,10 @@ export class Files extends Program<Args> {
             // TODO add ACL
             replicate: args?.replicate,
             replicas: { min: 3 },
+            sync: {
+                priority: getAdaptiveSyncPriority,
+                maxSimpleEntries: ADAPTIVE_SYNC_SIMPLE_ENTRY_BUDGET,
+            },
             keep: (entry) => this.shouldKeepFileEntry(entry),
             canPerform: async (operation) => {
                 if (!this.trustGraph) {


### PR DESCRIPTION
## Summary
- Configure file-share shared-log sync to prioritize newer heads during adaptive sync
- Pre-sync a bounded set of high-priority entries before bulk rateless IBLT repair
- Add a regression check that the adaptive sync priority policy is installed

## Verification
- pnpm --filter @peerbit/please-lib test -- src/__tests__/index.integration.test.ts -t "prioritizes newer heads" (ran integration suite: 43 passed)
- pnpm --filter @peerbit/please-lib build
- pnpm --filter file-share test:unit
- pnpm --filter file-share build
- PW_BENCH=1 PW_FILE_MB=50 PW_RESULT_FILE=/tmp/file-share-transfer-50mb-newest-sync.json pnpm --filter file-share test:e2e -- tests/transfer.bench.e2e.spec.ts

## Local 50 MiB bench
- status: passed
- upload: 1.956s / 214.43 Mbps
- discovery: 0.216s
- download: 6.898s / 60.80 Mbps
- listed root at 14 local chunks
- read probe resolved after complete chunks