### PR TITLE
fix(file-share): include peer hints in share URLs

### DIFF
--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -23,6 +23,7 @@ import {
     shouldRefreshRootListForFileChange,
     sortRootFilesForDisplay,
 } from "./root-list";
+import { getPeerDialAddresses, withSharePeerHints } from "./share-url";
 
 const saveRoleLocalStorage = (files: Files, role: string) => {
     localStorage.setItem(files.address + "-role", role); // Save role in localstorage for next time
@@ -82,6 +83,8 @@ type ListingDiagnostics = {
     skippedChildFileChangeEventCount: number;
     activeTransferCount: number;
     skippedActiveTransferRefreshCount: number;
+    sharePeerAddressCount: number;
+    lastShareUrlWithPeerHintsAt: number | null;
 };
 
 type SaveFilePickerWindow = Window & {
@@ -149,6 +152,8 @@ const createListingDiagnostics = (
     skippedChildFileChangeEventCount: 0,
     activeTransferCount: 0,
     skippedActiveTransferRefreshCount: 0,
+    sharePeerAddressCount: 0,
+    lastShareUrlWithPeerHintsAt: null,
 });
 
 export const useDebouncedEffect = (effect, deps, delay) => {
@@ -400,11 +405,7 @@ export const Drop = () => {
                     (connection) =>
                         connection?.remotePeer?.toString?.() ?? "unknown"
                 );
-                const peerAddresses = (
-                    peer?.getMultiaddrs?.() ??
-                    (peer as any)?.libp2p?.getMultiaddrs?.() ??
-                    []
-                ).map((address) => address?.toString?.() ?? String(address));
+                const peerAddresses = getPeerDialAddresses(peer);
                 const listedFiles = await Promise.all(
                     list.map(async (file) => ({
                         id: file.id,
@@ -428,6 +429,7 @@ export const Drop = () => {
                 return {
                     programAddress: files.program?.address ?? null,
                     programClosed: files.program?.closed ?? null,
+                    shareUrl: window.location.href,
                     persistChunkReads: files.program?.persistChunkReads ?? null,
                     runtimeOpenProfileSamples:
                         (
@@ -477,6 +479,50 @@ export const Drop = () => {
         peer?.identity?.publicKey,
         replicationSet.size,
     ]);
+
+    useEffect(() => {
+        if (!isHost || !shareAddress || !peer || left) {
+            return;
+        }
+
+        let stopped = false;
+        let interval: ReturnType<typeof setInterval> | undefined;
+        let stopTimer: ReturnType<typeof setTimeout> | undefined;
+        const syncShareUrlPeerHints = () => {
+            if (stopped) {
+                return;
+            }
+            const peerAddresses = getPeerDialAddresses(peer);
+            diagnosticsRef.current.sharePeerAddressCount = peerAddresses.length;
+            const nextHref = withSharePeerHints(
+                window.location.href,
+                peerAddresses,
+                { skipWhenBootstrapPresent: true }
+            );
+            if (nextHref !== window.location.href) {
+                window.history.replaceState(window.history.state, "", nextHref);
+                diagnosticsRef.current.lastShareUrlWithPeerHintsAt = Date.now();
+            }
+        };
+
+        syncShareUrlPeerHints();
+        interval = setInterval(syncShareUrlPeerHints, 2000);
+        stopTimer = setTimeout(() => {
+            if (interval) {
+                clearInterval(interval);
+            }
+        }, 30_000);
+
+        return () => {
+            stopped = true;
+            if (interval) {
+                clearInterval(interval);
+            }
+            if (stopTimer) {
+                clearTimeout(stopTimer);
+            }
+        };
+    }, [isHost, left, peer, shareAddress]);
 
     useDebouncedEffect(
         () => {

--- a/packages/file-share/frontend/src/share-url.ts
+++ b/packages/file-share/frontend/src/share-url.ts
@@ -1,0 +1,55 @@
+type PeerLike = {
+    getMultiaddrs?: () => unknown[];
+    libp2p?: {
+        getMultiaddrs?: () => unknown[];
+    };
+};
+
+export const getPeerDialAddresses = (peer: unknown): string[] => {
+    const peerLike = peer as PeerLike | undefined;
+    const addresses =
+        peerLike?.getMultiaddrs?.() ??
+        peerLike?.libp2p?.getMultiaddrs?.() ??
+        [];
+    const unique = new Set<string>();
+    for (const address of addresses) {
+        const value = address?.toString?.() ?? String(address ?? "");
+        const trimmed = value.trim();
+        if (trimmed) {
+            unique.add(trimmed);
+        }
+    }
+    return [...unique];
+};
+
+const getHashSearchParams = (url: URL) => {
+    const queryIndex = url.hash.indexOf("?");
+    return queryIndex === -1
+        ? new URLSearchParams()
+        : new URLSearchParams(url.hash.slice(queryIndex + 1));
+};
+
+const hasBootstrapOverride = (url: URL) =>
+    url.searchParams.has("bootstrap") ||
+    getHashSearchParams(url).has("bootstrap");
+
+export const withSharePeerHints = (
+    href: string,
+    peerAddresses: string[],
+    options: { skipWhenBootstrapPresent?: boolean } = {}
+) => {
+    const unique = [
+        ...new Set(peerAddresses.map((address) => address.trim())),
+    ].filter(Boolean);
+    if (unique.length === 0) {
+        return href;
+    }
+
+    const url = new URL(href);
+    if (options.skipWhenBootstrapPresent && hasBootstrapOverride(url)) {
+        return href;
+    }
+
+    url.searchParams.set("peer", unique.join(","));
+    return url.toString();
+};

--- a/packages/file-share/frontend/tests/share-url.unit.test.ts
+++ b/packages/file-share/frontend/tests/share-url.unit.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { getPeerDialAddresses, withSharePeerHints } from "../src/share-url";
+
+describe("share URL peer hints", () => {
+    it("adds normalized peer addresses before the hash route", () => {
+        const href = withSharePeerHints(
+            "https://files.dao.xyz/#/s/space-address",
+            [
+                "/dns4/bootstrap/tcp/4003/wss/p2p/a",
+                " /dns4/bootstrap/tcp/4003/wss/p2p/a ",
+                "/dns4/bootstrap/tcp/4002/p2p/b",
+            ]
+        );
+
+        const url = new URL(href);
+        expect(url.hash).toBe("#/s/space-address");
+        expect(url.searchParams.get("peer")).toBe(
+            "/dns4/bootstrap/tcp/4003/wss/p2p/a,/dns4/bootstrap/tcp/4002/p2p/b"
+        );
+    });
+
+    it("does not replace explicit bootstrap URLs", () => {
+        const href =
+            "https://files.dao.xyz/?bootstrap=/dns4/local#/s/space-address";
+
+        expect(
+            withSharePeerHints(href, ["/dns4/bootstrap/tcp/4003/wss/p2p/a"], {
+                skipWhenBootstrapPresent: true,
+            })
+        ).toBe(href);
+    });
+
+    it("extracts peer multiaddrs from peerbit-like clients", () => {
+        expect(
+            getPeerDialAddresses({
+                getMultiaddrs: () => [
+                    { toString: () => "/dns4/a/tcp/4003/wss/p2p/one" },
+                    { toString: () => "/dns4/a/tcp/4003/wss/p2p/one" },
+                    "/dns4/b/tcp/4002/p2p/two",
+                ],
+            })
+        ).toEqual(["/dns4/a/tcp/4003/wss/p2p/one", "/dns4/b/tcp/4002/p2p/two"]);
+    });
+});

--- a/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
@@ -19,9 +19,7 @@ const READER_ROLE = process.env.PW_READER_ROLE || "adaptive";
 const ADAPTIVE_REPLICATION_ROLE = { limits: { cpu: { max: 1 } } };
 const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "1024");
 const RESULT_FILE = process.env.PW_RESULT_FILE;
-const UPLOAD_TIMEOUT_MS = Number(
-    process.env.PW_UPLOAD_TIMEOUT_MS || "1800000"
-);
+const UPLOAD_TIMEOUT_MS = Number(process.env.PW_UPLOAD_TIMEOUT_MS || "1800000");
 const DOWNLOAD_TIMEOUT_MS = Number(
     process.env.PW_DOWNLOAD_TIMEOUT_MS || "1800000"
 );
@@ -77,7 +75,9 @@ const getDiagnostics = async (page: Page) => {
     return await page.evaluate(async () => {
         const hooks = (window as any).__peerbitFileShareTestHooks;
         if (!hooks?.getDiagnostics) {
-            throw new Error("Missing __peerbitFileShareTestHooks.getDiagnostics");
+            throw new Error(
+                "Missing __peerbitFileShareTestHooks.getDiagnostics"
+            );
         }
         return await hooks.getDiagnostics();
     });
@@ -108,6 +108,14 @@ const enableOpenProfiler = async (page: Page) => {
             writable: true,
         });
     });
+};
+
+const waitForShareUrlPeerHints = async (page: Page, timeout = 180_000) => {
+    await page.waitForFunction(
+        () => new URL(window.location.href).searchParams.has("peer"),
+        undefined,
+        { timeout }
+    );
 };
 
 const toMiBPerSecond = (bytes: number, durationMs: number) =>
@@ -175,7 +183,7 @@ test.describe("file-share transfer benchmark", () => {
                 writer,
                 `file-share-transfer-bench-${Date.now()}`
             );
-            const shareUrl = new URL(entryUrl);
+            let shareUrl = new URL(entryUrl);
             shareUrl.hash = `/s/${address}`;
             logStage("seed-reader-role");
             await seedReplicationRole(
@@ -186,9 +194,18 @@ test.describe("file-share transfer benchmark", () => {
 
             logStage("open-reader", { shareUrl: shareUrl.toString() });
             logStage("open-writer-page");
-            await writer.goto(shareUrl.toString(), { waitUntil: "domcontentloaded" });
+            await writer.goto(shareUrl.toString(), {
+                waitUntil: "domcontentloaded",
+            });
             logStage("writer-page-ready");
-            await reader.goto(shareUrl.toString(), { waitUntil: "domcontentloaded" });
+            if (!usesLocalBootstrap) {
+                logStage("wait-for-share-peer-hints");
+                await waitForShareUrlPeerHints(writer);
+            }
+            shareUrl = new URL(writer.url());
+            await reader.goto(shareUrl.toString(), {
+                waitUntil: "domcontentloaded",
+            });
             logStage("reader-page-ready");
 
             logStage("wait-for-input");
@@ -199,7 +216,9 @@ test.describe("file-share transfer benchmark", () => {
 
             logStage("upload");
             const uploadStartedAt = Date.now();
-            await writer.locator("#imgupload").setInputFiles(preparedFile.filePath);
+            await writer
+                .locator("#imgupload")
+                .setInputFiles(preparedFile.filePath);
             logStage("wait-for-writer-listing");
             await waitForFileListed(writer, fileName, UPLOAD_TIMEOUT_MS);
             logStage("wait-for-upload-complete");
@@ -297,13 +316,17 @@ test.describe("file-share transfer benchmark", () => {
                             ? error.message
                             : String(error),
                     stack:
-                        typeof error?.stack === "string" ? error.stack : undefined,
+                        typeof error?.stack === "string"
+                            ? error.stack
+                            : undefined,
                 },
                 writerDiagnostics: failureWriterDiagnostics,
                 readerDiagnostics: failureReaderDiagnostics,
             };
             await persistResult(result);
-            console.error(`FILE_SHARE_TRANSFER_BENCH ${JSON.stringify(result)}`);
+            console.error(
+                `FILE_SHARE_TRANSFER_BENCH ${JSON.stringify(result)}`
+            );
             throw error;
         } finally {
             await writerContext.close().catch(() => {});

--- a/packages/file-share/frontend/tests/two-runner.bench.mjs
+++ b/packages/file-share/frontend/tests/two-runner.bench.mjs
@@ -107,6 +107,14 @@ const enableOpenProfiler = async (page) => {
     });
 };
 
+const waitForShareUrlPeerHints = async (page, timeout = 180_000) => {
+    await page.waitForFunction(
+        () => new URL(window.location.href).searchParams.has("peer"),
+        undefined,
+        { timeout }
+    );
+};
+
 const getDiagnostics = async (page) => {
     return await page.evaluate(async () => {
         const hooks = window.__peerbitFileShareTestHooks;
@@ -564,10 +572,12 @@ const runWriter = async (coordinator) => {
             page,
             `file-share-two-runner-${Date.now()}`
         );
-        const shareUrl = new URL(entryUrl);
+        let shareUrl = new URL(entryUrl);
         shareUrl.hash = `/s/${address}`;
 
         await page.goto(shareUrl.toString(), { waitUntil: "domcontentloaded" });
+        await waitForShareUrlPeerHints(page);
+        shareUrl = new URL(page.url());
         await page.locator("#imgupload").waitFor({
             state: "attached",
             timeout: 60_000,


### PR DESCRIPTION
## Summary
- keep trusted host share URLs populated with direct Peerbit peer hints
- reuse the app-provided share URL in file-share transfer benches instead of reconstructing a hintless URL
- add unit coverage for peer-hinted share URL construction

## Verification
- pnpm --filter file-share test:unit
- pnpm --filter file-share build
- pnpm --filter file-share test:e2e -- download.local.e2e.spec.ts
- PW_BENCH=1 PW_BENCH_SCENARIO=local PW_READER_ROLE=adaptive PW_FILE_MB=10 PW_RESULT_FILE=/tmp/file-share-local-10-share-url.json pnpm --filter file-share test:e2e -- transfer.bench.e2e.spec.ts