### PR TITLE
fix(file-share): skip stale chunk head probes

### DIFF
--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -1241,6 +1241,142 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), expected)).to.be.true;
         });
 
+        it("stops probing ready manifest chunk heads after a miss", async () => {
+            const filestore = await peer.open(new Files());
+            const fileId = "missing-ready-heads";
+            const fileName = "missing ready heads";
+            const chunks = [
+                new TinyFile({
+                    id: `${fileId}:0`,
+                    name: `${fileName}/0`,
+                    file: new Uint8Array([1]),
+                    parentId: fileId,
+                    index: 0,
+                }),
+                new TinyFile({
+                    id: `${fileId}:1`,
+                    name: `${fileName}/1`,
+                    file: new Uint8Array([2]),
+                    parentId: fileId,
+                    index: 1,
+                }),
+                new TinyFile({
+                    id: `${fileId}:2`,
+                    name: `${fileName}/2`,
+                    file: new Uint8Array([3]),
+                    parentId: fileId,
+                    index: 2,
+                }),
+            ];
+            const expected = concat(chunks.map((chunk) => chunk.file));
+            const chunkEntryHeads = chunks.map(
+                (_, index) => `missing-head-${index}`
+            );
+            const pendingFile = new LargeFile({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount: chunks.length,
+                ready: false,
+            });
+            const readyManifest = new LargeFileWithChunkHeads({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount: chunks.length,
+                ready: true,
+                finalHash: sha256Base64Sync(expected),
+                chunkEntryHeads,
+            });
+            const originalSearch = filestore.files.index.search.bind(
+                filestore.files.index
+            );
+            const originalGet = filestore.files.index.get.bind(
+                filestore.files.index
+            );
+            const originalLogGet = filestore.files.log.log.get.bind(
+                filestore.files.log.log
+            );
+            let manifestHeadGets = 0;
+
+            (filestore.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasRootId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "id" &&
+                        getQueryValue(query) === fileId
+                );
+                if (hasRootId) {
+                    return (options as any)?.local === true
+                        ? [pendingFile]
+                        : [];
+                }
+                return originalSearch(request as never, options as never);
+            };
+            (filestore.files.index as any).get = async (
+                id: unknown,
+                options: any
+            ) => {
+                if (
+                    id === fileId &&
+                    options?.remote &&
+                    options.remote !== false
+                ) {
+                    return readyManifest;
+                }
+                if (typeof id === "string" && id.startsWith(`${fileId}:`)) {
+                    if (options?.remote && options.remote !== false) {
+                        return chunks[Number(id.slice(`${fileId}:`.length))];
+                    }
+                    return undefined;
+                }
+                return originalGet(id as never, options as never);
+            };
+            (filestore.files.log.log as any).get = async (
+                hash: string,
+                options: unknown
+            ) => {
+                if (chunkEntryHeads.includes(hash)) {
+                    manifestHeadGets++;
+                    await delay(25);
+                    return undefined;
+                }
+                return originalLogGet(hash as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await pendingFile.writeFile(filestore, {
+                    write: async (chunk) => {
+                        streamedChunks.push(chunk);
+                    },
+                });
+            } finally {
+                (filestore.files.index as any).search = originalSearch;
+                (filestore.files.index as any).get = originalGet;
+                (filestore.files.log.log as any).get = originalLogGet;
+            }
+
+            expect(manifestHeadGets).to.eq(1);
+            expect(
+                Object.keys(
+                    filestore.lastReadDiagnostics?.chunkManifestHeadMisses ?? {}
+                )
+            ).to.deep.eq(["0"]);
+            expect(
+                Object.values(
+                    filestore.lastReadDiagnostics?.chunkResolved ?? {}
+                )
+            ).to.deep.eq(chunks.map(() => "remote-get"));
+            expect(equals(concat(streamedChunks), expected)).to.be.true;
+        });
+
         it("keeps pending adaptive manifests blocked without ready or complete local chunks", async () => {
             const filestore = await peer.open(new Files());
             const fileName = "pending manifest with arbitrary local chunks";

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -199,6 +199,9 @@ type ChunkReadContext = {
     lastReadPeerHints?: string[];
     localChunkEntryHeads?: Map<string, string>;
     localChunkEntryHeadsScan?: Promise<Map<string, string>>;
+    manifestHeadAvailable?: boolean;
+    manifestHeadUnavailable?: boolean;
+    manifestHeadProbe?: Promise<void>;
 };
 
 export interface ReReadableChunkSource {
@@ -668,7 +671,7 @@ export class LargeFile extends AbstractFile {
         let directMisses = 0;
         let retryableFailures = 0;
         let nextNonReplicatingReadAfterFailures = 3;
-        let manifestHeadUnavailable = false;
+        let skipManifestHeadForChunk = false;
         const materializeLocalChunk = async (
             resolvedBy: string
         ): Promise<TinyFile | undefined> => {
@@ -827,8 +830,20 @@ export class LargeFile extends AbstractFile {
         const resolveChunkByManifestEntryHead = async (
             remoteFrom: string[] | undefined
         ): Promise<TinyFile | undefined> => {
-            if (manifestHeadUnavailable) {
+            if (
+                skipManifestHeadForChunk ||
+                readContext.manifestHeadUnavailable
+            ) {
                 return;
+            }
+            if (
+                readContext.manifestHeadAvailable !== true &&
+                readContext.manifestHeadProbe
+            ) {
+                await readContext.manifestHeadProbe.catch(() => undefined);
+                if (readContext.manifestHeadUnavailable) {
+                    return;
+                }
             }
             const heads = (this as { chunkEntryHeads?: unknown })
                 .chunkEntryHeads;
@@ -840,23 +855,41 @@ export class LargeFile extends AbstractFile {
             properties?.debug &&
                 ((properties.debug.chunkManifestHeads ||= {})[index] = head);
 
-            const entry = await files.files.log.log.get(head, {
-                remote: {
-                    timeout: attemptTimeout,
-                    throwOnMissing: false,
-                    retryMissingResponses: false,
-                    replicate: files.persistChunkReads,
-                    from: remoteFrom,
-                } as any,
+            let releaseProbe: (() => void) | undefined;
+            const manifestHeadProbe = new Promise<void>((resolve) => {
+                releaseProbe = resolve;
             });
-            if (!entry) {
-                manifestHeadUnavailable = true;
-                properties?.debug &&
-                    ((properties.debug.chunkManifestHeadMisses ||= {})[index] =
+            readContext.manifestHeadProbe = manifestHeadProbe;
+            let entry: Awaited<
+                ReturnType<typeof files.files.log.log.get>
+            > | null = null;
+            try {
+                entry = await files.files.log.log.get(head, {
+                    remote: {
+                        timeout: attemptTimeout,
+                        throwOnMissing: false,
+                        retryMissingResponses: false,
+                        replicate: files.persistChunkReads,
+                        from: remoteFrom,
+                    } as any,
+                });
+                if (!entry) {
+                    readContext.manifestHeadUnavailable = true;
+                    properties?.debug &&
                         ((properties.debug.chunkManifestHeadMisses ||= {})[
                             index
-                        ] ?? 0) + 1);
-                return;
+                        ] =
+                            ((properties.debug.chunkManifestHeadMisses ||= {})[
+                                index
+                            ] ?? 0) + 1);
+                    return;
+                }
+                readContext.manifestHeadAvailable = true;
+            } finally {
+                if (readContext.manifestHeadProbe === manifestHeadProbe) {
+                    readContext.manifestHeadProbe = undefined;
+                }
+                releaseProbe?.();
             }
 
             const operation = await entry.getPayloadValue();
@@ -905,7 +938,7 @@ export class LargeFile extends AbstractFile {
                     return localChunk;
                 }
             } catch (error) {
-                manifestHeadUnavailable = true;
+                skipManifestHeadForChunk = true;
                 if (!isRetryableChunkLookupError(error)) {
                     properties?.debug &&
                         (properties.debug.chunkFailure = {


### PR DESCRIPTION
## Summary
- stop retrying ready-manifest chunk entry-head lookups after the first miss within a file read
- fall back to direct chunk lookup/search for the remaining chunks instead of spending a timeout per missing head
- add a regression test for missing ready-manifest chunk heads

## Verification
- pnpm --filter @peerbit/please-lib build
- pnpm --filter file-share build
- pnpm --filter @peerbit/please-lib test
- 64 MB local adaptive smoke: passed, discovery 216ms, download 26.8s
- 64 MB local adaptive 3-run set: passed, download p50 33.4s, max 70.8s
- 5 MB local adaptive 3-run set: passed, download p50 379ms, discovery p50 2.7s

Bench JSON/logs are under /Users/admin/git/tmp/peerbit-file-share-manifest-head-skip-pr and are not committed.