### PR TITLE
Fix file-share ready manifest variant reads

### DIFF
--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -1,7 +1,7 @@
 import { usePeer, useProgram } from "@peerbit/react";
 import { useNavigate, useParams } from "react-router";
 import { useEffect, useReducer, useRef, useState } from "react";
-import { Files, AbstractFile, LargeFile } from "@peerbit/please-lib";
+import { Files, AbstractFile, isLargeFileLike } from "@peerbit/please-lib";
 import * as Toggle from "@radix-ui/react-toggle";
 import { MdArrowBack, MdUploadFile, MdClose, MdSettings } from "react-icons/md";
 import { FaSeedling } from "react-icons/fa";
@@ -115,7 +115,7 @@ const LARGE_FILE_DOWNLOAD_MIN_TIMEOUT_MS = 5 * 60_000;
 const LARGE_FILE_DOWNLOAD_TIMEOUT_PER_MB_MS = 1_000;
 
 const getDownloadTimeout = (file: AbstractFile) =>
-    file instanceof LargeFile
+    isLargeFileLike(file)
         ? Math.max(
               LARGE_FILE_DOWNLOAD_MIN_TIMEOUT_MS,
               Math.ceil(Number(file.size) / 1e6) *
@@ -423,20 +423,17 @@ export const Drop = () => {
                     list.map(async (file) => ({
                         id: file.id,
                         name: file.name,
-                        type: file instanceof LargeFile ? "large" : "tiny",
+                        type: isLargeFileLike(file) ? "large" : "tiny",
                         size: file.size.toString(),
-                        ready:
-                            file instanceof LargeFile ? file.ready : undefined,
-                        chunkCount:
-                            file instanceof LargeFile
-                                ? file.chunkCount
-                                : undefined,
-                        localChunkCount:
-                            file instanceof LargeFile
-                                ? await files.program
-                                      ?.countLocalChunks(file)
-                                      .catch(() => null)
-                                : undefined,
+                        ready: isLargeFileLike(file) ? file.ready : undefined,
+                        chunkCount: isLargeFileLike(file)
+                            ? file.chunkCount
+                            : undefined,
+                        localChunkCount: isLargeFileLike(file)
+                            ? await files.program
+                                  ?.countLocalChunks(file)
+                                  .catch(() => null)
+                            : undefined,
                     }))
                 );
                 return {
@@ -819,7 +816,7 @@ export const Drop = () => {
         const timeout = getDownloadTimeout(file);
         startActiveTransfer();
         try {
-            if (file instanceof LargeFile) {
+            if (isLargeFileLike(file)) {
                 files.program?.retainFileRead(file);
             }
             scheduleAdaptiveRefresh("download-start");

--- a/packages/file-share/frontend/src/File.tsx
+++ b/packages/file-share/frontend/src/File.tsx
@@ -1,4 +1,9 @@
-import { IndexableFile, LargeFile, TinyFile } from "@peerbit/please-lib";
+import {
+    IndexableFile,
+    LargeFile,
+    TinyFile,
+    isLargeFileLike,
+} from "@peerbit/please-lib";
 import { Files, AbstractFile } from "@peerbit/please-lib";
 import { useEffect, useReducer, useState } from "react";
 import { FaSeedling } from "react-icons/fa";
@@ -23,8 +28,9 @@ export const File = (properties: {
     const [progress, setProgess] = useState<number | null>(null);
     const [failedDownload, setFailedDownload] = useState<boolean>(false);
     const [replicatedChunksRatio, setReplicatedChunksRatio] = useState(0);
-    const largeFile =
-        properties.file instanceof LargeFile ? properties.file : undefined;
+    const largeFile = isLargeFileLike(properties.file)
+        ? properties.file
+        : undefined;
     const chunkCount = largeFile?.chunkCount ?? 0;
     const downloadDisabled = shouldDisableFileDownload({
         progress,

--- a/packages/file-share/frontend/src/root-list.ts
+++ b/packages/file-share/frontend/src/root-list.ts
@@ -1,4 +1,4 @@
-import { AbstractFile, LargeFile } from "@peerbit/please-lib";
+import { AbstractFile, LargeFile, isLargeFileLike } from "@peerbit/please-lib";
 
 type FileChangeRoot = Pick<AbstractFile, "id" | "parentId">;
 
@@ -20,10 +20,10 @@ const hasChangedFiles = (detail: FileChangeDetail) =>
     (detail.added?.length ?? 0) > 0 || (detail.removed?.length ?? 0) > 0;
 
 const isReadyLargeFile = (file: AbstractFile): file is LargeFile =>
-    file instanceof LargeFile && file.ready;
+    isLargeFileLike(file) && file.ready;
 
 const hasFinalLargeFileHash = (file: AbstractFile) =>
-    file instanceof LargeFile && !!file.finalHash;
+    isLargeFileLike(file) && !!file.finalHash;
 
 const shouldPreferRootCandidate = (
     candidate: AbstractFile,
@@ -48,7 +48,7 @@ export const getReadyLargeFileSignature = (files: AbstractFile[]) => {
     const readyFiles = files
         .filter(
             (file): file is LargeFile =>
-                file instanceof LargeFile && file.ready && !!file.finalHash
+                isLargeFileLike(file) && file.ready && !!file.finalHash
         )
         .map(
             (file) =>

--- a/packages/file-share/frontend/tests/ready-manifest-browser-probe.ts
+++ b/packages/file-share/frontend/tests/ready-manifest-browser-probe.ts
@@ -1,0 +1,34 @@
+import { deserialize, serialize } from "@dao-xyz/borsh";
+import {
+    AbstractFile,
+    LargeFileWithChunkHeads,
+    isLargeFileLike,
+} from "@peerbit/please-lib";
+
+export const roundtripReadyManifest = () => {
+    const readyManifest = new LargeFileWithChunkHeads({
+        id: "ready-manifest-browser-roundtrip",
+        name: "ready-manifest-browser-roundtrip.bin",
+        size: 10n * 1024n * 1024n,
+        chunkCount: 20,
+        ready: true,
+        finalHash: "final-hash",
+        chunkEntryHeads: Array.from(
+            { length: 20 },
+            (_, index) => `chunk-entry-head-${index}`
+        ),
+    });
+    const encoded = serialize(readyManifest);
+    const decoded = deserialize(encoded, AbstractFile);
+    return {
+        encodedLength: encoded.byteLength,
+        firstByte: encoded[0],
+        constructor: decoded.constructor.name,
+        largeFileLike: isLargeFileLike(decoded),
+        instanceOfLargeFileWithChunkHeads:
+            decoded instanceof LargeFileWithChunkHeads,
+        chunkEntryHeadCount:
+            (decoded as { chunkEntryHeads?: unknown[] }).chunkEntryHeads
+                ?.length ?? 0,
+    };
+};

--- a/packages/file-share/frontend/tests/ready-manifest-serialization.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/ready-manifest-serialization.e2e.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+const probePath = new URL("./ready-manifest-browser-probe.ts", import.meta.url)
+    .pathname;
+
+test("decodes ready manifests with chunk entry heads in the browser runtime", async ({
+    page,
+    baseURL,
+}) => {
+    if (!baseURL) {
+        throw new Error("Missing baseURL");
+    }
+
+    await page.goto(baseURL, { waitUntil: "domcontentloaded" });
+
+    const result = await page.evaluate(async (path) => {
+        const { roundtripReadyManifest } = await import(
+            /* @vite-ignore */ `/@fs${path}`
+        );
+        return roundtripReadyManifest();
+    }, probePath);
+
+    expect(result.constructor).toBe("LargeFileWithChunkHeads");
+    expect(result.firstByte).toBe(2);
+    expect(result.largeFileLike).toBe(true);
+    expect(result.instanceOfLargeFileWithChunkHeads).toBe(true);
+    expect(result.chunkEntryHeadCount).toBe(20);
+});

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -5,6 +5,7 @@ import {
     LargeFile,
     LargeFileWithChunkHeads,
     TinyFile,
+    isLargeFileLike,
 } from "../index.js";
 import { concat, equals } from "uint8arrays";
 import crypto from "crypto";
@@ -181,9 +182,9 @@ describe("index", () => {
                 (filestore.files.log as any).syncronizer?.syncOptions;
 
             expect(syncOptions?.maxSimpleEntries).to.eq(128);
-            expect(syncOptions?.priority?.({ wallTime: 20n })).to.be.greaterThan(
-                syncOptions?.priority?.({ wallTime: 10n })
-            );
+            expect(
+                syncOptions?.priority?.({ wallTime: 20n })
+            ).to.be.greaterThan(syncOptions?.priority?.({ wallTime: 10n }));
         });
 
         it("keeps ready root manifests during adaptive pruning", async () => {
@@ -282,7 +283,7 @@ describe("index", () => {
             );
 
             const added = await filestore.files.index.get(addedId);
-            expect(added).to.be.instanceOf(LargeFile);
+            expect(isLargeFileLike(added)).to.be.true;
             expect((added as LargeFile).finalHash).to.eq(expectedId);
             expect(blob.streamCalls).to.eq(1);
             expect(addProgress.some((x) => x > 0 && x < 1)).to.be.true;
@@ -312,10 +313,10 @@ describe("index", () => {
                     entry as never,
                     options as never
                 );
-                if (entry instanceof LargeFile && entry.ready === false) {
+                if (isLargeFileLike(entry) && entry.ready === false) {
                     pendingHead = result.entry.hash;
                 }
-                if (entry instanceof LargeFile && entry.ready === true) {
+                if (isLargeFileLike(entry) && entry.ready === true) {
                     readyNext = result.entry.meta.next;
                 }
                 return result;
@@ -338,7 +339,7 @@ describe("index", () => {
                             : next?.hash === pendingHead
                     )
                 ).to.be.true;
-                expect(listedFile).to.be.instanceOf(LargeFile);
+                expect(isLargeFileLike(listedFile)).to.be.true;
                 expect((listedFile as LargeFile).ready).to.be.true;
                 expect(
                     filestore.lastUploadDiagnostics?.readyManifestFinishedAt
@@ -363,7 +364,7 @@ describe("index", () => {
             const file = await filestoreReader.files.index.get(fileId);
             const streamedChunks: Uint8Array[] = [];
 
-            expect(file).to.be.instanceOf(LargeFile);
+            expect(isLargeFileLike(file)).to.be.true;
 
             await file!.writeFile(filestoreReader, {
                 write: async (chunk) => {
@@ -445,7 +446,7 @@ describe("index", () => {
             );
 
             const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
+            expect(isLargeFileLike(file)).to.be.true;
             stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
@@ -666,7 +667,7 @@ describe("index", () => {
             );
 
             const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
+            expect(isLargeFileLike(file)).to.be.true;
             stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
@@ -741,7 +742,7 @@ describe("index", () => {
             );
 
             const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
+            expect(isLargeFileLike(file)).to.be.true;
             stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
@@ -827,7 +828,7 @@ describe("index", () => {
             );
 
             const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
+            expect(isLargeFileLike(file)).to.be.true;
             stripChunkEntryHeads(file);
 
             const writerHash = peer.identity.publicKey.hashcode();
@@ -1004,6 +1005,127 @@ describe("index", () => {
             ).to.eq("complete-chunks");
             expect(streamedChunks.length).to.be.greaterThan(1);
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
+        it("streams a pending manifest resolved by a ready manifest get", async () => {
+            const filestore = await peer.open(new Files());
+            const fileId = "pending-ready-manifest-get";
+            const fileName = "pending manifest resolved by get";
+            const chunks = [
+                new Uint8Array([1, 2]),
+                new Uint8Array([3]),
+                new Uint8Array([4, 5]),
+            ];
+            const expected = concat(chunks);
+            const chunkEntryHeads: string[] = [];
+
+            for (const [index, file] of chunks.entries()) {
+                const result = await filestore.files.put(
+                    new TinyFile({
+                        id: `${fileId}:${index}`,
+                        name: `${fileName}/${index}`,
+                        file,
+                        parentId: fileId,
+                        index,
+                    })
+                );
+                chunkEntryHeads[index] = result.entry.hash;
+            }
+
+            const pendingFile = new LargeFile({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount: chunks.length,
+                ready: false,
+            });
+            const readyManifest = new LargeFileWithChunkHeads({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount: chunks.length,
+                ready: true,
+                finalHash: sha256Base64Sync(expected),
+                chunkEntryHeads,
+            });
+            const originalSearch = filestore.files.index.search.bind(
+                filestore.files.index
+            );
+            const originalGet = filestore.files.index.get.bind(
+                filestore.files.index
+            );
+            let readyManifestGets = 0;
+
+            (filestore.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasRootId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "id" &&
+                        getQueryValue(query) === fileId
+                );
+                if (hasRootId) {
+                    if ((options as any)?.local === true) {
+                        return [pendingFile];
+                    }
+                    return [];
+                }
+                return originalSearch(request as never, options as never);
+            };
+            (filestore.files.index as any).get = async (
+                id: unknown,
+                options: any
+            ) => {
+                if (
+                    id === fileId &&
+                    options?.remote &&
+                    options.remote !== false
+                ) {
+                    readyManifestGets++;
+                    return readyManifest;
+                }
+                if (typeof id === "string" && id.startsWith(`${fileId}:`)) {
+                    if (options?.remote && options.remote !== false) {
+                        throw new Error(
+                            "chunk direct get should not be needed when the ready manifest has entry heads"
+                        );
+                    }
+                    return undefined;
+                }
+                return originalGet(id as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await pendingFile.writeFile(
+                    filestore,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 20_000 }
+                );
+            } finally {
+                (filestore.files.index as any).search = originalSearch;
+                (filestore.files.index as any).get = originalGet;
+            }
+
+            expect(readyManifestGets).to.be.greaterThan(0);
+            expect(
+                filestore.lastReadDiagnostics?.waitUntilReadyResolvedBy
+            ).to.eq("ready-manifest-get");
+            expect(
+                Object.values(
+                    filestore.lastReadDiagnostics?.chunkResolved ?? {}
+                )
+            ).to.deep.eq(chunks.map(() => "manifest-head-get"));
+            expect(equals(concat(streamedChunks), expected)).to.be.true;
         });
 
         it("keeps pending adaptive manifests blocked without ready or complete local chunks", async () => {
@@ -1457,7 +1579,7 @@ describe("index", () => {
             );
 
             const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
+            expect(isLargeFileLike(file)).to.be.true;
             stripChunkEntryHeads(file);
 
             const writerHash = peer.identity.publicKey.hashcode();
@@ -1602,7 +1724,7 @@ describe("index", () => {
             );
 
             const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
+            expect(isLargeFileLike(file)).to.be.true;
             stripChunkEntryHeads(file);
 
             const writerHash = peer.identity.publicKey.hashcode();
@@ -1701,7 +1823,7 @@ describe("index", () => {
             );
 
             const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
+            expect(isLargeFileLike(file)).to.be.true;
             stripChunkEntryHeads(file);
 
             const writerHash = peer.identity.publicKey.hashcode();
@@ -1853,7 +1975,7 @@ describe("index", () => {
             );
 
             const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
+            expect(isLargeFileLike(file)).to.be.true;
             stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
@@ -1942,7 +2064,7 @@ describe("index", () => {
             );
 
             const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
+            expect(isLargeFileLike(file)).to.be.true;
             stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
@@ -2027,7 +2149,7 @@ describe("index", () => {
             );
 
             const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
+            expect(isLargeFileLike(file)).to.be.true;
             stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
@@ -2105,7 +2227,7 @@ describe("index", () => {
             );
 
             const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
+            expect(isLargeFileLike(file)).to.be.true;
             stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
@@ -2193,7 +2315,7 @@ describe("index", () => {
             );
 
             const file = await filestoreReader.files.index.get(fileId);
-            expect(file).to.be.instanceOf(LargeFile);
+            expect(isLargeFileLike(file)).to.be.true;
             stripChunkEntryHeads(file);
 
             const originalSearch = filestoreReader.files.index.search.bind(
@@ -2396,7 +2518,7 @@ describe("index", () => {
             let uploadId: string | undefined;
 
             (filestore.files as any).put = async (entry: unknown) => {
-                if (entry instanceof LargeFile && !entry.ready) {
+                if (isLargeFileLike(entry) && !entry.ready) {
                     uploadId = entry.id;
                 }
                 if (entry instanceof TinyFile && entry.parentId != null) {
@@ -2419,7 +2541,7 @@ describe("index", () => {
                         replicate: true,
                         timeout: 1_000,
                     });
-                    expect(match).to.be.instanceOf(LargeFile);
+                    expect(isLargeFileLike(match)).to.be.true;
                     expect((match as LargeFile).ready).to.be.false;
                     discoveredFile = match as LargeFile;
                 },
@@ -2468,7 +2590,7 @@ describe("index", () => {
             try {
                 const listed = await filestore.list();
                 expect(listed).to.have.length(1);
-                expect(listed[0]).to.be.instanceOf(LargeFile);
+                expect(isLargeFileLike(listed[0])).to.be.true;
                 expect((listed[0] as LargeFile).ready).to.be.true;
                 expect((listed[0] as LargeFile).finalHash).to.eq("ready-hash");
                 expect(searchCalls).to.eq(2);

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -667,6 +667,7 @@ export class LargeFile extends AbstractFile {
         let directMisses = 0;
         let retryableFailures = 0;
         let nextNonReplicatingReadAfterFailures = 3;
+        let manifestHeadUnavailable = false;
         const materializeLocalChunk = async (
             resolvedBy: string
         ): Promise<TinyFile | undefined> => {
@@ -822,6 +823,61 @@ export class LargeFile extends AbstractFile {
                 return chunk;
             }
         };
+        const resolveChunkByManifestEntryHead = async (
+            remoteFrom: string[] | undefined
+        ): Promise<TinyFile | undefined> => {
+            if (manifestHeadUnavailable) {
+                return;
+            }
+            const heads = (this as { chunkEntryHeads?: unknown })
+                .chunkEntryHeads;
+            const head = Array.isArray(heads) ? heads[index] : undefined;
+            if (typeof head !== "string") {
+                return;
+            }
+            files.retainChunkEntryHead(head);
+            properties?.debug &&
+                ((properties.debug.chunkManifestHeads ||= {})[index] = head);
+
+            const entry = await files.files.log.log.get(head, {
+                remote: {
+                    timeout: attemptTimeout,
+                    throwOnMissing: false,
+                    retryMissingResponses: true,
+                    replicate: files.persistChunkReads,
+                    from: remoteFrom,
+                } as any,
+            });
+            if (!entry) {
+                manifestHeadUnavailable = true;
+                properties?.debug &&
+                    ((properties.debug.chunkManifestHeadMisses ||= {})[index] =
+                        ((properties.debug.chunkManifestHeadMisses ||= {})[
+                            index
+                        ] ?? 0) + 1);
+                return;
+            }
+
+            const operation = await entry.getPayloadValue();
+            if (!isPutOperation(operation)) {
+                return;
+            }
+            const chunk = files.files.index.valueEncoding.decoder(
+                operation.data
+            );
+            if (
+                chunk instanceof TinyFile &&
+                chunk.parentId === this.id &&
+                chunk.index === index
+            ) {
+                knownChunks.set(index, chunk);
+                files.retainResolvedChunk(chunk);
+                properties?.debug &&
+                    ((properties.debug.chunkResolved ||= {})[index] =
+                        "manifest-head-get");
+                return chunk;
+            }
+        };
         const resolveChunkWithoutPersisting = async (
             remoteFrom: string[] | undefined
         ): Promise<TinyFile | undefined> => {
@@ -896,6 +952,7 @@ export class LargeFile extends AbstractFile {
                     return localChunk;
                 }
             } catch (error) {
+                manifestHeadUnavailable = true;
                 if (!isRetryableChunkLookupError(error)) {
                     properties?.debug &&
                         (properties.debug.chunkFailure = {
@@ -923,6 +980,30 @@ export class LargeFile extends AbstractFile {
             if (properties?.debug) {
                 (properties.debug.chunkHints ||= {})[index] =
                     remoteFrom ?? null;
+            }
+
+            try {
+                const chunk = await resolveChunkByManifestEntryHead(remoteFrom);
+                if (chunk) {
+                    return chunk;
+                }
+            } catch (error) {
+                if (!isRetryableChunkLookupError(error)) {
+                    properties?.debug &&
+                        (properties.debug.chunkFailure = {
+                            index,
+                            type: "non-retryable-manifest-head-get",
+                            message: getErrorMessage(error),
+                        });
+                    throw error;
+                }
+                if (remoteFrom && shouldRetryChunkLookupWithoutHints(error)) {
+                    hintedDeliveryFailures += 1;
+                }
+                retryableFailures += 1;
+                properties?.debug &&
+                    ((properties.debug.chunkRetryableManifestHeadGetErrors ||=
+                        {})[index] = getErrorMessage(error));
             }
 
             try {
@@ -1407,7 +1488,10 @@ export class LargeFile extends AbstractFile {
         const configuredReadAhead = files.persistChunkReads
             ? LARGE_FILE_PERSISTED_READ_AHEAD
             : LARGE_FILE_OBSERVER_READ_AHEAD;
-        const readAhead = Math.min(resolvedFile.chunkCount, configuredReadAhead);
+        const readAhead = Math.min(
+            resolvedFile.chunkCount,
+            configuredReadAhead
+        );
         debug.readAhead = readAhead;
 
         for (
@@ -1502,23 +1586,40 @@ export class LargeFileWithChunkHeads extends AbstractFile {
     }
 
     streamFile(files: Files, properties?: FileReadOptions) {
-        return LargeFile.prototype.streamFile.call(
-            this as unknown as LargeFile,
-            files,
-            properties
-        );
+        return toLargeFileDelegate(this).streamFile(files, properties);
     }
 
     delete(files: Files) {
-        return LargeFile.prototype.delete.call(
-            this as unknown as LargeFile,
-            files
-        );
+        return toLargeFileDelegate(this).delete(files);
     }
 }
-Object.setPrototypeOf(LargeFileWithChunkHeads.prototype, LargeFile.prototype);
 
-const isLargeFileLike = (value: unknown): value is LargeFile => {
+const toLargeFileDelegate = (
+    value: LargeFile | LargeFileWithChunkHeads
+): LargeFile => {
+    const file = new LargeFile({
+        id: value.id,
+        name: value.name,
+        size: value.size,
+        chunkCount: value.chunkCount,
+        ready: value.ready,
+        finalHash: value.finalHash,
+    });
+    const chunkEntryHeads = (value as { chunkEntryHeads?: unknown })
+        .chunkEntryHeads;
+    if (Array.isArray(chunkEntryHeads)) {
+        (
+            file as LargeFile & {
+                chunkEntryHeads?: string[];
+            }
+        ).chunkEntryHeads = chunkEntryHeads.filter(
+            (head): head is string => typeof head === "string"
+        );
+    }
+    return file;
+};
+
+export const isLargeFileLike = (value: unknown): value is LargeFile => {
     const file = value as Partial<LargeFile> & {
         parentId?: unknown;
     };
@@ -1543,15 +1644,7 @@ const toReadableLargeFile = (value: unknown): LargeFile | undefined => {
         return value as LargeFile;
     }
     if (Array.isArray((value as any).chunkEntryHeads)) {
-        return new LargeFileWithChunkHeads({
-            id: value.id,
-            name: value.name,
-            size: value.size,
-            chunkCount: value.chunkCount,
-            ready: value.ready,
-            finalHash: value.finalHash,
-            chunkEntryHeads: (value as any).chunkEntryHeads,
-        }) as unknown as LargeFile;
+        return toLargeFileDelegate(value);
     }
     return new LargeFile({
         id: value.id,
@@ -1987,10 +2080,9 @@ export class Files extends Program<Args> {
                 finalHash: toBase64(hasher.digest()),
                 chunkEntryHeads,
             });
-            await this.files.put(
-                readyManifest,
-                { meta: { next: [pendingManifest.entry] } }
-            );
+            await this.files.put(readyManifest, {
+                meta: { next: [pendingManifest.entry] },
+            });
             diagnostics.readyManifestFinishedAt = Date.now();
             diagnostics.chunkCount = chunkCount;
         } catch (error) {
@@ -2128,10 +2220,9 @@ export class Files extends Program<Args> {
                 finalHash: toBase64(hasher.digest()),
                 chunkEntryHeads,
             });
-            await this.files.put(
-                readyManifest,
-                { meta: { next: [pendingManifest.entry] } }
-            );
+            await this.files.put(readyManifest, {
+                meta: { next: [pendingManifest.entry] },
+            });
             diagnostics.readyManifestFinishedAt = Date.now();
         } catch (error) {
             diagnostics.failureAt = Date.now();


### PR DESCRIPTION
## Summary
- keep LargeFileWithChunkHeads as its own variant-2 borsh model instead of mutating its prototype into LargeFile
- delegate read/delete behavior through a real LargeFile instance carrying chunk-entry-head metadata
- use structural large-file checks in file-share UI/tests so ready manifests are not dropped because they are not instanceof LargeFile
- resolve chunks by exact ready-manifest entry heads before falling back to document get/search paths, with exact-head misses capped at one attempt per chunk
- add regressions for ready-manifest-get streaming, exact entry-head chunk reads, and browser borsh roundtrip of chunk-entry-head manifests

## Verification
- pnpm --filter @peerbit/please-lib build
- pnpm --filter @peerbit/please-lib test
- pnpm --filter file-share build
- pnpm --filter file-share test:unit
- pnpm --filter file-share test:e2e -- tests/ready-manifest-serialization.e2e.spec.ts
- PW_BENCH=1 PW_BENCH_SCENARIO=local PW_READER_ROLE=adaptive PW_FILE_MB=50 ... tests/transfer.bench.e2e.spec.ts
- GitHub Actions File Share Benchmarks, 50 MiB local/adaptive on a9dd9e18: https://github.com/dao-xyz/peerbit-examples/actions/runs/25217735976

## Benchmark notes
- Local 50 MiB adaptive on the final tree: upload 2.08s, discovery 0.26s, download 7.07s / 59.31 Mbps, no read failures.
- GitHub runner 50 MiB adaptive on a9dd9e18: upload 8.50s, discovery 1.67s, download 54.07s / 7.76 Mbps, no ready-manifest errors, no chunk failure, max manifest-head miss count 1.
- Earlier hosted run before capping manifest-head misses passed but was much slower: download 379.80s / 1.10 Mbps.