### PR TITLE
fix(file-share): allow large pending downloads to complete

### DIFF
--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -110,6 +110,19 @@ const getStreamingDownloadThresholdBytes = () => {
 const getFileSizeBigInt = (file: AbstractFile) =>
     typeof file.size === "bigint" ? file.size : BigInt(file.size);
 
+const DEFAULT_FILE_DOWNLOAD_TIMEOUT_MS = 10_000;
+const LARGE_FILE_DOWNLOAD_MIN_TIMEOUT_MS = 5 * 60_000;
+const LARGE_FILE_DOWNLOAD_TIMEOUT_PER_MB_MS = 1_000;
+
+const getDownloadTimeout = (file: AbstractFile) =>
+    file instanceof LargeFile
+        ? Math.max(
+              LARGE_FILE_DOWNLOAD_MIN_TIMEOUT_MS,
+              Math.ceil(Number(file.size) / 1e6) *
+                  LARGE_FILE_DOWNLOAD_TIMEOUT_PER_MB_MS
+          )
+        : DEFAULT_FILE_DOWNLOAD_TIMEOUT_MS;
+
 const createListingDiagnostics = (
     shareAddress: string | undefined,
     storedRole: ReplicationOptions | undefined
@@ -803,10 +816,7 @@ export const Drop = () => {
         file: AbstractFile,
         progress: (progress: number | null) => void
     ) => {
-        const timeout =
-            file instanceof LargeFile
-                ? Math.max(60_000, Math.ceil(Number(file.size) / 1e6) * 1_000)
-                : 10_000;
+        const timeout = getDownloadTimeout(file);
         startActiveTransfer();
         try {
             if (file instanceof LargeFile) {


### PR DESCRIPTION
Follows up dao-xyz/peerbit-examples#126. With pending manifests now gated on either a ready manifest or the complete local chunk set, the previous 60s minimum UI timeout is too short for 50 MiB prod adaptive transfers. This aligns large-file download timeout with the library's 5-minute default floor while keeping the per-MB scaling for larger files.\n\nThis does not claim to fix the remaining ready-probe decode warning; that is still separate.\n\nLocal verification:\n- pnpm --filter file-share test:unit\n- pnpm --filter file-share build