### PR TITLE
perf(file-share): increase persisted download read-ahead

### DIFF
--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -560,7 +560,8 @@ describe("index", () => {
             expect(directChunkGets).to.be.greaterThan(1);
             expect(maxInflightChunkGets).to.be.greaterThan(1);
             const readAhead = filestoreReader.lastReadDiagnostics?.readAhead;
-            expect(readAhead).to.eq(4);
+            expect(readAhead).to.be.greaterThan(4);
+            expect(readAhead).to.be.lessThanOrEqual(file!.chunkCount);
             expect(
                 filestoreReader.lastReadDiagnostics?.chunkAttemptTimeoutMs
             ).to.eq(5_000);

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -303,7 +303,7 @@ const LARGE_FILE_TARGET_CHUNK_COUNT = 256;
 const CHUNK_SIZE_GRANULARITY = 64 * 1024;
 const MAX_LARGE_FILE_SEGMENT_SIZE = 512 * 1024;
 const LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS = 5 * 60 * 1000;
-const LARGE_FILE_PERSISTED_READ_AHEAD = 4;
+const LARGE_FILE_PERSISTED_READ_AHEAD = 32;
 const LARGE_FILE_OBSERVER_READ_AHEAD = 2;
 const LARGE_FILE_OBSERVER_PREFETCH_TIMEOUT_MS = 5_000;
 const LARGE_FILE_MIN_CHUNK_ATTEMPT_TIMEOUT_MS = 5_000;
@@ -1414,9 +1414,10 @@ export class LargeFile extends AbstractFile {
             return pending;
         };
 
-        const readAhead = files.persistChunkReads
+        const configuredReadAhead = files.persistChunkReads
             ? LARGE_FILE_PERSISTED_READ_AHEAD
             : LARGE_FILE_OBSERVER_READ_AHEAD;
+        const readAhead = Math.min(resolvedFile.chunkCount, configuredReadAhead);
         debug.readAhead = readAhead;
 
         for (


### PR DESCRIPTION
## Summary
- increase persisted large-file download read-ahead from 4 chunks to a bounded 32 chunks
- record the effective read-ahead window so small files report the actual chunk count cap
- update the persisted read pipeline regression test to assert bounded concurrency instead of a hard-coded window of 4

## Verification
- pnpm --filter @peerbit/please-lib test -- --runInBand src/__tests__/index.integration.test.ts -t "pipelines persisted chunk reads" (ran package suite; 43 tests passed)
- pnpm --filter @peerbit/please-lib build
- pnpm --filter file-share build
- PW_BENCH=1 PW_BENCH_SCENARIO=local PW_READER_ROLE=adaptive PW_FILE_MB=10 PW_RESULT_FILE=/tmp/file-share-local-10-read-ahead.json pnpm --filter file-share test:e2e -- transfer.bench.e2e.spec.ts