### PR TITLE
fix(file-share): harden remote chunk reads

### DIFF
--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -578,7 +578,7 @@ describe("index", () => {
             expect(directChunkGets).to.be.greaterThan(1);
             expect(maxInflightChunkGets).to.be.greaterThan(1);
             const readAhead = filestoreReader.lastReadDiagnostics?.readAhead;
-            expect(readAhead).to.eq(8);
+            expect(readAhead).to.eq(2);
             expect(readAhead).to.be.lessThanOrEqual(file!.chunkCount);
             expect(filestoreReader.lastReadDiagnostics?.readAheadSource).to.eq(
                 "persisted-remote"
@@ -1241,7 +1241,7 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), expected)).to.be.true;
         });
 
-        it("stops probing ready manifest chunk heads after a miss", async () => {
+        it("falls back per chunk when ready manifest chunk heads are missing", async () => {
             const filestore = await peer.open(new Files());
             const fileId = "missing-ready-heads";
             const fileName = "missing ready heads";
@@ -1363,17 +1363,157 @@ describe("index", () => {
                 (filestore.files.log.log as any).get = originalLogGet;
             }
 
-            expect(manifestHeadGets).to.eq(1);
+            expect(manifestHeadGets).to.eq(chunks.length);
             expect(
                 Object.keys(
                     filestore.lastReadDiagnostics?.chunkManifestHeadMisses ?? {}
                 )
-            ).to.deep.eq(["0"]);
+            ).to.deep.eq(["0", "1", "2"]);
             expect(
                 Object.values(
                     filestore.lastReadDiagnostics?.chunkResolved ?? {}
                 )
             ).to.deep.eq(chunks.map(() => "remote-get"));
+            expect(equals(concat(streamedChunks), expected)).to.be.true;
+        });
+
+        it("retries transient ready manifest chunk head misses", async () => {
+            const filestore = await peer.open(new Files());
+            const fileId = "transient-ready-head-miss";
+            const fileName = "transient ready head miss";
+            const chunks = [
+                new Uint8Array([1]),
+                new Uint8Array([2]),
+                new Uint8Array([3]),
+            ];
+            const expected = concat(chunks);
+            const chunkEntryHeads: string[] = [];
+
+            for (const [index, file] of chunks.entries()) {
+                const result = await filestore.files.put(
+                    new TinyFile({
+                        id: `${fileId}:${index}`,
+                        name: `${fileName}/${index}`,
+                        file,
+                        parentId: fileId,
+                        index,
+                    })
+                );
+                chunkEntryHeads[index] = result.entry.hash;
+            }
+
+            const pendingFile = new LargeFile({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount: chunks.length,
+                ready: false,
+            });
+            const readyManifest = new LargeFileWithChunkHeads({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount: chunks.length,
+                ready: true,
+                finalHash: sha256Base64Sync(expected),
+                chunkEntryHeads,
+            });
+            const originalSearch = filestore.files.index.search.bind(
+                filestore.files.index
+            );
+            const originalGet = filestore.files.index.get.bind(
+                filestore.files.index
+            );
+            const originalLogGet = filestore.files.log.log.get.bind(
+                filestore.files.log.log
+            );
+            let firstHeadMissed = false;
+            let firstHeadGets = 0;
+
+            (filestore.files.index as any).search = async (
+                request: { query: unknown | unknown[] },
+                options: unknown
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const hasRootId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "id" &&
+                        getQueryValue(query) === fileId
+                );
+                if (hasRootId) {
+                    return (options as any)?.local === true
+                        ? [pendingFile]
+                        : [];
+                }
+                const hasParentId = queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "parentId" &&
+                        getQueryValue(query) === fileId
+                );
+                if (hasParentId) {
+                    return [];
+                }
+                return originalSearch(request as never, options as never);
+            };
+            (filestore.files.index as any).get = async (
+                id: unknown,
+                options: any
+            ) => {
+                if (
+                    id === fileId &&
+                    options?.remote &&
+                    options.remote !== false
+                ) {
+                    return readyManifest;
+                }
+                if (typeof id === "string" && id.startsWith(`${fileId}:`)) {
+                    return undefined;
+                }
+                return originalGet(id as never, options as never);
+            };
+            (filestore.files.log.log as any).get = async (
+                hash: string,
+                options: unknown
+            ) => {
+                if (hash === chunkEntryHeads[0]) {
+                    firstHeadGets++;
+                    if (!firstHeadMissed) {
+                        firstHeadMissed = true;
+                        return undefined;
+                    }
+                }
+                return originalLogGet(hash as never, options as never);
+            };
+
+            const streamedChunks: Uint8Array[] = [];
+
+            try {
+                await pendingFile.writeFile(
+                    filestore,
+                    {
+                        write: async (chunk) => {
+                            streamedChunks.push(chunk);
+                        },
+                    },
+                    { timeout: 2_000 }
+                );
+            } finally {
+                (filestore.files.index as any).search = originalSearch;
+                (filestore.files.index as any).get = originalGet;
+                (filestore.files.log.log as any).get = originalLogGet;
+            }
+
+            expect(firstHeadGets).to.be.greaterThan(1);
+            expect(
+                filestore.lastReadDiagnostics?.chunkManifestHeadMisses?.[0]
+            ).to.eq(1);
+            expect(
+                Object.values(
+                    filestore.lastReadDiagnostics?.chunkResolved ?? {}
+                )
+            ).to.deep.eq(chunks.map(() => "manifest-head-get"));
             expect(equals(concat(streamedChunks), expected)).to.be.true;
         });
 

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -199,9 +199,6 @@ type ChunkReadContext = {
     lastReadPeerHints?: string[];
     localChunkEntryHeads?: Map<string, string>;
     localChunkEntryHeadsScan?: Promise<Map<string, string>>;
-    manifestHeadAvailable?: boolean;
-    manifestHeadUnavailable?: boolean;
-    manifestHeadProbe?: Promise<void>;
 };
 
 export interface ReReadableChunkSource {
@@ -307,7 +304,7 @@ const CHUNK_SIZE_GRANULARITY = 64 * 1024;
 const MAX_LARGE_FILE_SEGMENT_SIZE = 512 * 1024;
 const LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS = 5 * 60 * 1000;
 const LARGE_FILE_PERSISTED_READ_AHEAD = 32;
-const LARGE_FILE_REMOTE_PERSISTED_READ_AHEAD = 8;
+const LARGE_FILE_REMOTE_PERSISTED_READ_AHEAD = 2;
 const LARGE_FILE_OBSERVER_READ_AHEAD = 2;
 const LARGE_FILE_OBSERVER_PREFETCH_TIMEOUT_MS = 5_000;
 const LARGE_FILE_MIN_CHUNK_ATTEMPT_TIMEOUT_MS = 5_000;
@@ -830,20 +827,8 @@ export class LargeFile extends AbstractFile {
         const resolveChunkByManifestEntryHead = async (
             remoteFrom: string[] | undefined
         ): Promise<TinyFile | undefined> => {
-            if (
-                skipManifestHeadForChunk ||
-                readContext.manifestHeadUnavailable
-            ) {
+            if (skipManifestHeadForChunk) {
                 return;
-            }
-            if (
-                readContext.manifestHeadAvailable !== true &&
-                readContext.manifestHeadProbe
-            ) {
-                await readContext.manifestHeadProbe.catch(() => undefined);
-                if (readContext.manifestHeadUnavailable) {
-                    return;
-                }
             }
             const heads = (this as { chunkEntryHeads?: unknown })
                 .chunkEntryHeads;
@@ -855,41 +840,24 @@ export class LargeFile extends AbstractFile {
             properties?.debug &&
                 ((properties.debug.chunkManifestHeads ||= {})[index] = head);
 
-            let releaseProbe: (() => void) | undefined;
-            const manifestHeadProbe = new Promise<void>((resolve) => {
-                releaseProbe = resolve;
+            const entry = await files.files.log.log.get(head, {
+                remote: {
+                    timeout: attemptTimeout,
+                    throwOnMissing: false,
+                    retryMissingResponses: false,
+                    replicate: files.persistChunkReads,
+                    from: remoteFrom,
+                } as any,
             });
-            readContext.manifestHeadProbe = manifestHeadProbe;
-            let entry: Awaited<
-                ReturnType<typeof files.files.log.log.get>
-            > | null = null;
-            try {
-                entry = await files.files.log.log.get(head, {
-                    remote: {
-                        timeout: attemptTimeout,
-                        throwOnMissing: false,
-                        retryMissingResponses: false,
-                        replicate: files.persistChunkReads,
-                        from: remoteFrom,
-                    } as any,
-                });
-                if (!entry) {
-                    readContext.manifestHeadUnavailable = true;
-                    properties?.debug &&
+            if (!entry) {
+                properties?.debug &&
+                    ((properties.debug.chunkManifestHeadMisses ||= {})[
+                        index
+                    ] =
                         ((properties.debug.chunkManifestHeadMisses ||= {})[
                             index
-                        ] =
-                            ((properties.debug.chunkManifestHeadMisses ||= {})[
-                                index
-                            ] ?? 0) + 1);
-                    return;
-                }
-                readContext.manifestHeadAvailable = true;
-            } finally {
-                if (readContext.manifestHeadProbe === manifestHeadProbe) {
-                    readContext.manifestHeadProbe = undefined;
-                }
-                releaseProbe?.();
+                        ] ?? 0) + 1);
+                return;
             }
 
             const operation = await entry.getPayloadValue();


### PR DESCRIPTION

## Summary
- stop treating one missing ready-manifest chunk entry head as proof that all manifest-head lookups are unavailable
- retry manifest-head lookup per chunk so transient public-relay/local-runner misses can recover during the existing read retry window
- reduce persisted remote read-ahead from 8 to 2 when the reader starts with only a partial local chunk set, avoiding congestion/starvation seen in 64 MB runs
- keep local persisted reads at read-ahead 32 and observer reads at read-ahead 2

## Why
The deployed 64 MB benchmark failure tracked in dao-xyz/peerbit#775 failed after the reader had already listed the ready file. The first fix addressed the manifest-head miss poisoning smell, but a GitHub local 64 MB benchmark still failed at chunk 23/128: several chunks spent minutes unresolved while many remote lookups were in flight. Reducing only the remote persisted read-ahead targets that congestion without slowing already-local reads.

## Validation
- `pnpm --filter @peerbit/please-lib exec vitest run src/__tests__/index.integration.test.ts -t "pipelines persisted chunk reads"`
- `pnpm --filter @peerbit/please-lib exec vitest run src/__tests__/index.integration.test.ts -t "ready manifest chunk head|transient ready manifest"`
- `pnpm --filter @peerbit/please-lib run build`
- `git diff --check`
- local 64 MB adaptive benchmark before read-ahead reduction: upload 2633 ms, discovery 249 ms, download 5396 ms, readAhead 8, final local chunks 109/128
- local 64 MB adaptive benchmark after read-ahead reduction: upload 2627 ms, discovery 114 ms, download 5888 ms, readAhead 2, final local chunks 128/128

## Current status
Draft until the GitHub Actions 64 MB local adaptive benchmark passes on this branch.
