### PR TITLE
test(file-share): keep prod benchmark writer hosted

### DIFF
--- a/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
@@ -183,8 +183,7 @@ test.describe("file-share transfer benchmark", () => {
                 writer,
                 `file-share-transfer-bench-${Date.now()}`
             );
-            let shareUrl = new URL(entryUrl);
-            shareUrl.hash = `/s/${address}`;
+            let shareUrl = new URL(writer.url());
             logStage("seed-reader-role");
             await seedReplicationRole(
                 reader,
@@ -193,10 +192,6 @@ test.describe("file-share transfer benchmark", () => {
             );
 
             logStage("open-reader", { shareUrl: shareUrl.toString() });
-            logStage("open-writer-page");
-            await writer.goto(shareUrl.toString(), {
-                waitUntil: "domcontentloaded",
-            });
             logStage("writer-page-ready");
             if (!usesLocalBootstrap) {
                 logStage("wait-for-share-peer-hints");


### PR DESCRIPTION

## Summary
- keep the benchmark writer on the page that created the file-share space during production runs
- wait for that hosted writer page to append peer hints before opening the reader
- avoid measuring a writer reload / remote program-resolution failure before the transfer benchmark actually starts

## Validation
- `git diff --check`
- `PW_BENCH=1 PW_BENCH_SCENARIO=prod PW_READER_ROLE=adaptive PW_FILE_MB=5 PW_BASE_URL=https://files.dao.xyz PW_RESULT_FILE=/Users/admin/git/tmp/peerbit-examples-5.2.18-prod-benches-fixed/pr-branch-prod-adaptive-5mb-smoke.json npx playwright test -c packages/file-share/frontend/playwright.config.ts packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts --reporter line`

5 MB production smoke result: upload 209 ms, discovery 9533 ms, download 489 ms.

## Follow-up
The corrected harness exposed a separate production 64 MB remote chunk resolution failure, tracked in dao-xyz/peerbit#775.
