### PR TITLE
Bound file-share remote read ahead

### DIFF
--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -455,6 +455,8 @@ describe("index", () => {
             const originalGet = filestoreReader.files.index.get.bind(
                 filestoreReader.files.index
             );
+            const originalCountLocalChunks =
+                filestoreReader.countLocalChunks.bind(filestoreReader);
             let parentIdSearches = 0;
             let directChunkGets = 0;
             let inflightChunkGets = 0;
@@ -548,21 +550,42 @@ describe("index", () => {
                 }
                 return originalGet(id as never, options as never);
             };
+            (filestoreReader as any).countLocalChunks = async (
+                parent: LargeFile
+            ) => {
+                if (parent.id === fileId) {
+                    return 0;
+                }
+                return originalCountLocalChunks(parent);
+            };
 
             const streamedChunks: Uint8Array[] = [];
 
-            await file!.writeFile(filestoreReader, {
-                write: async (chunk) => {
-                    streamedChunks.push(chunk);
-                },
-            });
+            try {
+                await file!.writeFile(filestoreReader, {
+                    write: async (chunk) => {
+                        streamedChunks.push(chunk);
+                    },
+                });
+            } finally {
+                (filestoreReader as any).countLocalChunks =
+                    originalCountLocalChunks;
+                (filestoreReader.files.index as any).search = originalSearch;
+                (filestoreReader.files.index as any).get = originalGet;
+            }
 
             expect(parentIdSearches).to.eq(0);
             expect(directChunkGets).to.be.greaterThan(1);
             expect(maxInflightChunkGets).to.be.greaterThan(1);
             const readAhead = filestoreReader.lastReadDiagnostics?.readAhead;
-            expect(readAhead).to.be.greaterThan(4);
+            expect(readAhead).to.eq(8);
             expect(readAhead).to.be.lessThanOrEqual(file!.chunkCount);
+            expect(filestoreReader.lastReadDiagnostics?.readAheadSource).to.eq(
+                "persisted-remote"
+            );
+            expect(
+                filestoreReader.lastReadDiagnostics?.initialLocalChunkCount
+            ).to.be.lessThan(file!.chunkCount);
             expect(
                 filestoreReader.lastReadDiagnostics?.chunkAttemptTimeoutMs
             ).to.eq(5_000);

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -304,6 +304,7 @@ const CHUNK_SIZE_GRANULARITY = 64 * 1024;
 const MAX_LARGE_FILE_SEGMENT_SIZE = 512 * 1024;
 const LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS = 5 * 60 * 1000;
 const LARGE_FILE_PERSISTED_READ_AHEAD = 32;
+const LARGE_FILE_REMOTE_PERSISTED_READ_AHEAD = 8;
 const LARGE_FILE_OBSERVER_READ_AHEAD = 2;
 const LARGE_FILE_OBSERVER_PREFETCH_TIMEOUT_MS = 5_000;
 const LARGE_FILE_MIN_CHUNK_ATTEMPT_TIMEOUT_MS = 5_000;
@@ -1403,6 +1404,8 @@ export class LargeFile extends AbstractFile {
             waitUntilReadyResolvedBy: null as string | null,
             prefetchedChunkCount: 0,
             readAhead: 0,
+            initialLocalChunkCount: null as number | null,
+            readAheadSource: null as string | null,
             initialReadPeerHints: null as string[] | null,
             chunkAttemptTimeoutMs: 0,
             finishedAt: null as number | null,
@@ -1458,6 +1461,11 @@ export class LargeFile extends AbstractFile {
             }
             debug.prefetchedChunkCount = knownChunks.size;
         }
+        if (files.persistChunkReads) {
+            debug.initialLocalChunkCount = await files
+                .countLocalChunks(resolvedFile)
+                .catch(() => null);
+        }
         const inFlightChunks = new Map<number, Promise<TinyFile>>();
         const resolveChunkWithReadAhead = (index: number) => {
             const cached = inFlightChunks.get(index);
@@ -1486,13 +1494,21 @@ export class LargeFile extends AbstractFile {
         };
 
         const configuredReadAhead = files.persistChunkReads
-            ? LARGE_FILE_PERSISTED_READ_AHEAD
+            ? debug.initialLocalChunkCount != null &&
+              debug.initialLocalChunkCount < resolvedFile.chunkCount
+                ? LARGE_FILE_REMOTE_PERSISTED_READ_AHEAD
+                : LARGE_FILE_PERSISTED_READ_AHEAD
             : LARGE_FILE_OBSERVER_READ_AHEAD;
         const readAhead = Math.min(
             resolvedFile.chunkCount,
             configuredReadAhead
         );
         debug.readAhead = readAhead;
+        debug.readAheadSource = files.persistChunkReads
+            ? readAhead === LARGE_FILE_PERSISTED_READ_AHEAD
+                ? "persisted-local"
+                : "persisted-remote"
+            : "observer";
 
         for (
             let index = 0;


### PR DESCRIPTION
## Summary
- bound persisted large-file read-ahead to 8 chunks when the reader does not yet have the complete chunk set locally
- keep the previous 32 chunk read-ahead when persisted chunks are already fully local
- expose `initialLocalChunkCount` and `readAheadSource` in read diagnostics so runner artifacts show which path was used
- update the persisted read-ahead integration test to cover the remote/incomplete-local path explicitly

## Why
The post-merge two-runner 50 MiB adaptive benchmark failed on the deployed app: the reader saw the ready manifest with only part of the chunk set local, launched 32 chunk resolutions at once, and chunk 1/100 starved until the lookup deadline. This change limits the remote pressure while preserving the faster local path.

Failed two-runner run: https://github.com/dao-xyz/peerbit-examples/actions/runs/25218216760

## Verification
- pnpm --filter @peerbit/please-lib build
- pnpm --filter @peerbit/please-lib exec vitest run -t "pipelines persisted chunk reads"
- pnpm --filter @peerbit/please-lib test
- pnpm --filter file-share build
- pnpm --filter file-share test:unit
- PW_BENCH=1 PW_BENCH_SCENARIO=local PW_READER_ROLE=adaptive PW_FILE_MB=50 ... tests/transfer.bench.e2e.spec.ts

## Local benchmark note
Final local 50 MiB adaptive run: upload 2.09s, discovery 0.37s, download 5.81s / 72.15 Mbps. Diagnostics showed `readAhead=8`, `initialLocalChunkCount=31`, and `readAheadSource=persisted-remote`.