### PR TITLE
Add experimental Peerbit shared filesystem MVP

### DIFF
--- a/.github/workflows/shared-fs-ci.yml
+++ b/.github/workflows/shared-fs-ci.yml
@@ -1,0 +1,94 @@
+name: Shared FS CI
+
+on:
+    pull_request:
+        paths:
+            - ".github/workflows/shared-fs-ci.yml"
+            - "package.json"
+            - "pnpm-lock.yaml"
+            - "tsconfig.json"
+            - "vitest.config.ts"
+            - "vitest.setup.ts"
+            - "packages/shared-fs/**"
+    push:
+        branches: [master]
+        paths:
+            - ".github/workflows/shared-fs-ci.yml"
+            - "package.json"
+            - "pnpm-lock.yaml"
+            - "tsconfig.json"
+            - "vitest.config.ts"
+            - "vitest.setup.ts"
+            - "packages/shared-fs/**"
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    portable:
+        name: Portable shared-fs tests (${{ matrix.os }})
+        runs-on: ${{ matrix.os }}
+        timeout-minutes: 30
+        strategy:
+            fail-fast: false
+            matrix:
+                os:
+                    - ubuntu-latest
+                    - macos-latest
+                    - windows-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  run_install: false
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: pnpm
+                  cache-dependency-path: pnpm-lock.yaml
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build shared-fs packages
+              run: pnpm -r --sort --filter @peerbit/shared-fs --filter @peerbit/shared-fs-cli run build
+
+            - name: Test shared-fs library
+              run: pnpm --filter @peerbit/shared-fs run test
+
+            - name: Test shared-fs CLI
+              run: pnpm --filter @peerbit/shared-fs-cli run test
+
+    format:
+        name: Shared-fs formatting
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  run_install: false
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: pnpm
+                  cache-dependency-path: pnpm-lock.yaml
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Check formatting
+              run: pnpm exec prettier --check packages/shared-fs

--- a/.github/workflows/shared-fs-ci.yml
+++ b/.github/workflows/shared-fs-ci.yml
@@ -54,6 +54,10 @@ jobs:
                   cache: pnpm
                   cache-dependency-path: pnpm-lock.yaml
 
+            - name: Use Bash for pnpm scripts on Windows
+              if: runner.os == 'Windows'
+              run: pnpm config set script-shell "C:\\Program Files\\Git\\bin\\bash.exe"
+
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/shared-fs-cross-os-interop.yml
+++ b/.github/workflows/shared-fs-cross-os-interop.yml
@@ -1,0 +1,177 @@
+name: Shared FS Cross-OS Interop
+
+on:
+    pull_request:
+        paths:
+            - ".github/workflows/shared-fs-cross-os-interop.yml"
+            - "package.json"
+            - "pnpm-lock.yaml"
+            - "tsconfig.json"
+            - "vitest.config.ts"
+            - "vitest.setup.ts"
+            - "packages/shared-fs/**"
+    workflow_dispatch:
+        inputs:
+            timeout_minutes:
+                description: "How long each peer waits for all OS files"
+                required: true
+                type: number
+                default: 10
+
+permissions:
+    actions: read
+    contents: read
+
+env:
+    INTEROP_TIMEOUT_MINUTES: ${{ github.event_name == 'workflow_dispatch' && inputs.timeout_minutes || '10' }}
+
+jobs:
+    seed-linux:
+        name: Seed peer (linux)
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  run_install: false
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: pnpm
+                  cache-dependency-path: pnpm-lock.yaml
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build shared-fs packages
+              run: pnpm -r --sort --filter @peerbit/shared-fs --filter @peerbit/shared-fs-cli run build
+
+            - name: Start seed peer
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  mkdir -p shared-fs-address interop-logs
+                  timeout_ms=$((INTEROP_TIMEOUT_MINUTES * 60 * 1000))
+                  (
+                    node packages/shared-fs/cli/lib/esm/cross-os-interop.js \
+                      --role seed \
+                      --machine linux \
+                      --expected linux,macos,windows \
+                      --address-file shared-fs-address/address.txt \
+                      --timeout-ms "$timeout_ms" \
+                      --directory .peerbit-shared-fs-interop-linux \
+                      > interop-logs/linux-seed.log 2>&1
+                    echo "$?" > interop-logs/linux-seed.exit
+                  ) &
+                  echo "$!" > interop-logs/linux-seed.pid
+
+                  for _ in {1..120}; do
+                    if test -s shared-fs-address/address.txt; then
+                      cat shared-fs-address/address.txt
+                      exit 0
+                    fi
+                    if ! kill -0 "$(cat interop-logs/linux-seed.pid)" 2>/dev/null; then
+                      cat interop-logs/linux-seed.log
+                      exit 1
+                    fi
+                    sleep 2
+                  done
+
+                  cat interop-logs/linux-seed.log
+                  echo "Timed out waiting for seed address"
+                  exit 1
+
+            - name: Upload shared filesystem address
+              uses: actions/upload-artifact@v4
+              with:
+                  name: shared-fs-address
+                  path: shared-fs-address/address.txt
+                  if-no-files-found: error
+
+            - name: Wait for all OS peers
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  while ! test -f interop-logs/linux-seed.exit; do
+                    tail -n 40 interop-logs/linux-seed.log || true
+                    sleep 10
+                  done
+                  cat interop-logs/linux-seed.log
+                  exit "$(cat interop-logs/linux-seed.exit)"
+
+    join:
+        name: Join peer (${{ matrix.machine }})
+        runs-on: ${{ matrix.os }}
+        timeout-minutes: 20
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - os: macos-latest
+                      machine: macos
+                    - os: windows-latest
+                      machine: windows
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  run_install: false
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: pnpm
+                  cache-dependency-path: pnpm-lock.yaml
+
+            - name: Use Bash for pnpm scripts on Windows
+              if: runner.os == 'Windows'
+              run: pnpm config set script-shell "C:\\Program Files\\Git\\bin\\bash.exe"
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build shared-fs packages
+              run: pnpm -r --sort --filter @peerbit/shared-fs --filter @peerbit/shared-fs-cli run build
+
+            - name: Download seed address
+              shell: bash
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  set -euo pipefail
+                  mkdir -p shared-fs-address
+                  for _ in {1..120}; do
+                    rm -f shared-fs-address/address.txt
+                    if gh run download "$GITHUB_RUN_ID" -n shared-fs-address -D shared-fs-address >/dev/null 2>&1 && test -s shared-fs-address/address.txt; then
+                      cat shared-fs-address/address.txt
+                      exit 0
+                    fi
+                    sleep 5
+                  done
+                  echo "Timed out waiting for seed address artifact"
+                  exit 1
+
+            - name: Join shared filesystem
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  timeout_ms=$((INTEROP_TIMEOUT_MINUTES * 60 * 1000))
+                  node packages/shared-fs/cli/lib/esm/cross-os-interop.js \
+                    --role join \
+                    --machine "${{ matrix.machine }}" \
+                    --expected linux,macos,windows \
+                    --address-file shared-fs-address/address.txt \
+                    --timeout-ms "$timeout_ms" \
+                    --directory ".peerbit-shared-fs-interop-${{ matrix.machine }}"

--- a/.github/workflows/shared-fs-native-smoke.yml
+++ b/.github/workflows/shared-fs-native-smoke.yml
@@ -1,0 +1,52 @@
+name: Shared FS Native Smoke
+
+on:
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    linux-fuse:
+        name: Linux FUSE native smoke
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  run_install: false
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: pnpm
+                  cache-dependency-path: pnpm-lock.yaml
+
+            - name: Install FUSE
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y fuse3 libfuse3-dev
+                  sudo modprobe fuse || true
+                  if test -e /dev/fuse; then
+                    sudo chmod 666 /dev/fuse
+                  fi
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Install optional native adapter
+              run: npm --prefix packages/shared-fs/library install --no-save --package-lock=false fuse-native@2.2.6
+
+            - name: Build shared-fs packages
+              run: pnpm -r --sort --filter @peerbit/shared-fs --filter @peerbit/shared-fs-cli run build
+
+            - name: Run native mount smoke
+              env:
+                  PEERBIT_SHARED_FS_NATIVE_SMOKE: "1"
+              run: pnpm --filter @peerbit/shared-fs exec vitest run src/__tests__/native-mount.smoke.test.ts

--- a/packages/shared-fs/cli/README.md
+++ b/packages/shared-fs/cli/README.md
@@ -7,8 +7,13 @@ peerbit-fs create
 peerbit-fs mount <address> <mountpoint>
 peerbit-fs status [address]
 peerbit-fs conflicts <address>
+peerbit-fs benchmark [address]
 peerbit-fs unmount <mountpoint>
 ```
+
+`benchmark` writes and reads one large file plus a configurable many-small-files
+workload. It is a baseline for tracking regressions, not a claim that v0 is
+optimized for code workspaces.
 
 Linux/macOS mounts require FUSE/macFUSE plus the optional `fuse-native` package.
 Windows requires a WinFsp adapter binary; the shared IPC/backend contract is in

--- a/packages/shared-fs/cli/README.md
+++ b/packages/shared-fs/cli/README.md
@@ -15,6 +15,12 @@ peerbit-fs unmount <mountpoint>
 workload. It is a baseline for tracking regressions, not a claim that v0 is
 optimized for code workspaces.
 
+`status` prints the current native mount adapter, whether its prerequisites are
+available on the host, and any missing pieces before optionally opening an
+address.
+
 Linux/macOS mounts require FUSE/macFUSE plus the optional `fuse-native` package.
 Windows requires a WinFsp adapter binary; the shared IPC/backend contract is in
-place, but no WinFsp binary is bundled yet.
+place, but no WinFsp binary is bundled yet. The repo includes a manual
+`Shared FS Native Smoke` GitHub workflow for Linux FUSE. Portable CI still runs
+the backend and cross-OS shared-store checks on Linux, macOS, and Windows.

--- a/packages/shared-fs/cli/README.md
+++ b/packages/shared-fs/cli/README.md
@@ -1,0 +1,15 @@
+# Peerbit Shared FS CLI
+
+Experimental native mount CLI for `@peerbit/shared-fs`.
+
+```bash
+peerbit-fs create
+peerbit-fs mount <address> <mountpoint>
+peerbit-fs status [address]
+peerbit-fs conflicts <address>
+peerbit-fs unmount <mountpoint>
+```
+
+Linux/macOS mounts require FUSE/macFUSE plus the optional `fuse-native` package.
+Windows requires a WinFsp adapter binary; the shared IPC/backend contract is in
+place, but no WinFsp binary is bundled yet.

--- a/packages/shared-fs/cli/package.json
+++ b/packages/shared-fs/cli/package.json
@@ -1,0 +1,50 @@
+{
+    "name": "@peerbit/shared-fs-cli",
+    "version": "0.0.1",
+    "author": "dao.xyz",
+    "repository": "https://github.com/@dao-xyz/peerbit-examples",
+    "license": "Apache-2.0",
+    "type": "module",
+    "private": false,
+    "publishConfig": {
+        "access": "public"
+    },
+    "sideEffects": false,
+    "module": "lib/esm/index.js",
+    "types": "lib/esm/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./lib/esm/index.d.ts",
+            "import": "./lib/esm/index.js"
+        }
+    },
+    "bin": {
+        "peerbit-fs": "./lib/esm/bin.js"
+    },
+    "files": [
+        "lib",
+        "src",
+        "!src/**/__tests__",
+        "!lib/**/__tests__",
+        "LICENSE"
+    ],
+    "engines": {
+        "node": ">=18"
+    },
+    "scripts": {
+        "clean": "shx rm -rf lib/*",
+        "build": "pnpm run clean && tsc -p tsconfig.json",
+        "test": "vitest run",
+        "test:watch": "vitest"
+    },
+    "dependencies": {
+        "@multiformats/multiaddr": "^13.0.1",
+        "@peerbit/shared-fs": "workspace:*",
+        "chalk": "^5.3.0",
+        "peerbit": "^5",
+        "yargs": "^17.7.2"
+    },
+    "devDependencies": {
+        "typescript": "^5.6.3"
+    }
+}

--- a/packages/shared-fs/cli/src/__tests__/index.test.ts
+++ b/packages/shared-fs/cli/src/__tests__/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { runCli } from "../index.js";
+
+describe("peerbit-fs cli", () => {
+    it("exports the CLI entry point", () => {
+        expect(runCli).toBeTypeOf("function");
+    });
+});

--- a/packages/shared-fs/cli/src/bin.ts
+++ b/packages/shared-fs/cli/src/bin.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { runCli } from "./index.js";
+
+runCli().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+});

--- a/packages/shared-fs/cli/src/cross-os-interop.ts
+++ b/packages/shared-fs/cli/src/cross-os-interop.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { openSharedFs } from "@peerbit/shared-fs";
+import { Peerbit } from "peerbit";
+
+type Options = {
+    role: "seed" | "join";
+    machine: string;
+    expected: string[];
+    addressFile: string;
+    timeoutMs: number;
+    directory?: string;
+};
+
+const parseArgs = (args: string[]): Options => {
+    const value = (name: string) => {
+        const index = args.indexOf(name);
+        return index === -1 ? undefined : args[index + 1];
+    };
+    const role = value("--role");
+    if (role !== "seed" && role !== "join") {
+        throw new Error("--role must be seed or join");
+    }
+    const machine = value("--machine");
+    if (!machine) {
+        throw new Error("--machine is required");
+    }
+    const addressFile = value("--address-file");
+    if (!addressFile) {
+        throw new Error("--address-file is required");
+    }
+    return {
+        role,
+        machine,
+        expected: (value("--expected") ?? "linux,macos,windows")
+            .split(",")
+            .map((entry) => entry.trim())
+            .filter(Boolean),
+        addressFile,
+        timeoutMs: Number(value("--timeout-ms") ?? 10 * 60 * 1000),
+        directory: value("--directory"),
+    };
+};
+
+const decode = (value: Uint8Array | undefined) =>
+    value ? new TextDecoder().decode(value) : undefined;
+
+const waitUntil = async (
+    assertion: () => Promise<void> | void,
+    timeoutMs: number,
+    intervalMs = 2_000
+) => {
+    const deadline = Date.now() + timeoutMs;
+    let lastError: unknown;
+    while (Date.now() < deadline) {
+        try {
+            await assertion();
+            return;
+        } catch (error) {
+            lastError = error;
+            await new Promise((resolve) => setTimeout(resolve, intervalMs));
+        }
+    }
+    throw lastError;
+};
+
+const filePathForMachine = (machine: string) => `/${machine}.txt`;
+
+const waitForAllMachines = async (
+    fs: Awaited<ReturnType<typeof openSharedFs>>,
+    expected: string[],
+    timeoutMs: number
+) => {
+    await waitUntil(async () => {
+        const missing: string[] = [];
+        for (const machine of expected) {
+            const contents = decode(
+                await fs.readFile(filePathForMachine(machine))
+            );
+            if (contents !== `hello from ${machine}`) {
+                missing.push(machine);
+            }
+        }
+        if (missing.length > 0) {
+            throw new Error(`Missing files from: ${missing.join(", ")}`);
+        }
+    }, timeoutMs);
+};
+
+const main = async () => {
+    const options = parseArgs(process.argv.slice(2));
+    const peer = await Peerbit.create({ directory: options.directory });
+    try {
+        await peer.bootstrap();
+        const address =
+            options.role === "join"
+                ? (await readFile(options.addressFile, "utf8")).trim()
+                : undefined;
+        const fs = await openSharedFs({
+            peerbit: peer,
+            address,
+            machineLabel: options.machine,
+        });
+
+        if (options.role === "seed") {
+            await mkdir(path.dirname(options.addressFile), { recursive: true });
+            await writeFile(options.addressFile, fs.address ?? "", "utf8");
+            console.log(`seed address: ${fs.address}`);
+        } else {
+            console.log(`joining address: ${address}`);
+        }
+
+        await fs.writeFile(
+            filePathForMachine(options.machine),
+            `hello from ${options.machine}`
+        );
+        await waitForAllMachines(fs, options.expected, options.timeoutMs);
+        console.log(
+            `read files from all machines: ${options.expected.join(", ")}`
+        );
+    } finally {
+        await peer.stop();
+    }
+};
+
+main().catch((error) => {
+    console.error(
+        error instanceof Error ? error.stack || error.message : error
+    );
+    process.exitCode = 1;
+});

--- a/packages/shared-fs/cli/src/index.ts
+++ b/packages/shared-fs/cli/src/index.ts
@@ -5,6 +5,7 @@ import {
     createSharedFsMountBackend,
     mountNativeSharedFs,
     openSharedFs,
+    runSharedFsBenchmark,
     unmountNativeMountpoint,
 } from "@peerbit/shared-fs";
 import { multiaddr } from "@multiformats/multiaddr";
@@ -110,6 +111,25 @@ const printNativeRequirements = () => {
     console.log("linux: libfuse/FUSE plus the optional fuse-native package");
     console.log("macOS: macFUSE plus the optional fuse-native package");
     console.log("windows: WinFsp adapter binary is required");
+};
+
+const printBenchmarkResult = (
+    result: Awaited<ReturnType<typeof runSharedFsBenchmark>>
+) => {
+    console.log(chalk.bold(`benchmark root: ${result.root}`));
+    console.log(
+        `large write: ${result.largeFile.writeMs}ms ${result.largeFile.writeMbps.toFixed(2)} Mbps`
+    );
+    console.log(
+        `large read:  ${result.largeFile.readMs}ms ${result.largeFile.readMbps.toFixed(2)} Mbps`
+    );
+    console.log(
+        `small write: ${result.smallFiles.writeMs}ms ${result.smallFiles.filesPerSecondWrite.toFixed(2)} files/s`
+    );
+    console.log(`small list:  ${result.smallFiles.listMs}ms`);
+    console.log(
+        `small read:  ${result.smallFiles.readMs}ms ${result.smallFiles.filesPerSecondRead.toFixed(2)} files/s`
+    );
 };
 
 const openCliFs = async (
@@ -298,6 +318,74 @@ export const runCli = async (args = hideBin(process.argv)) => {
                                 `  ${version.id} ${version.size} bytes ${version.machineLabel} ${version.authorKey}`
                             );
                         }
+                    }
+                } finally {
+                    await stopPeerbitForCli(peerbit);
+                }
+            }
+        )
+        .command(
+            "benchmark [address]",
+            "run a baseline large-file and many-small-files workload",
+            (command) =>
+                command
+                    .positional("address", {
+                        type: "string",
+                    })
+                    .option("large-size", {
+                        type: "number",
+                        default: 16 * 1024 * 1024,
+                        description: "Large file size in bytes.",
+                    })
+                    .option("small-files", {
+                        type: "number",
+                        default: 200,
+                        description: "Number of small files to write and read.",
+                    })
+                    .option("small-size", {
+                        type: "number",
+                        default: 1024,
+                        description: "Small file size in bytes.",
+                    })
+                    .option("root", {
+                        type: "string",
+                        description:
+                            "Benchmark root path inside the shared filesystem.",
+                    })
+                    .option("cleanup", {
+                        type: "boolean",
+                        default: false,
+                        description:
+                            "Delete benchmark files after metrics are collected.",
+                    })
+                    .option("json", {
+                        type: "boolean",
+                        default: false,
+                        description: "Print machine-readable JSON.",
+                    }),
+            async (argv) => {
+                const directory = resolveDirectory(argv.directory);
+                const peerbit = await Peerbit.create({ directory });
+                try {
+                    if (argv.address) {
+                        await connectToNetwork(peerbit, argv.peer);
+                    }
+                    const fsHandle = await openCliFs(peerbit, {
+                        address: argv.address,
+                        machineLabel: argv.machine,
+                        replicate: argv.replicate,
+                    });
+                    const result = await runSharedFsBenchmark(fsHandle, {
+                        root: argv.root,
+                        largeFileSize: argv.largeSize,
+                        smallFileCount: argv.smallFiles,
+                        smallFileSize: argv.smallSize,
+                        cleanup: argv.cleanup,
+                    });
+                    if (argv.json) {
+                        console.log(JSON.stringify(result, null, 2));
+                    } else {
+                        printBenchmarkResult(result);
                     }
                 } finally {
                     await stopPeerbitForCli(peerbit);

--- a/packages/shared-fs/cli/src/index.ts
+++ b/packages/shared-fs/cli/src/index.ts
@@ -1,0 +1,326 @@
+import {
+    NativeMountUnavailableError,
+    createSharedFsIpcClient,
+    createSharedFsIpcServer,
+    createSharedFsMountBackend,
+    mountNativeSharedFs,
+    openSharedFs,
+    unmountNativeMountpoint,
+} from "@peerbit/shared-fs";
+import { multiaddr } from "@multiformats/multiaddr";
+import chalk from "chalk";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Peerbit } from "peerbit";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+const DEFAULT_DIRECTORY_NAME = "peerbit-shared-fs";
+const CLI_REPLICATION_ARGS = {
+    replicate: {
+        limits: {
+            cpu: {
+                max: 1,
+                monitor: undefined,
+            },
+        },
+    },
+} as const;
+
+type CliProgramArgs =
+    | typeof CLI_REPLICATION_ARGS
+    | {
+          replicate: false;
+      };
+
+const resolveDirectory = (directoryArg?: string) => {
+    if (directoryArg === undefined) {
+        const directory = path.join(os.homedir(), DEFAULT_DIRECTORY_NAME);
+        fs.mkdirSync(directory, { recursive: true });
+        return directory;
+    }
+    if (directoryArg === "" || directoryArg === "null") {
+        return undefined;
+    }
+    fs.mkdirSync(directoryArg, { recursive: true });
+    return directoryArg;
+};
+
+const coerceAddresses = (addrs: string | string[]) => {
+    return (Array.isArray(addrs) ? addrs : [addrs]).map((address) =>
+        multiaddr(address)
+    );
+};
+
+const connectToNetwork = async (peerbit: Peerbit, peer?: string | string[]) => {
+    if (peer) {
+        await peerbit.dial(coerceAddresses(peer));
+        return;
+    }
+    await peerbit.bootstrap();
+};
+
+const stopPeerbitForCli = async (
+    peerbit: Peerbit,
+    options?: { timeoutMs?: number }
+) => {
+    const timeoutMs = options?.timeoutMs ?? 10_000;
+    const timer = setTimeout(() => {
+        console.warn(
+            chalk.yellow(
+                `Peer shutdown exceeded ${Math.round(timeoutMs / 1000)} seconds, forcing CLI exit.`
+            )
+        );
+        process.exit(process.exitCode ?? 0);
+    }, timeoutMs);
+    timer.unref?.();
+
+    try {
+        await peerbit.stop();
+    } finally {
+        clearTimeout(timer);
+    }
+};
+
+const waitForTermination = async (stop: () => Promise<void>) => {
+    await new Promise<void>((resolve, reject) => {
+        let settled = false;
+        const keepAlive = setInterval(() => {}, 1 << 30);
+        const finish = async () => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            clearInterval(keepAlive);
+            try {
+                await stop();
+                resolve();
+            } catch (error) {
+                reject(error);
+            }
+        };
+        process.once("SIGINT", finish);
+        process.once("SIGTERM", finish);
+    });
+};
+
+const printNativeRequirements = () => {
+    console.log(chalk.bold("Native mount requirements"));
+    console.log("linux: libfuse/FUSE plus the optional fuse-native package");
+    console.log("macOS: macFUSE plus the optional fuse-native package");
+    console.log("windows: WinFsp adapter binary is required");
+};
+
+const openCliFs = async (
+    peerbit: Peerbit,
+    options: {
+        address?: string;
+        machineLabel?: string;
+        replicate?: boolean;
+    }
+) => {
+    const programArgs: CliProgramArgs =
+        options.replicate === false
+            ? { replicate: false }
+            : CLI_REPLICATION_ARGS;
+    return openSharedFs({
+        peerbit,
+        address: options.address,
+        machineLabel: options.machineLabel || os.hostname(),
+        ...programArgs,
+    });
+};
+
+export const runCli = async (args = hideBin(process.argv)) => {
+    await yargs(args)
+        .scriptName("peerbit-fs")
+        .option("directory", {
+            alias: "d",
+            type: "string",
+            description:
+                "Peerbit state directory. Use an empty string for in-memory state.",
+        })
+        .option("machine", {
+            type: "string",
+            description: "Machine label stored on every signed file version.",
+        })
+        .option("peer", {
+            type: "string",
+            array: true,
+            description:
+                "Multiaddr peer to dial before opening a shared filesystem.",
+        })
+        .option("replicate", {
+            type: "boolean",
+            default: true,
+            description:
+                "Help replicate remote data. Disable with --no-replicate.",
+        })
+        .command(
+            "create",
+            "create a new experimental shared filesystem",
+            (command) => command,
+            async (argv) => {
+                const directory = resolveDirectory(argv.directory);
+                const peerbit = await Peerbit.create({ directory });
+                try {
+                    const fsHandle = await openCliFs(peerbit, {
+                        machineLabel: argv.machine,
+                        replicate: argv.replicate,
+                    });
+                    console.log(fsHandle.address);
+                } finally {
+                    await stopPeerbitForCli(peerbit);
+                }
+            }
+        )
+        .command(
+            "mount <address> <mountpoint>",
+            "mount a shared filesystem using the native adapter",
+            (command) =>
+                command
+                    .positional("address", {
+                        type: "string",
+                        demandOption: true,
+                    })
+                    .positional("mountpoint", {
+                        type: "string",
+                        demandOption: true,
+                    }),
+            async (argv) => {
+                const directory = resolveDirectory(argv.directory);
+                const peerbit = await Peerbit.create({ directory });
+                let ipc:
+                    | Awaited<ReturnType<typeof createSharedFsIpcServer>>
+                    | undefined;
+                let mounted:
+                    | Awaited<ReturnType<typeof mountNativeSharedFs>>
+                    | undefined;
+                try {
+                    await connectToNetwork(peerbit, argv.peer);
+                    const fsHandle = await openCliFs(peerbit, {
+                        address: argv.address,
+                        machineLabel: argv.machine,
+                        replicate: argv.replicate,
+                    });
+                    const backend = createSharedFsMountBackend(fsHandle);
+                    ipc = await createSharedFsIpcServer(backend);
+                    mounted = await mountNativeSharedFs(
+                        createSharedFsIpcClient(ipc.endpoint),
+                        {
+                            mountpoint: path.resolve(String(argv.mountpoint)),
+                        }
+                    );
+                    console.log(
+                        chalk.green(
+                            `Mounted ${fsHandle.address} at ${mounted.mountpoint}`
+                        )
+                    );
+                    console.log(`IPC endpoint: ${ipc.endpoint}`);
+                    await waitForTermination(async () => {
+                        await mounted?.unmount();
+                        await ipc?.close();
+                        await stopPeerbitForCli(peerbit);
+                    });
+                } catch (error) {
+                    await mounted?.unmount().catch(() => {});
+                    await ipc?.close().catch(() => {});
+                    await stopPeerbitForCli(peerbit).catch(() => {});
+                    if (error instanceof NativeMountUnavailableError) {
+                        console.error(chalk.red(error.message));
+                        printNativeRequirements();
+                        process.exitCode = 1;
+                        return;
+                    }
+                    throw error;
+                }
+            }
+        )
+        .command(
+            "status [address]",
+            "show local adapter requirements and optional filesystem status",
+            (command) =>
+                command.positional("address", {
+                    type: "string",
+                }),
+            async (argv) => {
+                printNativeRequirements();
+                if (!argv.address) {
+                    return;
+                }
+                const directory = resolveDirectory(argv.directory);
+                const peerbit = await Peerbit.create({ directory });
+                try {
+                    await connectToNetwork(peerbit, argv.peer);
+                    const fsHandle = await openCliFs(peerbit, {
+                        address: argv.address,
+                        machineLabel: argv.machine,
+                        replicate: argv.replicate,
+                    });
+                    const rootEntries = await fsHandle.list("/");
+                    const conflicts = await fsHandle.conflicts();
+                    console.log(`address: ${fsHandle.address}`);
+                    console.log(`root entries: ${rootEntries.length}`);
+                    console.log(`conflicts: ${conflicts.length}`);
+                } finally {
+                    await stopPeerbitForCli(peerbit);
+                }
+            }
+        )
+        .command(
+            "conflicts <address>",
+            "list visible conflict versions",
+            (command) =>
+                command.positional("address", {
+                    type: "string",
+                    demandOption: true,
+                }),
+            async (argv) => {
+                const directory = resolveDirectory(argv.directory);
+                const peerbit = await Peerbit.create({ directory });
+                try {
+                    await connectToNetwork(peerbit, argv.peer);
+                    const fsHandle = await openCliFs(peerbit, {
+                        address: argv.address,
+                        machineLabel: argv.machine,
+                        replicate: argv.replicate,
+                    });
+                    const conflicts = await fsHandle.conflicts();
+                    if (conflicts.length === 0) {
+                        console.log("No conflicts");
+                        return;
+                    }
+                    for (const conflict of conflicts) {
+                        console.log(chalk.bold(conflict.path));
+                        for (const version of conflict.versions) {
+                            console.log(
+                                `  ${version.id} ${version.size} bytes ${version.machineLabel} ${version.authorKey}`
+                            );
+                        }
+                    }
+                } finally {
+                    await stopPeerbitForCli(peerbit);
+                }
+            }
+        )
+        .command(
+            "unmount <mountpoint>",
+            "unmount a native shared filesystem mountpoint",
+            (command) =>
+                command.positional("mountpoint", {
+                    type: "string",
+                    demandOption: true,
+                }),
+            async (argv) => {
+                await unmountNativeMountpoint(
+                    path.resolve(String(argv.mountpoint))
+                );
+                console.log(chalk.green(`Unmounted ${argv.mountpoint}`));
+            }
+        )
+        .demandCommand(1)
+        .strict()
+        .help()
+        .parseAsync();
+};

--- a/packages/shared-fs/cli/src/index.ts
+++ b/packages/shared-fs/cli/src/index.ts
@@ -3,6 +3,7 @@ import {
     createSharedFsIpcClient,
     createSharedFsIpcServer,
     createSharedFsMountBackend,
+    getNativeMountSupport,
     mountNativeSharedFs,
     openSharedFs,
     runSharedFsBenchmark,
@@ -106,7 +107,22 @@ const waitForTermination = async (stop: () => Promise<void>) => {
     });
 };
 
-const printNativeRequirements = () => {
+const printNativeRequirements = async () => {
+    const support = await getNativeMountSupport();
+    console.log(chalk.bold("Native mount status"));
+    console.log(`platform: ${support.platform}`);
+    console.log(`adapter: ${support.adapter}`);
+    console.log(`available: ${support.available ? "yes" : "no"}`);
+    if (support.missing.length > 0) {
+        console.log("missing:");
+        for (const item of support.missing) {
+            console.log(`  - ${item}`);
+        }
+    }
+    for (const note of support.notes) {
+        console.log(`note: ${note}`);
+    }
+    console.log("");
     console.log(chalk.bold("Native mount requirements"));
     console.log("linux: libfuse/FUSE plus the optional fuse-native package");
     console.log("macOS: macFUSE plus the optional fuse-native package");
@@ -249,7 +265,7 @@ export const runCli = async (args = hideBin(process.argv)) => {
                     await stopPeerbitForCli(peerbit).catch(() => {});
                     if (error instanceof NativeMountUnavailableError) {
                         console.error(chalk.red(error.message));
-                        printNativeRequirements();
+                        await printNativeRequirements();
                         process.exitCode = 1;
                         return;
                     }
@@ -265,7 +281,7 @@ export const runCli = async (args = hideBin(process.argv)) => {
                     type: "string",
                 }),
             async (argv) => {
-                printNativeRequirements();
+                await printNativeRequirements();
                 if (!argv.address) {
                     return;
                 }

--- a/packages/shared-fs/cli/tsconfig.json
+++ b/packages/shared-fs/cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src"],
+    "exclude": ["src/__tests__"],
+    "compilerOptions": {
+        "noEmit": false,
+        "outDir": "lib/esm"
+    }
+}

--- a/packages/shared-fs/cli/vitest.setup.ts
+++ b/packages/shared-fs/cli/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "../../../vitest.setup.ts";

--- a/packages/shared-fs/library/README.md
+++ b/packages/shared-fs/library/README.md
@@ -53,6 +53,8 @@ work; v0 does not optimize the small-file workload yet.
 The TypeScript Peerbit side exposes a small POSIX-ish backend and a local
 JSON-lines IPC protocol with `getattr`, `readdir`, `open`, `read`, `write`,
 `flush`, `fsync`, `release`, `mkdir`, `rmdir`, `rename`, and `unlink`.
+Run `peerbit-fs status` to report the current host platform, selected adapter,
+and any missing native mount prerequisites.
 
 The first adapter path is intentionally experimental:
 
@@ -60,6 +62,13 @@ The first adapter path is intentionally experimental:
 - macOS requires macFUSE and the optional `fuse-native` package.
 - Windows requires a WinFsp adapter binary; the shared IPC contract is present,
   but this package does not bundle that binary yet.
+
+Portable CI covers the shared backend and IPC contract on Linux, macOS, and
+Windows, plus a cross-OS interop workflow where all three runners join one
+shared filesystem address and read each other's files. The native Linux FUSE
+smoke can be run manually with the `Shared FS Native Smoke` workflow. macOS and
+Windows native mount smoke tests need runners with macFUSE/WinFsp installed and
+are left as adapter hardening work.
 
 ## Conflicts
 

--- a/packages/shared-fs/library/README.md
+++ b/packages/shared-fs/library/README.md
@@ -1,0 +1,64 @@
+# Peerbit Shared FS
+
+Experimental shared filesystem primitives for Peerbit.
+
+This package is intentionally marked experimental. It provides the Peerbit-backed
+metadata and content model used by the `peerbit-fs` CLI and native mount adapters.
+
+```ts
+import { openSharedFs } from "@peerbit/shared-fs";
+import { Peerbit } from "peerbit";
+
+const peerbit = await Peerbit.create({ directory: "./peerbit-fs-state" });
+const fs = await openSharedFs({
+    peerbit,
+    machineLabel: "workstation-a",
+});
+
+await fs.mkdir("/docs");
+await fs.writeFile("/docs/hello.txt", new TextEncoder().encode("hello"));
+console.log(await fs.readFile("/docs/hello.txt"));
+console.log(fs.address);
+```
+
+The v0 model is commit-on-close for mounted writes, local-first, and conflict
+preserving. Concurrent versions are never overwritten silently; they are exposed
+through `conflicts()` and can be resolved with `resolveConflict()`.
+
+## CLI
+
+The companion `@peerbit/shared-fs-cli` package installs `peerbit-fs`:
+
+```bash
+peerbit-fs create
+peerbit-fs mount <address> <mountpoint>
+peerbit-fs status [address]
+peerbit-fs conflicts <address>
+peerbit-fs unmount <mountpoint>
+```
+
+Mounted writes are buffered by the native adapter and committed as one signed
+Peerbit file version on `flush`, `fsync`, or `release`/close.
+
+## Native Mounts
+
+The TypeScript Peerbit side exposes a small POSIX-ish backend and a local
+JSON-lines IPC protocol with `getattr`, `readdir`, `open`, `read`, `write`,
+`flush`, `fsync`, `release`, `mkdir`, `rmdir`, `rename`, and `unlink`.
+
+The first adapter path is intentionally experimental:
+
+- Linux requires FUSE/libfuse and the optional `fuse-native` package.
+- macOS requires macFUSE and the optional `fuse-native` package.
+- Windows requires a WinFsp adapter binary; the shared IPC contract is present,
+  but this package does not bundle that binary yet.
+
+## Conflicts
+
+Concurrent saves remain addressable versions. The visible file version is only
+a deterministic display choice. Conflicting versions are listed through
+`conflicts()` and exposed to mount adapters below:
+
+```text
+/.peerbit-conflicts/<encoded-path>/<version-id>
+```

--- a/packages/shared-fs/library/README.md
+++ b/packages/shared-fs/library/README.md
@@ -34,11 +34,19 @@ peerbit-fs create
 peerbit-fs mount <address> <mountpoint>
 peerbit-fs status [address]
 peerbit-fs conflicts <address>
+peerbit-fs benchmark [address]
 peerbit-fs unmount <mountpoint>
 ```
 
 Mounted writes are buffered by the native adapter and committed as one signed
 Peerbit file version on `flush`, `fsync`, or `release`/close.
+
+## Benchmark Baseline
+
+`runSharedFsBenchmark(fs)` and `peerbit-fs benchmark` run a simple baseline
+workload: one large file upload/download plus a many-small-files write/list/read
+pass. This is meant to track regressions and guide future agent/code workspace
+work; v0 does not optimize the small-file workload yet.
 
 ## Native Mounts
 

--- a/packages/shared-fs/library/package.json
+++ b/packages/shared-fs/library/package.json
@@ -1,0 +1,49 @@
+{
+    "name": "@peerbit/shared-fs",
+    "version": "0.0.1",
+    "author": "dao.xyz",
+    "repository": "https://github.com/@dao-xyz/peerbit-examples",
+    "license": "Apache-2.0",
+    "type": "module",
+    "private": false,
+    "publishConfig": {
+        "access": "public"
+    },
+    "sideEffects": false,
+    "module": "lib/esm/index.js",
+    "types": "lib/esm/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./lib/esm/index.d.ts",
+            "import": "./lib/esm/index.js"
+        }
+    },
+    "files": [
+        "lib",
+        "src",
+        "!src/**/__tests__",
+        "!lib/**/__tests__",
+        "LICENSE"
+    ],
+    "engines": {
+        "node": ">=18"
+    },
+    "scripts": {
+        "clean": "shx rm -rf lib/*",
+        "build": "pnpm run clean && tsc -p tsconfig.json",
+        "test": "vitest run",
+        "test:watch": "vitest"
+    },
+    "devDependencies": {
+        "@peerbit/test-utils": "^3.0.33",
+        "typescript": "^5.6.3"
+    },
+    "dependencies": {
+        "@dao-xyz/borsh": "^6.0.0",
+        "@peerbit/crypto": "^3",
+        "@peerbit/document": "^13",
+        "@peerbit/program": "^6",
+        "peerbit": "^5",
+        "uint8arrays": "^5.1.0"
+    }
+}

--- a/packages/shared-fs/library/src/__tests__/mount-backend.test.ts
+++ b/packages/shared-fs/library/src/__tests__/mount-backend.test.ts
@@ -1,0 +1,106 @@
+import { Peerbit } from "peerbit";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+    CONFLICTS_DIR,
+    createSharedFsIpcClient,
+    createSharedFsIpcServer,
+    createSharedFsMountBackend,
+    encodeConflictPathName,
+    openSharedFs,
+    type SharedFsHandle,
+} from "../index.js";
+
+const encode = (value: string) => new TextEncoder().encode(value);
+const decode = (value: Uint8Array | undefined) =>
+    value ? new TextDecoder().decode(value) : undefined;
+
+describe("shared fs mount backend", () => {
+    let peer: Peerbit;
+    let fs: SharedFsHandle;
+
+    beforeEach(async () => {
+        peer = await Peerbit.create();
+        fs = await openSharedFs({
+            peerbit: peer,
+            machineLabel: "mount-test",
+        });
+    });
+
+    afterEach(async () => {
+        await peer.stop();
+    });
+
+    it("commits buffered writes on release", async () => {
+        const backend = createSharedFsMountBackend(fs);
+        await backend.mkdir("/docs");
+        const handle = await backend.open("/docs/file.txt", {
+            write: true,
+            create: true,
+            truncate: true,
+        });
+
+        await backend.write(handle, encode("hello"), 0);
+        expect(await fs.readFile("/docs/file.txt")).toBeUndefined();
+
+        await backend.release(handle);
+        expect(decode(await fs.readFile("/docs/file.txt"))).toBe("hello");
+    });
+
+    it("exposes conflicts through the metadata namespace", async () => {
+        const backend = createSharedFsMountBackend(fs);
+        await fs.writeFile("/note.txt", "base");
+        const base = (await fs.versions("/note.txt"))
+            .filter((version) => version.head)
+            .map((version) => version.id);
+        const left = await fs.writeFile("/note.txt", "left", {
+            baseVersionIds: base,
+        });
+        const right = await fs.writeFile("/note.txt", "right", {
+            baseVersionIds: base,
+        });
+
+        expect(
+            (await backend.readdir("/")).map((entry) => entry.name)
+        ).toContain(CONFLICTS_DIR);
+        const conflictName = encodeConflictPathName("/note.txt");
+        expect(
+            (await backend.readdir(`/${CONFLICTS_DIR}`)).map(
+                (entry) => entry.name
+            )
+        ).toEqual([conflictName]);
+        expect(
+            (await backend.readdir(`/${CONFLICTS_DIR}/${conflictName}`))
+                .map((entry) => entry.name)
+                .sort()
+        ).toEqual([left.id, right.id].sort());
+
+        const handle = await backend.open(
+            `/${CONFLICTS_DIR}/${conflictName}/${right.id}`
+        );
+        expect(decode(await backend.read(handle, 1024, 0))).toBe("right");
+        await backend.release(handle);
+    });
+
+    it("round-trips backend calls through local IPC", async () => {
+        const backend = createSharedFsMountBackend(fs);
+        const server = await createSharedFsIpcServer(backend);
+        try {
+            const client = createSharedFsIpcClient(server.endpoint);
+            await client.mkdir("/ipc");
+            const handle = await client.open("/ipc/file.txt", {
+                write: true,
+                create: true,
+                truncate: true,
+            });
+            await client.write(handle, encode("over ipc"), 0);
+            await client.release(handle);
+
+            const stat = await client.getattr("/ipc/file.txt");
+            expect(stat.kind).toBe("file");
+            expect(stat.size).toBe("over ipc".length);
+            expect(decode(await fs.readFile("/ipc/file.txt"))).toBe("over ipc");
+        } finally {
+            await server.close();
+        }
+    });
+});

--- a/packages/shared-fs/library/src/__tests__/native-mount.smoke.test.ts
+++ b/packages/shared-fs/library/src/__tests__/native-mount.smoke.test.ts
@@ -1,0 +1,90 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Peerbit } from "peerbit";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+    NativeMountUnavailableError,
+    mountNativeSharedFs,
+    openSharedFs,
+} from "../index.js";
+
+const decode = (value: Uint8Array | undefined) =>
+    value ? new TextDecoder().decode(value) : undefined;
+
+const waitUntil = async (
+    assertion: () => Promise<void> | void,
+    options: { timeoutMs?: number; intervalMs?: number } = {}
+) => {
+    const timeoutMs = options.timeoutMs ?? 20_000;
+    const intervalMs = options.intervalMs ?? 100;
+    const deadline = Date.now() + timeoutMs;
+    let lastError: unknown;
+    while (Date.now() < deadline) {
+        try {
+            await assertion();
+            return;
+        } catch (error) {
+            lastError = error;
+            await new Promise((resolve) => setTimeout(resolve, intervalMs));
+        }
+    }
+    throw lastError;
+};
+
+const runNativeSmoke = process.env.PEERBIT_SHARED_FS_NATIVE_SMOKE === "1";
+
+(runNativeSmoke ? describe : describe.skip)(
+    "shared fs native mount smoke",
+    () => {
+        let peer: Peerbit | undefined;
+        let mountpoint: string | undefined;
+
+        afterEach(async () => {
+            await peer?.stop();
+            if (mountpoint) {
+                await rm(mountpoint, { force: true, recursive: true });
+            }
+        });
+
+        it("mounts, writes with native fs calls, reads back, and unmounts", async () => {
+            peer = await Peerbit.create();
+            const fs = await openSharedFs({
+                peerbit: peer,
+                machineLabel: "native-smoke",
+            });
+            mountpoint = await mkdtemp(
+                path.join(tmpdir(), "peerbit-shared-fs-")
+            );
+
+            let session:
+                | Awaited<ReturnType<typeof mountNativeSharedFs>>
+                | undefined;
+            try {
+                session = await mountNativeSharedFs(fs, { mountpoint });
+                await writeFile(
+                    path.join(mountpoint, "hello.txt"),
+                    "hello native"
+                );
+
+                await waitUntil(async () => {
+                    expect(decode(await fs.readFile("/hello.txt"))).toBe(
+                        "hello native"
+                    );
+                });
+                expect(
+                    await readFile(path.join(mountpoint, "hello.txt"), "utf8")
+                ).toBe("hello native");
+            } catch (error) {
+                if (error instanceof NativeMountUnavailableError) {
+                    throw new Error(
+                        `Native smoke requested but adapter is unavailable: ${error.message}`
+                    );
+                }
+                throw error;
+            } finally {
+                await session?.unmount();
+            }
+        });
+    }
+);

--- a/packages/shared-fs/library/src/__tests__/native-mount.test.ts
+++ b/packages/shared-fs/library/src/__tests__/native-mount.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { getNativeMountSupport } from "../index.js";
+
+describe("native mount support detection", () => {
+    it("reports adapter availability without throwing", async () => {
+        const support = await getNativeMountSupport();
+        expect(support.platform).toBe(process.platform);
+        expect(support.adapter).toMatch(/^(fuse-native|winfsp|unsupported)$/);
+        expect(support.available).toBeTypeOf("boolean");
+        expect(Array.isArray(support.missing)).toBe(true);
+        expect(Array.isArray(support.notes)).toBe(true);
+    });
+});

--- a/packages/shared-fs/library/src/__tests__/shared-fs.test.ts
+++ b/packages/shared-fs/library/src/__tests__/shared-fs.test.ts
@@ -1,0 +1,99 @@
+import { Peerbit } from "peerbit";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+    DEFAULT_FILE_CHUNK_SIZE,
+    openSharedFs,
+    type SharedFsHandle,
+} from "../index.js";
+
+const encode = (value: string) => new TextEncoder().encode(value);
+const decode = (value: Uint8Array | undefined) =>
+    value ? new TextDecoder().decode(value) : undefined;
+
+const patternedBytes = (size: number) => {
+    const bytes = new Uint8Array(size);
+    for (let i = 0; i < bytes.byteLength; i++) {
+        bytes[i] = i % 251;
+    }
+    return bytes;
+};
+
+describe("shared fs library", () => {
+    let peer: Peerbit;
+    let fs: SharedFsHandle;
+
+    beforeEach(async () => {
+        peer = await Peerbit.create();
+        fs = await openSharedFs({
+            peerbit: peer,
+            machineLabel: "test-machine",
+        });
+    });
+
+    afterEach(async () => {
+        await peer.stop();
+    });
+
+    it("creates, lists, reads, renames, deletes directories and files", async () => {
+        await fs.mkdir("/docs");
+        await fs.writeFile("/docs/hello.txt", "hello");
+
+        expect(decode(await fs.readFile("/docs/hello.txt"))).toBe("hello");
+        expect((await fs.list("/docs")).map((entry) => entry.name)).toEqual([
+            "hello.txt",
+        ]);
+
+        await fs.rename("/docs/hello.txt", "/docs/greeting.txt");
+        expect(await fs.readFile("/docs/hello.txt")).toBeUndefined();
+        expect(decode(await fs.readFile("/docs/greeting.txt"))).toBe("hello");
+
+        await fs.rm("/docs/greeting.txt");
+        expect(await fs.readFile("/docs/greeting.txt")).toBeUndefined();
+
+        await fs.rm("/docs");
+        expect((await fs.list("/")).map((entry) => entry.name)).toEqual([]);
+    });
+
+    it("chunks and reads large files", async () => {
+        const bytes = patternedBytes(DEFAULT_FILE_CHUNK_SIZE * 2 + 17);
+        await fs.writeFile("/large.bin", bytes);
+
+        expect(await fs.readFile("/large.bin")).toEqual(bytes);
+        const [version] = await fs.versions("/large.bin");
+        expect(version.size).toBe(BigInt(bytes.byteLength));
+        expect(version.machineLabel).toBe("test-machine");
+        expect(version.authorKey.length).toBeGreaterThan(0);
+    });
+
+    it("preserves concurrent versions and resolves conflicts explicitly", async () => {
+        await fs.writeFile("/note.txt", "base");
+        const base = (await fs.versions("/note.txt"))
+            .filter((version) => version.head)
+            .map((version) => version.id);
+
+        const left = await fs.writeFile("/note.txt", "left", {
+            baseVersionIds: base,
+        });
+        const right = await fs.writeFile("/note.txt", "right", {
+            baseVersionIds: base,
+        });
+
+        const conflicts = await fs.conflicts();
+        expect(conflicts).toHaveLength(1);
+        expect(conflicts[0].path).toBe("/note.txt");
+        expect(
+            conflicts[0].versions.map((version) => version.id).sort()
+        ).toEqual([left.id, right.id].sort());
+        expect(decode(await fs.readVersion("/note.txt", right.id))).toBe(
+            "right"
+        );
+
+        await fs.resolveConflict("/note.txt", left.id);
+
+        expect(await fs.conflicts()).toEqual([]);
+        expect(decode(await fs.readFile("/note.txt"))).toBe("left");
+        expect(decode(await fs.readVersion("/note.txt", right.id))).toBe(
+            "right"
+        );
+    });
+});

--- a/packages/shared-fs/library/src/__tests__/shared-fs.test.ts
+++ b/packages/shared-fs/library/src/__tests__/shared-fs.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
     DEFAULT_FILE_CHUNK_SIZE,
     openSharedFs,
+    runSharedFsBenchmark,
     type SharedFsHandle,
 } from "../index.js";
 
@@ -16,6 +17,26 @@ const patternedBytes = (size: number) => {
         bytes[i] = i % 251;
     }
     return bytes;
+};
+
+const waitUntil = async (
+    assertion: () => Promise<void> | void,
+    options: { timeoutMs?: number; intervalMs?: number } = {}
+) => {
+    const timeoutMs = options.timeoutMs ?? 20_000;
+    const intervalMs = options.intervalMs ?? 100;
+    const deadline = Date.now() + timeoutMs;
+    let lastError: unknown;
+    while (Date.now() < deadline) {
+        try {
+            await assertion();
+            return;
+        } catch (error) {
+            lastError = error;
+            await new Promise((resolve) => setTimeout(resolve, intervalMs));
+        }
+    }
+    throw lastError;
 };
 
 describe("shared fs library", () => {
@@ -95,5 +116,110 @@ describe("shared fs library", () => {
         expect(decode(await fs.readVersion("/note.txt", right.id))).toBe(
             "right"
         );
+    });
+
+    it("runs the baseline benchmark workload", async () => {
+        const result = await runSharedFsBenchmark(fs, {
+            root: "/benchmark",
+            largeFileSize: 1024,
+            smallFileCount: 3,
+            smallFileSize: 16,
+            cleanup: true,
+        });
+
+        expect(result.largeFile.bytes).toBe(1024);
+        expect(result.smallFiles.count).toBe(3);
+        expect(result.smallFiles.bytesPerFile).toBe(16);
+    });
+});
+
+describe("shared fs replication", () => {
+    const peers: Peerbit[] = [];
+
+    const createPeer = async () => {
+        const peer = await Peerbit.create();
+        peers.push(peer);
+        return peer;
+    };
+
+    afterEach(async () => {
+        await Promise.all(peers.splice(0).map((peer) => peer.stop()));
+    });
+
+    it("syncs a local-first write after peers reconnect", async () => {
+        const writerPeer = await createPeer();
+        const readerPeer = await createPeer();
+        const writer = await openSharedFs({
+            peerbit: writerPeer,
+            machineLabel: "writer-machine",
+        });
+        await writer.writeFile("/offline.txt", "local-first");
+        expect(decode(await writer.readFile("/offline.txt"))).toBe(
+            "local-first"
+        );
+
+        await writerPeer.dial(readerPeer);
+        const reader = await openSharedFs({
+            peerbit: readerPeer,
+            address: writer.address,
+            machineLabel: "reader-machine",
+            replicate: false,
+        });
+
+        await waitUntil(async () => {
+            expect(decode(await reader.readFile("/offline.txt"))).toBe(
+                "local-first"
+            );
+        });
+    });
+
+    it("preserves signed conflict heads from two peers", async () => {
+        const peerA = await createPeer();
+        const peerB = await createPeer();
+        await peerA.dial(peerB);
+
+        const fsA = await openSharedFs({
+            peerbit: peerA,
+            machineLabel: "peer-a",
+        });
+        const fsB = await openSharedFs({
+            peerbit: peerB,
+            address: fsA.address,
+            machineLabel: "peer-b",
+        });
+
+        await fsA.writeFile("/shared.txt", "base");
+        await waitUntil(async () => {
+            expect(decode(await fsB.readFile("/shared.txt"))).toBe("base");
+        });
+
+        const base = (await fsA.versions("/shared.txt"))
+            .filter((version) => version.head)
+            .map((version) => version.id);
+        await fsA.writeFile("/shared.txt", "from-a", {
+            baseVersionIds: base,
+        });
+        await fsB.writeFile("/shared.txt", "from-b", {
+            baseVersionIds: base,
+        });
+
+        await waitUntil(async () => {
+            const conflicts = await fsA.conflicts("/shared.txt");
+            expect(conflicts).toHaveLength(1);
+            expect(
+                conflicts[0].versions
+                    .map((version) => version.machineLabel)
+                    .sort()
+            ).toEqual(["peer-a", "peer-b"]);
+        });
+        await waitUntil(async () => {
+            const conflicts = await fsB.conflicts("/shared.txt");
+            expect(conflicts).toHaveLength(1);
+            expect(
+                conflicts[0].versions
+                    .map((version) => version.machineLabel)
+                    .sort()
+            ).toEqual(["peer-a", "peer-b"]);
+        });
     });
 });

--- a/packages/shared-fs/library/src/benchmark.ts
+++ b/packages/shared-fs/library/src/benchmark.ts
@@ -1,0 +1,179 @@
+import { joinFsPath, normalizeFsPath } from "./path.js";
+
+export type SharedFsBenchmarkTarget = {
+    readFile(path: string): Promise<Uint8Array | undefined>;
+    writeFile(path: string, source: Uint8Array | string): Promise<unknown>;
+    mkdir(path: string): Promise<unknown>;
+    rm(path: string): Promise<unknown>;
+    list(path?: string): Promise<unknown[]>;
+};
+
+export type SharedFsBenchmarkOptions = {
+    root?: string;
+    largeFileSize?: number;
+    smallFileCount?: number;
+    smallFileSize?: number;
+    cleanup?: boolean;
+};
+
+export type SharedFsBenchmarkResult = {
+    root: string;
+    largeFile: {
+        bytes: number;
+        writeMs: number;
+        readMs: number;
+        writeMbps: number;
+        readMbps: number;
+    };
+    smallFiles: {
+        count: number;
+        bytesPerFile: number;
+        writeMs: number;
+        listMs: number;
+        readMs: number;
+        filesPerSecondWrite: number;
+        filesPerSecondRead: number;
+    };
+};
+
+const bytesPerMsToMbps = (bytes: number, ms: number) => {
+    if (ms <= 0) {
+        return 0;
+    }
+    return (bytes * 8) / 1_000_000 / (ms / 1_000);
+};
+
+const filesPerSecond = (files: number, ms: number) => {
+    if (ms <= 0) {
+        return 0;
+    }
+    return files / (ms / 1_000);
+};
+
+const measure = async (fn: () => Promise<void>) => {
+    const started = Date.now();
+    await fn();
+    return Date.now() - started;
+};
+
+const patternedBytes = (size: number, seed = 0) => {
+    const bytes = new Uint8Array(size);
+    for (let i = 0; i < bytes.byteLength; i++) {
+        bytes[i] = (i + seed) % 251;
+    }
+    return bytes;
+};
+
+const assertBytesEqual = (
+    actual: Uint8Array | undefined,
+    expected: Uint8Array
+) => {
+    if (!actual) {
+        throw new Error("Expected file bytes, got undefined");
+    }
+    if (actual.byteLength !== expected.byteLength) {
+        throw new Error(
+            `Expected ${expected.byteLength} bytes, got ${actual.byteLength}`
+        );
+    }
+    for (let i = 0; i < expected.byteLength; i++) {
+        if (actual[i] !== expected[i]) {
+            throw new Error(`Byte mismatch at offset ${i}`);
+        }
+    }
+};
+
+const cleanupTree = async (target: SharedFsBenchmarkTarget, root: string) => {
+    const smallRoot = joinFsPath(root, "small");
+    for (const entry of (await target.list(smallRoot).catch(() => [])) as {
+        name: string;
+    }[]) {
+        await target.rm(joinFsPath(smallRoot, entry.name));
+    }
+    await target.rm(joinFsPath(root, "large.bin")).catch(() => {});
+    await target.rm(smallRoot).catch(() => {});
+    await target.rm(root).catch(() => {});
+};
+
+export const runSharedFsBenchmark = async (
+    target: SharedFsBenchmarkTarget,
+    options: SharedFsBenchmarkOptions = {}
+): Promise<SharedFsBenchmarkResult> => {
+    const root = normalizeFsPath(
+        options.root ?? `/.peerbit-benchmark-${Date.now()}`
+    );
+    const largeFileSize = options.largeFileSize ?? 16 * 1024 * 1024;
+    const smallFileCount = options.smallFileCount ?? 200;
+    const smallFileSize = options.smallFileSize ?? 1024;
+    const largePath = joinFsPath(root, "large.bin");
+    const smallRoot = joinFsPath(root, "small");
+
+    await target.mkdir(root);
+    await target.mkdir(smallRoot);
+
+    const largeFile = patternedBytes(largeFileSize);
+    const largeWriteMs = await measure(async () => {
+        await target.writeFile(largePath, largeFile);
+    });
+    const largeReadMs = await measure(async () => {
+        assertBytesEqual(await target.readFile(largePath), largeFile);
+    });
+
+    const smallWriteMs = await measure(async () => {
+        for (let i = 0; i < smallFileCount; i++) {
+            await target.writeFile(
+                joinFsPath(smallRoot, `file-${String(i).padStart(5, "0")}.bin`),
+                patternedBytes(smallFileSize, i)
+            );
+        }
+    });
+
+    const listMs = await measure(async () => {
+        const entries = await target.list(smallRoot);
+        if (entries.length !== smallFileCount) {
+            throw new Error(
+                `Expected ${smallFileCount} small files, got ${entries.length}`
+            );
+        }
+    });
+
+    const smallReadMs = await measure(async () => {
+        for (let i = 0; i < smallFileCount; i++) {
+            assertBytesEqual(
+                await target.readFile(
+                    joinFsPath(
+                        smallRoot,
+                        `file-${String(i).padStart(5, "0")}.bin`
+                    )
+                ),
+                patternedBytes(smallFileSize, i)
+            );
+        }
+    });
+
+    const result = {
+        root,
+        largeFile: {
+            bytes: largeFileSize,
+            writeMs: largeWriteMs,
+            readMs: largeReadMs,
+            writeMbps: bytesPerMsToMbps(largeFileSize, largeWriteMs),
+            readMbps: bytesPerMsToMbps(largeFileSize, largeReadMs),
+        },
+        smallFiles: {
+            count: smallFileCount,
+            bytesPerFile: smallFileSize,
+            writeMs: smallWriteMs,
+            listMs,
+            readMs: smallReadMs,
+            filesPerSecondWrite: filesPerSecond(smallFileCount, smallWriteMs),
+            filesPerSecondRead: filesPerSecond(smallFileCount, smallReadMs),
+        },
+    };
+
+    if (options.cleanup) {
+        await cleanupTree(target, root);
+    }
+
+    return result;
+};

--- a/packages/shared-fs/library/src/index.ts
+++ b/packages/shared-fs/library/src/index.ts
@@ -1,0 +1,885 @@
+import { field, variant } from "@dao-xyz/borsh";
+import {
+    randomBytes,
+    sha256Base64Sync,
+    sha256Sync,
+    toBase64,
+    toBase64URL,
+} from "@peerbit/crypto";
+import { Documents, SearchRequest } from "@peerbit/document";
+import { Program } from "@peerbit/program";
+import { concat, fromString } from "uint8arrays";
+import type { Peerbit } from "peerbit";
+import {
+    DeleteMarker,
+    DirectoryRecord,
+    FileChunk,
+    FileRecord,
+    FileVersion,
+    IndexableSharedFsEntry,
+    SharedFsEntry,
+    isFileHead,
+    type FileHead,
+} from "./model.js";
+import {
+    ROOT_NODE_ID,
+    basename,
+    dirname,
+    joinFsPath,
+    normalizeFsPath,
+    pathSegments,
+} from "./path.js";
+
+export * from "./model.js";
+export * from "./ipc.js";
+export * from "./mount-backend.js";
+export * from "./native-mount.js";
+export * from "./path.js";
+
+export const SHARED_FS_EXPERIMENTAL = true;
+export const DEFAULT_FILE_CHUNK_SIZE = 512 * 1024;
+
+type OpenReplicateOptions =
+    | false
+    | {
+          factor?: number;
+          limits?: {
+              storage?: number;
+              cpu?: number | { max: number; monitor?: unknown };
+          };
+      };
+
+export type SharedFsOpenArgs = {
+    machineLabel?: string;
+    replicate?: OpenReplicateOptions;
+};
+
+export type OpenSharedFsOptions = SharedFsOpenArgs & {
+    peerbit: Peerbit;
+    address?: string | unknown;
+    id?: Uint8Array;
+    directory?: string;
+};
+
+export type SharedFsEntryInfo = {
+    path: string;
+    nodeId: string;
+    name: string;
+    kind: "directory" | "file";
+    size: bigint;
+    updatedAt: bigint;
+    authorKey: string;
+    machineLabel: string;
+    conflict: boolean;
+};
+
+export type SharedFsVersionInfo = {
+    id: string;
+    nodeId: string;
+    path: string;
+    size: bigint;
+    contentHash?: string;
+    parentVersionIds: string[];
+    createdAt: bigint;
+    authorKey: string;
+    machineLabel: string;
+    deleted: boolean;
+    head: boolean;
+};
+
+export type SharedFsConflict = {
+    path: string;
+    nodeId: string;
+    versions: SharedFsVersionInfo[];
+};
+
+export type WriteFileOptions = {
+    /**
+     * Allows callers that observed an older base to publish a concurrent version.
+     * Normal writes should leave this undefined so the current visible heads are
+     * used as parents.
+     */
+    baseVersionIds?: string[];
+    chunkSize?: number;
+};
+
+type Projection = {
+    directories: DirectoryRecord[];
+    files: FileRecord[];
+    versions: FileVersion[];
+    chunks: FileChunk[];
+    deletes: DeleteMarker[];
+};
+
+type ResolvedPath =
+    | { kind: "root"; nodeId: typeof ROOT_NODE_ID; path: "/" }
+    | { kind: "directory"; record: DirectoryRecord; path: string }
+    | { kind: "file"; record: FileRecord; path: string };
+
+const now = () => BigInt(Date.now());
+
+const createId = (prefix: string) =>
+    `${prefix}:${toBase64URL(randomBytes(32))}`;
+
+const toBytes = async (
+    source: Uint8Array | string | AsyncIterable<Uint8Array>
+): Promise<Uint8Array> => {
+    if (typeof source === "string") {
+        return new TextEncoder().encode(source);
+    }
+    if (source instanceof Uint8Array) {
+        return source;
+    }
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of source) {
+        chunks.push(chunk);
+    }
+    return chunks.length === 0 ? new Uint8Array(0) : concat(chunks);
+};
+
+const chunkBytes = (bytes: Uint8Array, chunkSize = DEFAULT_FILE_CHUNK_SIZE) => {
+    const chunks: Uint8Array[] = [];
+    for (let offset = 0; offset < bytes.byteLength; offset += chunkSize) {
+        chunks.push(
+            bytes.subarray(
+                offset,
+                Math.min(offset + chunkSize, bytes.byteLength)
+            )
+        );
+    }
+    if (chunks.length === 0) {
+        chunks.push(new Uint8Array(0));
+    }
+    return chunks;
+};
+
+const newestFirst = <
+    T extends { createdAt?: bigint; updatedAt?: bigint; id: string },
+>(
+    a: T,
+    b: T
+) => {
+    const aTime = Number(a.updatedAt ?? a.createdAt ?? 0n);
+    const bTime = Number(b.updatedAt ?? b.createdAt ?? 0n);
+    return bTime - aTime || b.id.localeCompare(a.id);
+};
+
+const latestRecord = <T extends { id: string; updatedAt: bigint }>(
+    records: T[]
+) => {
+    return [...records].sort(newestFirst)[0];
+};
+
+@variant("peerbit_shared_fs")
+export class SharedFileSystem extends Program<SharedFsOpenArgs> {
+    @field({ type: Uint8Array })
+    id: Uint8Array;
+
+    @field({ type: Documents })
+    entries: Documents<SharedFsEntry, IndexableSharedFsEntry>;
+
+    machineLabel = "unknown-machine";
+    replicate: OpenReplicateOptions | undefined;
+
+    constructor(properties: { id?: Uint8Array } = {}) {
+        super();
+        this.id = properties.id ?? randomBytes(32);
+        this.entries = new Documents({
+            id: sha256Sync(concat([this.id, fromString("/shared-fs")])),
+        });
+    }
+
+    async open(args?: SharedFsOpenArgs) {
+        this.machineLabel = args?.machineLabel || "unknown-machine";
+        this.replicate = args?.replicate;
+        await this.entries.open({
+            type: SharedFsEntry,
+            replicate: args?.replicate as any,
+            replicas: { min: 3 },
+            index: {
+                type: IndexableSharedFsEntry,
+            },
+        });
+    }
+
+    private authorKey() {
+        return toBase64(this.node.identity.publicKey.bytes);
+    }
+
+    private signedMetadata() {
+        return {
+            authorKey: this.authorKey(),
+            machineLabel: this.machineLabel,
+            timestamp: now(),
+        };
+    }
+
+    private async allEntries(): Promise<SharedFsEntry[]> {
+        return this.entries.index.search(
+            new SearchRequest({
+                query: [],
+                fetch: 0xffffffff,
+            }),
+            {
+                local: true,
+                remote: {
+                    timeout: 10_000,
+                    throwOnMissing: false,
+                    replicate: this.replicate !== false,
+                },
+            } as any
+        ) as Promise<SharedFsEntry[]>;
+    }
+
+    private async projection(): Promise<Projection> {
+        const entries = await this.allEntries();
+        return {
+            directories: entries.filter(
+                (entry): entry is DirectoryRecord =>
+                    entry instanceof DirectoryRecord
+            ),
+            files: entries.filter(
+                (entry): entry is FileRecord => entry instanceof FileRecord
+            ),
+            versions: entries.filter(
+                (entry): entry is FileVersion => entry instanceof FileVersion
+            ),
+            chunks: entries.filter(
+                (entry): entry is FileChunk => entry instanceof FileChunk
+            ),
+            deletes: entries.filter(
+                (entry): entry is DeleteMarker => entry instanceof DeleteMarker
+            ),
+        };
+    }
+
+    private currentDirectories(projection: Projection) {
+        const byId = new Map<string, DirectoryRecord[]>();
+        for (const record of projection.directories) {
+            const records = byId.get(record.nodeId) ?? [];
+            records.push(record);
+            byId.set(record.nodeId, records);
+        }
+        return [...byId.values()]
+            .map(latestRecord)
+            .filter((record) => !record.deleted);
+    }
+
+    private currentFiles(projection: Projection) {
+        const byId = new Map<string, FileRecord[]>();
+        for (const record of projection.files) {
+            const records = byId.get(record.nodeId) ?? [];
+            records.push(record);
+            byId.set(record.nodeId, records);
+        }
+        return [...byId.values()]
+            .map(latestRecord)
+            .filter((record) => !record.deleted);
+    }
+
+    private async resolvePath(
+        path: string,
+        projection?: Projection
+    ): Promise<ResolvedPath | undefined> {
+        const state = projection ?? (await this.projection());
+        const normalized = normalizeFsPath(path);
+        if (normalized === "/") {
+            return { kind: "root", nodeId: ROOT_NODE_ID, path: "/" };
+        }
+        const segments = pathSegments(normalized);
+        const directories = this.currentDirectories(state);
+        const files = this.currentFiles(state);
+        let parentId = ROOT_NODE_ID;
+        let currentPath = "/";
+        for (let i = 0; i < segments.length; i++) {
+            const name = segments[i];
+            currentPath = joinFsPath(currentPath, name);
+            const isLast = i === segments.length - 1;
+            const directory = directories.find(
+                (record) => record.parentId === parentId && record.name === name
+            );
+            if (directory) {
+                if (isLast) {
+                    return {
+                        kind: "directory",
+                        record: directory,
+                        path: currentPath,
+                    };
+                }
+                parentId = directory.nodeId;
+                continue;
+            }
+            if (isLast) {
+                const file = files.find(
+                    (record) =>
+                        record.parentId === parentId && record.name === name
+                );
+                if (file) {
+                    return { kind: "file", record: file, path: currentPath };
+                }
+            }
+            return undefined;
+        }
+        return undefined;
+    }
+
+    private async resolveParent(path: string, projection?: Projection) {
+        const state = projection ?? (await this.projection());
+        const parentPath = dirname(path);
+        const resolved = await this.resolvePath(parentPath, state);
+        if (!resolved) {
+            throw new Error(`Parent directory does not exist: ${parentPath}`);
+        }
+        if (resolved.kind === "file") {
+            throw new Error(`Parent path is a file: ${parentPath}`);
+        }
+        return resolved.kind === "root" ? ROOT_NODE_ID : resolved.record.nodeId;
+    }
+
+    private headsForNode(projection: Projection, nodeId: string): FileHead[] {
+        const heads = [...projection.versions, ...projection.deletes].filter(
+            (entry) => isFileHead(entry) && entry.nodeId === nodeId
+        );
+        const referenced = new Set<string>();
+        for (const head of heads) {
+            for (const parentId of head.parentVersionIds) {
+                referenced.add(parentId);
+            }
+        }
+        return heads
+            .filter((head) => !referenced.has(head.id))
+            .sort(newestFirst);
+    }
+
+    private visibleFileHead(projection: Projection, nodeId: string) {
+        return this.headsForNode(projection, nodeId)[0];
+    }
+
+    private pathForRecord(
+        record: FileRecord | DirectoryRecord,
+        projection: Projection
+    ) {
+        const names = [record.name];
+        let parentId = record.parentId;
+        const directories = this.currentDirectories(projection);
+        while (parentId !== ROOT_NODE_ID) {
+            const parent = directories.find(
+                (candidate) => candidate.nodeId === parentId
+            );
+            if (!parent) {
+                break;
+            }
+            names.unshift(parent.name);
+            parentId = parent.parentId;
+        }
+        return "/" + names.join("/");
+    }
+
+    private versionInfo(
+        head: FileHead,
+        path: string,
+        projection: Projection
+    ): SharedFsVersionInfo {
+        const heads = new Set(
+            this.headsForNode(projection, head.nodeId).map((x) => x.id)
+        );
+        return {
+            id: head.id,
+            nodeId: head.nodeId,
+            path,
+            size: head instanceof FileVersion ? head.size : 0n,
+            contentHash:
+                head instanceof FileVersion ? head.contentHash : undefined,
+            parentVersionIds: head.parentVersionIds,
+            createdAt: head.createdAt,
+            authorKey: head.authorKey,
+            machineLabel: head.machineLabel,
+            deleted: head instanceof DeleteMarker,
+            head: heads.has(head.id),
+        };
+    }
+
+    async mkdir(path: string) {
+        const normalized = normalizeFsPath(path);
+        if (normalized === "/") {
+            return;
+        }
+        const projection = await this.projection();
+        if (await this.resolvePath(normalized, projection)) {
+            throw new Error(`Path already exists: ${normalized}`);
+        }
+        const metadata = this.signedMetadata();
+        const directory = new DirectoryRecord({
+            nodeId: createId("dir"),
+            parentId: await this.resolveParent(normalized, projection),
+            name: basename(normalized),
+            createdAt: metadata.timestamp,
+            authorKey: metadata.authorKey,
+            machineLabel: metadata.machineLabel,
+        });
+        await this.entries.put(directory);
+    }
+
+    async writeFile(
+        path: string,
+        source: Uint8Array | string | AsyncIterable<Uint8Array>,
+        options: WriteFileOptions = {}
+    ) {
+        const normalized = normalizeFsPath(path);
+        if (normalized === "/") {
+            throw new Error("Cannot write to root");
+        }
+        const bytes = await toBytes(source);
+        const projection = await this.projection();
+        const existing = await this.resolvePath(normalized, projection);
+        if (existing?.kind === "directory") {
+            throw new Error(`Path is a directory: ${normalized}`);
+        }
+        const metadata = this.signedMetadata();
+        const parentId = await this.resolveParent(normalized, projection);
+        const nodeId =
+            existing?.kind === "file"
+                ? existing.record.nodeId
+                : createId("file");
+        const parentVersionIds =
+            options.baseVersionIds ??
+            (existing?.kind === "file"
+                ? this.headsForNode(projection, existing.record.nodeId).map(
+                      (head) => head.id
+                  )
+                : []);
+        const versionId = createId("version");
+        const chunks = chunkBytes(bytes, options.chunkSize).map(
+            (chunk, index) =>
+                new FileChunk({
+                    id: `${versionId}:${index}`,
+                    versionId,
+                    index,
+                    bytes: chunk,
+                })
+        );
+        for (const chunk of chunks) {
+            await this.entries.put(chunk);
+        }
+        const version = new FileVersion({
+            id: versionId,
+            nodeId,
+            parentId,
+            name: basename(normalized),
+            parentVersionIds,
+            contentHash: sha256Base64Sync(bytes),
+            size: BigInt(bytes.byteLength),
+            chunkIds: chunks.map((chunk) => chunk.id),
+            createdAt: metadata.timestamp,
+            authorKey: metadata.authorKey,
+            machineLabel: metadata.machineLabel,
+        });
+        await this.entries.put(version);
+        await this.entries.put(
+            new FileRecord({
+                nodeId,
+                parentId,
+                name: basename(normalized),
+                currentVersionId: versionId,
+                createdAt:
+                    existing?.kind === "file"
+                        ? existing.record.createdAt
+                        : metadata.timestamp,
+                updatedAt: metadata.timestamp,
+                authorKey: metadata.authorKey,
+                machineLabel: metadata.machineLabel,
+            })
+        );
+        return this.versionInfo(version, normalized, {
+            ...projection,
+            versions: [...projection.versions, version],
+            chunks: [...projection.chunks, ...chunks],
+        });
+    }
+
+    private readFileVersion(
+        version: FileVersion,
+        normalizedPath: string,
+        projection: Projection
+    ) {
+        const chunks = version.chunkIds.map((id) => {
+            const chunk = projection.chunks.find(
+                (candidate) => candidate.id === id
+            );
+            if (!chunk) {
+                throw new Error(`Missing chunk ${id} for ${normalizedPath}`);
+            }
+            if (sha256Base64Sync(chunk.bytes) !== chunk.hash) {
+                throw new Error(`Chunk hash mismatch ${id}`);
+            }
+            return chunk.bytes;
+        });
+        const bytes = chunks.length === 0 ? new Uint8Array(0) : concat(chunks);
+        if (sha256Base64Sync(bytes) !== version.contentHash) {
+            throw new Error(`File hash mismatch for ${normalizedPath}`);
+        }
+        return bytes;
+    }
+
+    async readFile(path: string) {
+        const normalized = normalizeFsPath(path);
+        const projection = await this.projection();
+        const resolved = await this.resolvePath(normalized, projection);
+        if (!resolved || resolved.kind !== "file") {
+            return undefined;
+        }
+        const head = this.visibleFileHead(projection, resolved.record.nodeId);
+        if (!(head instanceof FileVersion)) {
+            return undefined;
+        }
+        return this.readFileVersion(head, normalized, projection);
+    }
+
+    async readVersion(path: string, versionId: string) {
+        const normalized = normalizeFsPath(path);
+        const projection = await this.projection();
+        const resolved = await this.resolvePath(normalized, projection);
+        if (!resolved || resolved.kind !== "file") {
+            return undefined;
+        }
+        const version = projection.versions.find(
+            (candidate) =>
+                candidate.nodeId === resolved.record.nodeId &&
+                candidate.id === versionId
+        );
+        return version
+            ? this.readFileVersion(version, normalized, projection)
+            : undefined;
+    }
+
+    async list(path = "/"): Promise<SharedFsEntryInfo[]> {
+        const normalized = normalizeFsPath(path);
+        const projection = await this.projection();
+        const resolved = await this.resolvePath(normalized, projection);
+        if (!resolved) {
+            throw new Error(`Path does not exist: ${normalized}`);
+        }
+        if (resolved.kind === "file") {
+            throw new Error(`Path is a file: ${normalized}`);
+        }
+        const parentId =
+            resolved.kind === "root" ? ROOT_NODE_ID : resolved.record.nodeId;
+        const directories = this.currentDirectories(projection).filter(
+            (record) => record.parentId === parentId
+        );
+        const files = this.currentFiles(projection).filter(
+            (record) => record.parentId === parentId
+        );
+        const directoryInfos = directories.map((record) => ({
+            path: joinFsPath(normalized, record.name),
+            nodeId: record.nodeId,
+            name: record.name,
+            kind: "directory" as const,
+            size: 0n,
+            updatedAt: record.updatedAt,
+            authorKey: record.authorKey,
+            machineLabel: record.machineLabel,
+            conflict: false,
+        }));
+        const fileInfos: SharedFsEntryInfo[] = [];
+        for (const record of files) {
+            const head = this.visibleFileHead(projection, record.nodeId);
+            if (head instanceof DeleteMarker || !head) {
+                continue;
+            }
+            fileInfos.push({
+                path: joinFsPath(normalized, record.name),
+                nodeId: record.nodeId,
+                name: record.name,
+                kind: "file" as const,
+                size: head instanceof FileVersion ? head.size : 0n,
+                updatedAt: record.updatedAt,
+                authorKey: record.authorKey,
+                machineLabel: record.machineLabel,
+                conflict:
+                    this.headsForNode(projection, record.nodeId).length > 1,
+            });
+        }
+        return [...directoryInfos, ...fileInfos].sort((a, b) =>
+            a.name.localeCompare(b.name)
+        );
+    }
+
+    async versions(path: string): Promise<SharedFsVersionInfo[]> {
+        const normalized = normalizeFsPath(path);
+        const projection = await this.projection();
+        const resolved = await this.resolvePath(normalized, projection);
+        if (!resolved || resolved.kind !== "file") {
+            return [];
+        }
+        return [...projection.versions, ...projection.deletes]
+            .filter(
+                (entry) =>
+                    isFileHead(entry) && entry.nodeId === resolved.record.nodeId
+            )
+            .sort(newestFirst)
+            .map((entry) => this.versionInfo(entry, normalized, projection));
+    }
+
+    async conflicts(path?: string): Promise<SharedFsConflict[]> {
+        const projection = await this.projection();
+        const files = this.currentFiles(projection);
+        const target = path
+            ? await this.resolvePath(path, projection)
+            : undefined;
+        const records =
+            target?.kind === "file"
+                ? [target.record]
+                : files.filter((record) => {
+                      if (!path) {
+                          return true;
+                      }
+                      const normalizedPrefix = normalizeFsPath(path);
+                      return this.pathForRecord(record, projection).startsWith(
+                          normalizedPrefix
+                      );
+                  });
+        return records
+            .map((record) => {
+                const heads = this.headsForNode(projection, record.nodeId);
+                if (heads.length <= 1) {
+                    return undefined;
+                }
+                const recordPath = this.pathForRecord(record, projection);
+                return {
+                    path: recordPath,
+                    nodeId: record.nodeId,
+                    versions: heads.map((head) =>
+                        this.versionInfo(head, recordPath, projection)
+                    ),
+                };
+            })
+            .filter((value): value is SharedFsConflict => value != null);
+    }
+
+    async resolveConflict(path: string, versionId: string) {
+        const normalized = normalizeFsPath(path);
+        const projection = await this.projection();
+        const resolved = await this.resolvePath(normalized, projection);
+        if (!resolved || resolved.kind !== "file") {
+            throw new Error(`Path is not a file: ${normalized}`);
+        }
+        const selected = projection.versions.find(
+            (version) =>
+                version.nodeId === resolved.record.nodeId &&
+                version.id === versionId
+        );
+        if (!selected) {
+            throw new Error(
+                `Version ${versionId} does not exist for ${normalized}`
+            );
+        }
+        const heads = this.headsForNode(projection, resolved.record.nodeId);
+        const metadata = this.signedMetadata();
+        const resolution = new FileVersion({
+            id: createId("version"),
+            nodeId: selected.nodeId,
+            parentId: resolved.record.parentId,
+            name: resolved.record.name,
+            parentVersionIds: heads.map((head) => head.id),
+            contentHash: selected.contentHash,
+            size: selected.size,
+            chunkIds: selected.chunkIds,
+            createdAt: metadata.timestamp,
+            authorKey: metadata.authorKey,
+            machineLabel: metadata.machineLabel,
+            conflictResolution: true,
+        });
+        await this.entries.put(resolution);
+        await this.entries.put(
+            new FileRecord({
+                nodeId: resolved.record.nodeId,
+                parentId: resolved.record.parentId,
+                name: resolved.record.name,
+                currentVersionId: resolution.id,
+                createdAt: resolved.record.createdAt,
+                updatedAt: metadata.timestamp,
+                authorKey: metadata.authorKey,
+                machineLabel: metadata.machineLabel,
+                deleted: resolved.record.deleted,
+            })
+        );
+        return this.versionInfo(resolution, normalized, {
+            ...projection,
+            versions: [...projection.versions, resolution],
+        });
+    }
+
+    async rm(path: string) {
+        const normalized = normalizeFsPath(path);
+        if (normalized === "/") {
+            throw new Error("Cannot remove root");
+        }
+        const projection = await this.projection();
+        const resolved = await this.resolvePath(normalized, projection);
+        if (!resolved) {
+            return;
+        }
+        if (resolved.kind === "root") {
+            throw new Error("Cannot remove root");
+        }
+        const metadata = this.signedMetadata();
+        if (resolved.kind === "directory") {
+            const childCount = (await this.list(normalized)).length;
+            if (childCount > 0) {
+                throw new Error(`Directory is not empty: ${normalized}`);
+            }
+            await this.entries.put(
+                new DirectoryRecord({
+                    nodeId: resolved.record.nodeId,
+                    parentId: resolved.record.parentId,
+                    name: resolved.record.name,
+                    createdAt: resolved.record.createdAt,
+                    updatedAt: metadata.timestamp,
+                    authorKey: metadata.authorKey,
+                    machineLabel: metadata.machineLabel,
+                    deleted: true,
+                })
+            );
+            return;
+        }
+        const marker = new DeleteMarker({
+            id: createId("delete"),
+            nodeId: resolved.record.nodeId,
+            parentId: resolved.record.parentId,
+            name: resolved.record.name,
+            parentVersionIds: this.headsForNode(
+                projection,
+                resolved.record.nodeId
+            ).map((head) => head.id),
+            createdAt: metadata.timestamp,
+            authorKey: metadata.authorKey,
+            machineLabel: metadata.machineLabel,
+        });
+        await this.entries.put(marker);
+        await this.entries.put(
+            new FileRecord({
+                nodeId: resolved.record.nodeId,
+                parentId: resolved.record.parentId,
+                name: resolved.record.name,
+                currentVersionId: marker.id,
+                createdAt: resolved.record.createdAt,
+                updatedAt: metadata.timestamp,
+                authorKey: metadata.authorKey,
+                machineLabel: metadata.machineLabel,
+                deleted: true,
+            })
+        );
+    }
+
+    async rename(from: string, to: string) {
+        const fromPath = normalizeFsPath(from);
+        const toPath = normalizeFsPath(to);
+        const projection = await this.projection();
+        const resolved = await this.resolvePath(fromPath, projection);
+        if (!resolved || resolved.kind === "root") {
+            throw new Error(`Path does not exist: ${fromPath}`);
+        }
+        if (await this.resolvePath(toPath, projection)) {
+            throw new Error(`Destination already exists: ${toPath}`);
+        }
+        const parentId = await this.resolveParent(toPath, projection);
+        const metadata = this.signedMetadata();
+        if (resolved.kind === "directory") {
+            await this.entries.put(
+                new DirectoryRecord({
+                    nodeId: resolved.record.nodeId,
+                    parentId,
+                    name: basename(toPath),
+                    createdAt: resolved.record.createdAt,
+                    updatedAt: metadata.timestamp,
+                    authorKey: metadata.authorKey,
+                    machineLabel: metadata.machineLabel,
+                    deleted: resolved.record.deleted,
+                })
+            );
+        } else {
+            await this.entries.put(
+                new FileRecord({
+                    nodeId: resolved.record.nodeId,
+                    parentId,
+                    name: basename(toPath),
+                    currentVersionId: resolved.record.currentVersionId,
+                    createdAt: resolved.record.createdAt,
+                    updatedAt: metadata.timestamp,
+                    authorKey: metadata.authorKey,
+                    machineLabel: metadata.machineLabel,
+                    deleted: resolved.record.deleted,
+                })
+            );
+        }
+    }
+}
+
+export class SharedFsHandle {
+    constructor(readonly program: SharedFileSystem) {}
+
+    get address() {
+        return this.program.address?.toString();
+    }
+
+    readFile(path: string) {
+        return this.program.readFile(path);
+    }
+
+    writeFile(
+        path: string,
+        source: Uint8Array | string | AsyncIterable<Uint8Array>,
+        options?: WriteFileOptions
+    ) {
+        return this.program.writeFile(path, source, options);
+    }
+
+    readVersion(path: string, versionId: string) {
+        return this.program.readVersion(path, versionId);
+    }
+
+    mkdir(path: string) {
+        return this.program.mkdir(path);
+    }
+
+    rm(path: string) {
+        return this.program.rm(path);
+    }
+
+    rename(from: string, to: string) {
+        return this.program.rename(from, to);
+    }
+
+    list(path?: string) {
+        return this.program.list(path);
+    }
+
+    versions(path: string) {
+        return this.program.versions(path);
+    }
+
+    conflicts(path?: string) {
+        return this.program.conflicts(path);
+    }
+
+    resolveConflict(path: string, versionId: string) {
+        return this.program.resolveConflict(path, versionId);
+    }
+}
+
+export const openSharedFs = async (options: OpenSharedFsOptions) => {
+    const args: SharedFsOpenArgs = {
+        machineLabel: options.machineLabel,
+        replicate: options.replicate,
+    };
+    const program = options.address
+        ? await options.peerbit.open<SharedFileSystem>(options.address as any, {
+              args,
+          })
+        : await options.peerbit.open(new SharedFileSystem({ id: options.id }), {
+              existing: "reuse",
+              args,
+          });
+    return new SharedFsHandle(program);
+};

--- a/packages/shared-fs/library/src/index.ts
+++ b/packages/shared-fs/library/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./path.js";
 
 export * from "./model.js";
+export * from "./benchmark.js";
 export * from "./ipc.js";
 export * from "./mount-backend.js";
 export * from "./native-mount.js";

--- a/packages/shared-fs/library/src/ipc.ts
+++ b/packages/shared-fs/library/src/ipc.ts
@@ -1,0 +1,227 @@
+import { createServer, createConnection, type Server } from "node:net";
+import { existsSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+    SharedFsBackendError,
+    type SharedFsMountBackend,
+    type SharedFsOpenFlags,
+} from "./mount-backend.js";
+
+export type SharedFsIpcEndpoint = string;
+
+export type SharedFsIpcServer = {
+    endpoint: SharedFsIpcEndpoint;
+    close(): Promise<void>;
+};
+
+type IpcRequest = {
+    id: number;
+    op: keyof SharedFsMountBackend;
+    args: unknown[];
+};
+
+type IpcResponse =
+    | {
+          id: number;
+          ok: true;
+          result: unknown;
+      }
+    | {
+          id: number;
+          ok: false;
+          error: {
+              code?: string;
+              message: string;
+          };
+      };
+
+const encodeBytes = (bytes: Uint8Array) => ({
+    $bytes: Buffer.from(bytes).toString("base64"),
+});
+
+const decodeBytes = (value: unknown): unknown => {
+    if (Array.isArray(value)) {
+        return value.map(decodeBytes);
+    }
+    if (value && typeof value === "object") {
+        const maybeBytes = value as { $bytes?: unknown };
+        if (typeof maybeBytes.$bytes === "string") {
+            return new Uint8Array(Buffer.from(maybeBytes.$bytes, "base64"));
+        }
+        return Object.fromEntries(
+            Object.entries(value).map(([key, entry]) => [
+                key,
+                decodeBytes(entry),
+            ])
+        );
+    }
+    return value;
+};
+
+const encodeResult = (value: unknown): unknown => {
+    if (value instanceof Uint8Array) {
+        return encodeBytes(value);
+    }
+    if (Array.isArray(value)) {
+        return value.map(encodeResult);
+    }
+    if (value && typeof value === "object") {
+        return Object.fromEntries(
+            Object.entries(value).map(([key, entry]) => [
+                key,
+                encodeResult(entry),
+            ])
+        );
+    }
+    return value;
+};
+
+const writeJsonLine = (socket: NodeJS.WritableStream, value: unknown) => {
+    socket.write(`${JSON.stringify(value)}\n`);
+};
+
+export const defaultSharedFsIpcEndpoint = (name = randomUUID()) => {
+    if (process.platform === "win32") {
+        return `\\\\.\\pipe\\peerbit-shared-fs-${name}`;
+    }
+    return join("/tmp", `pbfs-${name.slice(0, 8)}.sock`);
+};
+
+export const createSharedFsIpcServer = async (
+    backend: SharedFsMountBackend,
+    endpoint = defaultSharedFsIpcEndpoint()
+): Promise<SharedFsIpcServer> => {
+    const server: Server = createServer((socket) => {
+        let buffered = "";
+        socket.on("data", (chunk) => {
+            buffered += chunk.toString("utf8");
+            const lines = buffered.split("\n");
+            buffered = lines.pop() ?? "";
+            for (const line of lines) {
+                if (line.length === 0) {
+                    continue;
+                }
+                void (async () => {
+                    let requestId = 0;
+                    try {
+                        const request = JSON.parse(line) as IpcRequest;
+                        requestId = request.id;
+                        const args = decodeBytes(request.args) as unknown[];
+                        const method = backend[request.op] as (
+                            ...args: unknown[]
+                        ) => Promise<unknown>;
+                        const result = await method(...args);
+                        writeJsonLine(socket, {
+                            id: request.id,
+                            ok: true,
+                            result: encodeResult(result),
+                        } satisfies IpcResponse);
+                    } catch (error) {
+                        writeJsonLine(socket, {
+                            id: requestId,
+                            ok: false,
+                            error: {
+                                code:
+                                    error instanceof SharedFsBackendError
+                                        ? error.code
+                                        : undefined,
+                                message:
+                                    error instanceof Error
+                                        ? error.message
+                                        : String(error),
+                            },
+                        } satisfies IpcResponse);
+                    }
+                })();
+            }
+        });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        if (process.platform !== "win32" && existsSync(endpoint)) {
+            unlinkSync(endpoint);
+        }
+        server.listen(endpoint, () => {
+            server.off("error", reject);
+            resolve();
+        });
+    });
+
+    return {
+        endpoint,
+        close() {
+            return new Promise<void>((resolve, reject) => {
+                server.close((error) => {
+                    if (error) {
+                        reject(error);
+                    } else {
+                        resolve();
+                    }
+                });
+            });
+        },
+    };
+};
+
+export const createSharedFsIpcClient = (
+    endpoint: SharedFsIpcEndpoint
+): SharedFsMountBackend => {
+    let nextId = 1;
+
+    const request = async (op: keyof SharedFsMountBackend, args: unknown[]) => {
+        const id = nextId++;
+        return new Promise<unknown>((resolve, reject) => {
+            const socket = createConnection(endpoint);
+            let buffered = "";
+            socket.on("error", reject);
+            socket.on("connect", () => {
+                writeJsonLine(socket, {
+                    id,
+                    op,
+                    args: encodeResult(args) as unknown[],
+                } satisfies IpcRequest);
+            });
+            socket.on("data", (chunk) => {
+                buffered += chunk.toString("utf8");
+                const newline = buffered.indexOf("\n");
+                if (newline === -1) {
+                    return;
+                }
+                const response = JSON.parse(
+                    buffered.slice(0, newline)
+                ) as IpcResponse;
+                socket.end();
+                if (response.ok) {
+                    resolve(decodeBytes(response.result));
+                } else {
+                    reject(
+                        new SharedFsBackendError(
+                            (response.error.code as any) ?? "EIO",
+                            response.error.message
+                        )
+                    );
+                }
+            });
+        });
+    };
+
+    return {
+        getattr: (path) => request("getattr", [path]) as Promise<any>,
+        readdir: (path) => request("readdir", [path]) as Promise<any>,
+        open: (path, flags?: SharedFsOpenFlags) =>
+            request("open", [path, flags]) as Promise<number>,
+        read: (handle, size, offset) =>
+            request("read", [handle, size, offset]) as Promise<Uint8Array>,
+        write: (handle, data, offset) =>
+            request("write", [handle, data, offset]) as Promise<number>,
+        flush: (handle) => request("flush", [handle]) as Promise<void>,
+        fsync: (handle) => request("fsync", [handle]) as Promise<void>,
+        release: (handle) => request("release", [handle]) as Promise<void>,
+        mkdir: (path) => request("mkdir", [path]) as Promise<void>,
+        rmdir: (path) => request("rmdir", [path]) as Promise<void>,
+        rename: (from, to) => request("rename", [from, to]) as Promise<void>,
+        unlink: (path) => request("unlink", [path]) as Promise<void>,
+    };
+};

--- a/packages/shared-fs/library/src/model.ts
+++ b/packages/shared-fs/library/src/model.ts
@@ -42,28 +42,45 @@ export class IndexableSharedFsEntry {
     @field({ type: "bool" })
     deleted: boolean;
 
-    constructor(value: SharedFsEntry) {
+    constructor(value?: SharedFsEntry) {
+        if (!value) {
+            this.id = "";
+            this.kind = "";
+            this.deleted = false;
+            return;
+        }
         this.id = value.id;
-        this.kind = value.kind;
         this.deleted = false;
-        if (value instanceof DirectoryRecord || value instanceof FileRecord) {
+        if (value instanceof DirectoryRecord) {
+            this.kind = "directory";
+            this.nodeId = value.nodeId;
+            this.parentId = value.parentId;
+            this.name = value.name;
+            this.deleted = value.deleted;
+        } else if (value instanceof FileRecord) {
+            this.kind = "file";
             this.nodeId = value.nodeId;
             this.parentId = value.parentId;
             this.name = value.name;
             this.deleted = value.deleted;
         } else if (value instanceof FileVersion) {
+            this.kind = "file-version";
             this.nodeId = value.nodeId;
             this.parentId = value.parentId;
             this.name = value.name;
             this.versionId = value.id;
         } else if (value instanceof FileChunk) {
+            this.kind = "file-chunk";
             this.versionId = value.versionId;
         } else if (value instanceof DeleteMarker) {
+            this.kind = "delete-marker";
             this.nodeId = value.nodeId;
             this.parentId = value.parentId;
             this.name = value.name;
             this.versionId = value.id;
             this.deleted = true;
+        } else {
+            this.kind = value.kind;
         }
     }
 }

--- a/packages/shared-fs/library/src/model.ts
+++ b/packages/shared-fs/library/src/model.ts
@@ -1,0 +1,356 @@
+import { field, option, variant, vec } from "@dao-xyz/borsh";
+import { sha256Base64Sync } from "@peerbit/crypto";
+
+export type SharedFsEntryKind =
+    | "directory"
+    | "file"
+    | "file-version"
+    | "file-chunk"
+    | "delete-marker";
+
+export abstract class SharedFsEntry {
+    abstract id: string;
+    abstract kind: SharedFsEntryKind;
+}
+
+export type SignedMetadata = {
+    authorKey: string;
+    machineLabel: string;
+    timestamp: bigint | number;
+};
+
+@variant("shared_fs_indexable_entry")
+export class IndexableSharedFsEntry {
+    @field({ type: "string" })
+    id: string;
+
+    @field({ type: "string" })
+    kind: string;
+
+    @field({ type: option("string") })
+    nodeId?: string;
+
+    @field({ type: option("string") })
+    parentId?: string;
+
+    @field({ type: option("string") })
+    name?: string;
+
+    @field({ type: option("string") })
+    versionId?: string;
+
+    @field({ type: "bool" })
+    deleted: boolean;
+
+    constructor(value: SharedFsEntry) {
+        this.id = value.id;
+        this.kind = value.kind;
+        this.deleted = false;
+        if (value instanceof DirectoryRecord || value instanceof FileRecord) {
+            this.nodeId = value.nodeId;
+            this.parentId = value.parentId;
+            this.name = value.name;
+            this.deleted = value.deleted;
+        } else if (value instanceof FileVersion) {
+            this.nodeId = value.nodeId;
+            this.parentId = value.parentId;
+            this.name = value.name;
+            this.versionId = value.id;
+        } else if (value instanceof FileChunk) {
+            this.versionId = value.versionId;
+        } else if (value instanceof DeleteMarker) {
+            this.nodeId = value.nodeId;
+            this.parentId = value.parentId;
+            this.name = value.name;
+            this.versionId = value.id;
+            this.deleted = true;
+        }
+    }
+}
+
+@variant("shared_fs_directory_record")
+export class DirectoryRecord extends SharedFsEntry {
+    kind: SharedFsEntryKind = "directory";
+
+    @field({ type: "string" })
+    id: string;
+
+    @field({ type: "string" })
+    nodeId: string;
+
+    @field({ type: "string" })
+    parentId: string;
+
+    @field({ type: "string" })
+    name: string;
+
+    @field({ type: "u64" })
+    createdAt: bigint;
+
+    @field({ type: "u64" })
+    updatedAt: bigint;
+
+    @field({ type: "string" })
+    authorKey: string;
+
+    @field({ type: "string" })
+    machineLabel: string;
+
+    @field({ type: "bool" })
+    deleted: boolean;
+
+    constructor(properties?: {
+        nodeId: string;
+        parentId: string;
+        name: string;
+        createdAt: bigint | number;
+        updatedAt?: bigint | number;
+        authorKey: string;
+        machineLabel: string;
+        deleted?: boolean;
+    }) {
+        super();
+        if (properties) {
+            this.id = properties.nodeId;
+            this.nodeId = properties.nodeId;
+            this.parentId = properties.parentId;
+            this.name = properties.name;
+            this.createdAt = BigInt(properties.createdAt);
+            this.updatedAt = BigInt(
+                properties.updatedAt ?? properties.createdAt
+            );
+            this.authorKey = properties.authorKey;
+            this.machineLabel = properties.machineLabel;
+            this.deleted = properties.deleted ?? false;
+        }
+    }
+}
+
+@variant("shared_fs_file_record")
+export class FileRecord extends SharedFsEntry {
+    kind: SharedFsEntryKind = "file";
+
+    @field({ type: "string" })
+    id: string;
+
+    @field({ type: "string" })
+    nodeId: string;
+
+    @field({ type: "string" })
+    parentId: string;
+
+    @field({ type: "string" })
+    name: string;
+
+    @field({ type: option("string") })
+    currentVersionId?: string;
+
+    @field({ type: "u64" })
+    createdAt: bigint;
+
+    @field({ type: "u64" })
+    updatedAt: bigint;
+
+    @field({ type: "string" })
+    authorKey: string;
+
+    @field({ type: "string" })
+    machineLabel: string;
+
+    @field({ type: "bool" })
+    deleted: boolean;
+
+    constructor(properties?: {
+        nodeId: string;
+        parentId: string;
+        name: string;
+        currentVersionId?: string;
+        createdAt: bigint | number;
+        updatedAt?: bigint | number;
+        authorKey: string;
+        machineLabel: string;
+        deleted?: boolean;
+    }) {
+        super();
+        if (properties) {
+            this.id = properties.nodeId;
+            this.nodeId = properties.nodeId;
+            this.parentId = properties.parentId;
+            this.name = properties.name;
+            this.currentVersionId = properties.currentVersionId;
+            this.createdAt = BigInt(properties.createdAt);
+            this.updatedAt = BigInt(
+                properties.updatedAt ?? properties.createdAt
+            );
+            this.authorKey = properties.authorKey;
+            this.machineLabel = properties.machineLabel;
+            this.deleted = properties.deleted ?? false;
+        }
+    }
+}
+
+@variant("shared_fs_file_chunk")
+export class FileChunk extends SharedFsEntry {
+    kind: SharedFsEntryKind = "file-chunk";
+
+    @field({ type: "string" })
+    id: string;
+
+    @field({ type: "string" })
+    versionId: string;
+
+    @field({ type: "u32" })
+    index: number;
+
+    @field({ type: Uint8Array })
+    bytes: Uint8Array;
+
+    @field({ type: "string" })
+    hash: string;
+
+    constructor(properties?: {
+        id: string;
+        versionId: string;
+        index: number;
+        bytes: Uint8Array;
+        hash?: string;
+    }) {
+        super();
+        if (properties) {
+            this.id = properties.id;
+            this.versionId = properties.versionId;
+            this.index = properties.index;
+            this.bytes = properties.bytes;
+            this.hash = properties.hash ?? sha256Base64Sync(properties.bytes);
+        }
+    }
+}
+
+@variant("shared_fs_file_version")
+export class FileVersion extends SharedFsEntry {
+    kind: SharedFsEntryKind = "file-version";
+
+    @field({ type: "string" })
+    id: string;
+
+    @field({ type: "string" })
+    nodeId: string;
+
+    @field({ type: "string" })
+    parentId: string;
+
+    @field({ type: "string" })
+    name: string;
+
+    @field({ type: vec("string") })
+    parentVersionIds: string[];
+
+    @field({ type: "string" })
+    contentHash: string;
+
+    @field({ type: "u64" })
+    size: bigint;
+
+    @field({ type: vec("string") })
+    chunkIds: string[];
+
+    @field({ type: "u64" })
+    createdAt: bigint;
+
+    @field({ type: "string" })
+    authorKey: string;
+
+    @field({ type: "string" })
+    machineLabel: string;
+
+    @field({ type: "bool" })
+    conflictResolution: boolean;
+
+    constructor(properties?: {
+        id: string;
+        nodeId: string;
+        parentId: string;
+        name: string;
+        parentVersionIds?: string[];
+        contentHash: string;
+        size: bigint | number;
+        chunkIds: string[];
+        createdAt: bigint | number;
+        authorKey: string;
+        machineLabel: string;
+        conflictResolution?: boolean;
+    }) {
+        super();
+        if (properties) {
+            this.id = properties.id;
+            this.nodeId = properties.nodeId;
+            this.parentId = properties.parentId;
+            this.name = properties.name;
+            this.parentVersionIds = properties.parentVersionIds ?? [];
+            this.contentHash = properties.contentHash;
+            this.size = BigInt(properties.size);
+            this.chunkIds = properties.chunkIds;
+            this.createdAt = BigInt(properties.createdAt);
+            this.authorKey = properties.authorKey;
+            this.machineLabel = properties.machineLabel;
+            this.conflictResolution = properties.conflictResolution ?? false;
+        }
+    }
+}
+
+@variant("shared_fs_delete_marker")
+export class DeleteMarker extends SharedFsEntry {
+    kind: SharedFsEntryKind = "delete-marker";
+
+    @field({ type: "string" })
+    id: string;
+
+    @field({ type: "string" })
+    nodeId: string;
+
+    @field({ type: "string" })
+    parentId: string;
+
+    @field({ type: "string" })
+    name: string;
+
+    @field({ type: vec("string") })
+    parentVersionIds: string[];
+
+    @field({ type: "u64" })
+    createdAt: bigint;
+
+    @field({ type: "string" })
+    authorKey: string;
+
+    @field({ type: "string" })
+    machineLabel: string;
+
+    constructor(properties?: {
+        id: string;
+        nodeId: string;
+        parentId: string;
+        name: string;
+        parentVersionIds?: string[];
+        createdAt: bigint | number;
+        authorKey: string;
+        machineLabel: string;
+    }) {
+        super();
+        if (properties) {
+            this.id = properties.id;
+            this.nodeId = properties.nodeId;
+            this.parentId = properties.parentId;
+            this.name = properties.name;
+            this.parentVersionIds = properties.parentVersionIds ?? [];
+            this.createdAt = BigInt(properties.createdAt);
+            this.authorKey = properties.authorKey;
+            this.machineLabel = properties.machineLabel;
+        }
+    }
+}
+
+export type FileHead = FileVersion | DeleteMarker;
+
+export const isFileHead = (entry: SharedFsEntry): entry is FileHead =>
+    entry instanceof FileVersion || entry instanceof DeleteMarker;

--- a/packages/shared-fs/library/src/mount-backend.ts
+++ b/packages/shared-fs/library/src/mount-backend.ts
@@ -1,0 +1,544 @@
+import type {
+    SharedFsConflict,
+    SharedFsEntryInfo,
+    SharedFsVersionInfo,
+    WriteFileOptions,
+} from "./index.js";
+import {
+    CONFLICTS_DIR,
+    basename,
+    decodeConflictPathName,
+    dirname,
+    encodeConflictPathName,
+    joinFsPath,
+    normalizeFsPath,
+    pathSegments,
+} from "./path.js";
+
+export type SharedFsMountBackendTarget = {
+    readFile(path: string): Promise<Uint8Array | undefined>;
+    readVersion(
+        path: string,
+        versionId: string
+    ): Promise<Uint8Array | undefined>;
+    writeFile(
+        path: string,
+        source: Uint8Array | string | AsyncIterable<Uint8Array>,
+        options?: WriteFileOptions
+    ): Promise<unknown>;
+    mkdir(path: string): Promise<unknown>;
+    rm(path: string): Promise<unknown>;
+    rename(from: string, to: string): Promise<unknown>;
+    list(path?: string): Promise<SharedFsEntryInfo[]>;
+    versions(path: string): Promise<SharedFsVersionInfo[]>;
+    conflicts(path?: string): Promise<SharedFsConflict[]>;
+};
+
+export type SharedFsOpenFlags =
+    | number
+    | string
+    | {
+          read?: boolean;
+          write?: boolean;
+          create?: boolean;
+          truncate?: boolean;
+          append?: boolean;
+      };
+
+export type SharedFsStat = {
+    path: string;
+    kind: "directory" | "file";
+    size: number;
+    mode: number;
+    mtimeMs: number;
+    ctimeMs: number;
+    nlink: number;
+};
+
+export type SharedFsDirent = {
+    name: string;
+    kind: "directory" | "file";
+};
+
+export type SharedFsMountBackend = {
+    getattr(path: string): Promise<SharedFsStat>;
+    readdir(path: string): Promise<SharedFsDirent[]>;
+    open(path: string, flags?: SharedFsOpenFlags): Promise<number>;
+    read(handle: number, size: number, offset: number): Promise<Uint8Array>;
+    write(handle: number, data: Uint8Array, offset: number): Promise<number>;
+    flush(handle: number): Promise<void>;
+    fsync(handle: number): Promise<void>;
+    release(handle: number): Promise<void>;
+    mkdir(path: string): Promise<void>;
+    rmdir(path: string): Promise<void>;
+    rename(from: string, to: string): Promise<void>;
+    unlink(path: string): Promise<void>;
+};
+
+export type SharedFsBackendErrorCode =
+    | "ENOENT"
+    | "EIO"
+    | "EEXIST"
+    | "EISDIR"
+    | "ENOTDIR"
+    | "EACCES"
+    | "EBADF"
+    | "EROFS";
+
+export class SharedFsBackendError extends Error {
+    constructor(
+        readonly code: SharedFsBackendErrorCode,
+        message: string
+    ) {
+        super(message);
+        this.name = "SharedFsBackendError";
+    }
+}
+
+type OpenHandle = {
+    path: string;
+    buffer: Uint8Array;
+    write: boolean;
+    dirty: boolean;
+    readOnly: boolean;
+};
+
+const S_IFDIR = 0o040000;
+const S_IFREG = 0o100000;
+const O_WRONLY = 0o1;
+const O_RDWR = 0o2;
+const O_CREAT = 0o100;
+const O_TRUNC = 0o1000;
+const O_APPEND = 0o2000;
+
+const bigintToSize = (value: bigint) => {
+    return value > BigInt(Number.MAX_SAFE_INTEGER)
+        ? Number.MAX_SAFE_INTEGER
+        : Number(value);
+};
+
+const nowMs = () => Date.now();
+
+const directoryStat = (path: string, mtimeMs = nowMs()): SharedFsStat => ({
+    path,
+    kind: "directory",
+    size: 0,
+    mode: S_IFDIR | 0o755,
+    mtimeMs,
+    ctimeMs: mtimeMs,
+    nlink: 2,
+});
+
+const fileStat = (
+    path: string,
+    size: number,
+    mtimeMs = nowMs()
+): SharedFsStat => ({
+    path,
+    kind: "file",
+    size,
+    mode: S_IFREG | 0o644,
+    mtimeMs,
+    ctimeMs: mtimeMs,
+    nlink: 1,
+});
+
+const parseFlags = (flags: SharedFsOpenFlags | undefined) => {
+    if (flags == null) {
+        return {
+            read: true,
+            write: false,
+            create: false,
+            truncate: false,
+            append: false,
+        };
+    }
+    if (typeof flags === "string") {
+        return {
+            read: flags.includes("+") || flags.startsWith("r"),
+            write:
+                flags.includes("w") ||
+                flags.includes("a") ||
+                flags.includes("+"),
+            create: flags.includes("w") || flags.includes("a"),
+            truncate: flags.includes("w"),
+            append: flags.includes("a"),
+        };
+    }
+    if (typeof flags === "number") {
+        const access = flags & 0o3;
+        return {
+            read: access === 0 || access === O_RDWR,
+            write: access === O_WRONLY || access === O_RDWR,
+            create: (flags & O_CREAT) === O_CREAT,
+            truncate: (flags & O_TRUNC) === O_TRUNC,
+            append: (flags & O_APPEND) === O_APPEND,
+        };
+    }
+    return {
+        read: flags.read ?? !flags.write,
+        write: flags.write ?? false,
+        create: flags.create ?? false,
+        truncate: flags.truncate ?? false,
+        append: flags.append ?? false,
+    };
+};
+
+const isConflictPath = (path: string) => {
+    return pathSegments(path)[0] === CONFLICTS_DIR;
+};
+
+const parseConflictPath = (path: string) => {
+    const segments = pathSegments(path);
+    if (segments[0] !== CONFLICTS_DIR) {
+        return undefined;
+    }
+    if (segments.length === 1) {
+        return { kind: "root" as const };
+    }
+    const filePath = decodeConflictPathName(segments[1]);
+    if (segments.length === 2) {
+        return { kind: "path" as const, filePath };
+    }
+    if (segments.length === 3) {
+        return { kind: "version" as const, filePath, versionId: segments[2] };
+    }
+    return { kind: "invalid" as const };
+};
+
+const notFound = (path: string) =>
+    new SharedFsBackendError("ENOENT", `Path does not exist: ${path}`);
+
+const findEntry = async (
+    target: SharedFsMountBackendTarget,
+    path: string
+): Promise<SharedFsEntryInfo | undefined> => {
+    const normalized = normalizeFsPath(path);
+    if (normalized === "/") {
+        return undefined;
+    }
+    const entries = await target.list(dirname(normalized));
+    return entries.find((entry) => entry.name === basename(normalized));
+};
+
+export const createSharedFsMountBackend = (
+    target: SharedFsMountBackendTarget
+): SharedFsMountBackend => {
+    const handles = new Map<number, OpenHandle>();
+    let nextHandle = 1;
+
+    const conflictForPath = async (path: string) => {
+        const conflicts = await target.conflicts();
+        return conflicts.find((conflict) => conflict.path === path);
+    };
+
+    const getattrConflict = async (path: string): Promise<SharedFsStat> => {
+        const parsed = parseConflictPath(path);
+        if (!parsed || parsed.kind === "invalid") {
+            throw notFound(path);
+        }
+        if (parsed.kind === "root") {
+            return directoryStat(joinFsPath("/", CONFLICTS_DIR));
+        }
+        const conflict = await conflictForPath(parsed.filePath);
+        if (!conflict) {
+            throw notFound(path);
+        }
+        if (parsed.kind === "path") {
+            return directoryStat(path);
+        }
+        const version = conflict.versions.find(
+            (candidate) => candidate.id === parsed.versionId
+        );
+        if (!version || version.deleted) {
+            throw notFound(path);
+        }
+        return fileStat(
+            path,
+            bigintToSize(version.size),
+            Number(version.createdAt)
+        );
+    };
+
+    const readConflictFile = async (path: string) => {
+        const parsed = parseConflictPath(path);
+        if (!parsed || parsed.kind !== "version") {
+            throw new SharedFsBackendError(
+                "EISDIR",
+                `Path is not a conflict file: ${path}`
+            );
+        }
+        const bytes = await target.readVersion(
+            parsed.filePath,
+            parsed.versionId
+        );
+        if (!bytes) {
+            throw notFound(path);
+        }
+        return bytes;
+    };
+
+    const commit = async (handle: OpenHandle) => {
+        if (!handle.dirty) {
+            return;
+        }
+        if (handle.readOnly) {
+            throw new SharedFsBackendError(
+                "EROFS",
+                `Path is read-only: ${handle.path}`
+            );
+        }
+        await target.writeFile(handle.path, handle.buffer);
+        handle.dirty = false;
+    };
+
+    const backend: SharedFsMountBackend = {
+        async getattr(path: string) {
+            const normalized = normalizeFsPath(path);
+            if (normalized === "/") {
+                return directoryStat("/");
+            }
+            if (isConflictPath(normalized)) {
+                return getattrConflict(normalized);
+            }
+            const entry = await findEntry(target, normalized);
+            if (!entry) {
+                throw notFound(normalized);
+            }
+            return entry.kind === "directory"
+                ? directoryStat(normalized, Number(entry.updatedAt))
+                : fileStat(
+                      normalized,
+                      bigintToSize(entry.size),
+                      Number(entry.updatedAt)
+                  );
+        },
+
+        async readdir(path: string) {
+            const normalized = normalizeFsPath(path);
+            if (isConflictPath(normalized)) {
+                const parsed = parseConflictPath(normalized);
+                if (
+                    !parsed ||
+                    parsed.kind === "invalid" ||
+                    parsed.kind === "version"
+                ) {
+                    throw new SharedFsBackendError(
+                        "ENOTDIR",
+                        `Path is not a directory: ${normalized}`
+                    );
+                }
+                if (parsed.kind === "root") {
+                    return (await target.conflicts()).map((conflict) => ({
+                        name: encodeConflictPathName(conflict.path),
+                        kind: "directory" as const,
+                    }));
+                }
+                const conflict = await conflictForPath(parsed.filePath);
+                if (!conflict) {
+                    throw notFound(normalized);
+                }
+                return conflict.versions
+                    .filter((version) => !version.deleted)
+                    .map((version) => ({
+                        name: version.id,
+                        kind: "file" as const,
+                    }));
+            }
+            const entries = (await target.list(normalized)).map((entry) => ({
+                name: entry.name,
+                kind: entry.kind,
+            }));
+            if (normalized === "/") {
+                entries.push({ name: CONFLICTS_DIR, kind: "directory" });
+            }
+            return entries;
+        },
+
+        async open(path: string, flags?: SharedFsOpenFlags) {
+            const normalized = normalizeFsPath(path);
+            const parsedFlags = parseFlags(flags);
+            if (isConflictPath(normalized)) {
+                if (parsedFlags.write) {
+                    throw new SharedFsBackendError(
+                        "EROFS",
+                        `Path is read-only: ${normalized}`
+                    );
+                }
+                const buffer = await readConflictFile(normalized);
+                const handle = nextHandle++;
+                handles.set(handle, {
+                    path: normalized,
+                    buffer,
+                    write: false,
+                    dirty: false,
+                    readOnly: true,
+                });
+                return handle;
+            }
+            const entry = await findEntry(target, normalized);
+            if (entry?.kind === "directory") {
+                throw new SharedFsBackendError(
+                    "EISDIR",
+                    `Path is a directory: ${normalized}`
+                );
+            }
+            if (!entry && !parsedFlags.create && !parsedFlags.write) {
+                throw notFound(normalized);
+            }
+            const existing = parsedFlags.truncate
+                ? new Uint8Array(0)
+                : ((await target.readFile(normalized)) ?? new Uint8Array(0));
+            const handle = nextHandle++;
+            handles.set(handle, {
+                path: normalized,
+                buffer: existing,
+                write: parsedFlags.write,
+                dirty: false,
+                readOnly: false,
+            });
+            return handle;
+        },
+
+        async read(handle: number, size: number, offset: number) {
+            const openHandle = handles.get(handle);
+            if (!openHandle) {
+                throw new SharedFsBackendError(
+                    "EBADF",
+                    `Unknown file handle: ${handle}`
+                );
+            }
+            return openHandle.buffer.subarray(offset, offset + size);
+        },
+
+        async write(handle: number, data: Uint8Array, offset: number) {
+            const openHandle = handles.get(handle);
+            if (!openHandle) {
+                throw new SharedFsBackendError(
+                    "EBADF",
+                    `Unknown file handle: ${handle}`
+                );
+            }
+            if (!openHandle.write) {
+                throw new SharedFsBackendError(
+                    "EACCES",
+                    `File handle is not writable: ${handle}`
+                );
+            }
+            const nextLength = Math.max(
+                openHandle.buffer.byteLength,
+                offset + data.byteLength
+            );
+            const nextBuffer = new Uint8Array(nextLength);
+            nextBuffer.set(openHandle.buffer);
+            nextBuffer.set(data, offset);
+            openHandle.buffer = nextBuffer;
+            openHandle.dirty = true;
+            return data.byteLength;
+        },
+
+        async flush(handle: number) {
+            const openHandle = handles.get(handle);
+            if (!openHandle) {
+                throw new SharedFsBackendError(
+                    "EBADF",
+                    `Unknown file handle: ${handle}`
+                );
+            }
+            await commit(openHandle);
+        },
+
+        async fsync(handle: number) {
+            const openHandle = handles.get(handle);
+            if (!openHandle) {
+                throw new SharedFsBackendError(
+                    "EBADF",
+                    `Unknown file handle: ${handle}`
+                );
+            }
+            await commit(openHandle);
+        },
+
+        async release(handle: number) {
+            const openHandle = handles.get(handle);
+            if (!openHandle) {
+                return;
+            }
+            await commit(openHandle);
+            handles.delete(handle);
+        },
+
+        async mkdir(path: string) {
+            const normalized = normalizeFsPath(path);
+            if (isConflictPath(normalized)) {
+                throw new SharedFsBackendError(
+                    "EROFS",
+                    `Path is read-only: ${normalized}`
+                );
+            }
+            if (await findEntry(target, normalized)) {
+                throw new SharedFsBackendError(
+                    "EEXIST",
+                    `Path already exists: ${normalized}`
+                );
+            }
+            await target.mkdir(normalized);
+        },
+
+        async rmdir(path: string) {
+            const normalized = normalizeFsPath(path);
+            if (isConflictPath(normalized)) {
+                throw new SharedFsBackendError(
+                    "EROFS",
+                    `Path is read-only: ${normalized}`
+                );
+            }
+            const entry = await findEntry(target, normalized);
+            if (!entry) {
+                throw notFound(normalized);
+            }
+            if (entry.kind !== "directory") {
+                throw new SharedFsBackendError(
+                    "ENOTDIR",
+                    `Path is not a directory: ${normalized}`
+                );
+            }
+            await target.rm(normalized);
+        },
+
+        async rename(from: string, to: string) {
+            const fromPath = normalizeFsPath(from);
+            const toPath = normalizeFsPath(to);
+            if (isConflictPath(fromPath) || isConflictPath(toPath)) {
+                throw new SharedFsBackendError(
+                    "EROFS",
+                    "Conflict metadata is read-only"
+                );
+            }
+            await target.rename(fromPath, toPath);
+        },
+
+        async unlink(path: string) {
+            const normalized = normalizeFsPath(path);
+            if (isConflictPath(normalized)) {
+                throw new SharedFsBackendError(
+                    "EROFS",
+                    `Path is read-only: ${normalized}`
+                );
+            }
+            const entry = await findEntry(target, normalized);
+            if (!entry) {
+                throw notFound(normalized);
+            }
+            if (entry.kind !== "file") {
+                throw new SharedFsBackendError(
+                    "EISDIR",
+                    `Path is a directory: ${normalized}`
+                );
+            }
+            await target.rm(normalized);
+        },
+    };
+
+    return backend;
+};

--- a/packages/shared-fs/library/src/native-mount.ts
+++ b/packages/shared-fs/library/src/native-mount.ts
@@ -18,6 +18,14 @@ export type NativeMountSession = {
     unmount(): Promise<void>;
 };
 
+export type NativeMountSupport = {
+    platform: NodeJS.Platform;
+    adapter: "fuse-native" | "winfsp" | "unsupported";
+    available: boolean;
+    missing: string[];
+    notes: string[];
+};
+
 export class NativeMountUnavailableError extends Error {
     constructor(message: string) {
         super(message);
@@ -43,6 +51,108 @@ const importOptional = async (specifier: string) => {
         "return import(specifier)"
     ) as (specifier: string) => Promise<unknown>;
     return dynamicImport(specifier);
+};
+
+const pathExists = async (path: string) => {
+    const { access } = await import("node:fs/promises");
+    try {
+        await access(path);
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+const commandExists = async (command: string) => {
+    const { execFile } = await import("node:child_process");
+    const executable = process.platform === "win32" ? "where" : "which";
+    return new Promise<boolean>((resolve) => {
+        execFile(executable, [command], (error) => {
+            resolve(!error);
+        });
+    });
+};
+
+const packageAvailable = async (specifier: string) => {
+    try {
+        await importOptional(specifier);
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+export const getNativeMountSupport = async (): Promise<NativeMountSupport> => {
+    if (process.platform === "linux") {
+        const hasFuseDevice = await pathExists("/dev/fuse");
+        const hasFusermount =
+            (await commandExists("fusermount3")) ||
+            (await commandExists("fusermount"));
+        const hasFuseNative = await packageAvailable("fuse-native");
+        const missing = [
+            !hasFuseDevice ? "/dev/fuse" : undefined,
+            !hasFusermount ? "fusermount/fusermount3" : undefined,
+            !hasFuseNative ? "optional fuse-native package" : undefined,
+        ].filter((value): value is string => value != null);
+        return {
+            platform: process.platform,
+            adapter: "fuse-native",
+            available: missing.length === 0,
+            missing,
+            notes: ["Linux native mounts use FUSE/libfuse."],
+        };
+    }
+
+    if (process.platform === "darwin") {
+        const hasMacFuse =
+            (await pathExists("/Library/Filesystems/macfuse.fs")) ||
+            (await commandExists("mount_macfuse"));
+        const hasFuseNative = await packageAvailable("fuse-native");
+        const missing = [
+            !hasMacFuse ? "macFUSE" : undefined,
+            !hasFuseNative ? "optional fuse-native package" : undefined,
+        ].filter((value): value is string => value != null);
+        return {
+            platform: process.platform,
+            adapter: "fuse-native",
+            available: missing.length === 0,
+            missing,
+            notes: [
+                "macOS native mounts require macFUSE, which usually needs host-level installation and approval.",
+            ],
+        };
+    }
+
+    if (process.platform === "win32") {
+        const hasWinFsp =
+            (await pathExists(
+                "C:\\Program Files\\WinFsp\\bin\\winfsp-x64.dll"
+            )) ||
+            (await pathExists(
+                "C:\\Program Files (x86)\\WinFsp\\bin\\winfsp-x64.dll"
+            ));
+        const missing = [
+            !hasWinFsp ? "WinFsp runtime" : undefined,
+            "WinFsp adapter binary",
+        ].filter((value): value is string => value != null);
+        return {
+            platform: process.platform,
+            adapter: "winfsp",
+            available: false,
+            missing,
+            notes: [
+                "The shared IPC/backend contract is present, but this package does not bundle a WinFsp adapter binary yet.",
+            ],
+        };
+    }
+
+    return {
+        platform: process.platform,
+        adapter: "unsupported",
+        available: false,
+        missing: [`native mount adapter for ${process.platform}`],
+        notes: [],
+    };
 };
 
 const isBackend = (

--- a/packages/shared-fs/library/src/native-mount.ts
+++ b/packages/shared-fs/library/src/native-mount.ts
@@ -1,0 +1,278 @@
+import type {
+    SharedFsMountBackend,
+    SharedFsMountBackendTarget,
+} from "./mount-backend.js";
+import {
+    SharedFsBackendError,
+    createSharedFsMountBackend,
+} from "./mount-backend.js";
+
+export type NativeMountOptions = {
+    mountpoint: string;
+    force?: boolean;
+    mkdir?: boolean;
+};
+
+export type NativeMountSession = {
+    mountpoint: string;
+    unmount(): Promise<void>;
+};
+
+export class NativeMountUnavailableError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "NativeMountUnavailableError";
+    }
+}
+
+const errno = {
+    EPERM: -1,
+    ENOENT: -2,
+    EIO: -5,
+    EBADF: -9,
+    EACCES: -13,
+    EEXIST: -17,
+    ENOTDIR: -20,
+    EISDIR: -21,
+    EROFS: -30,
+};
+
+const importOptional = async (specifier: string) => {
+    const dynamicImport = new Function(
+        "specifier",
+        "return import(specifier)"
+    ) as (specifier: string) => Promise<unknown>;
+    return dynamicImport(specifier);
+};
+
+const isBackend = (
+    value: SharedFsMountBackend | SharedFsMountBackendTarget
+): value is SharedFsMountBackend => {
+    return typeof (value as SharedFsMountBackend).getattr === "function";
+};
+
+const toErrno = (error: unknown) => {
+    if (error instanceof SharedFsBackendError) {
+        return errno[error.code] ?? errno.EIO;
+    }
+    return errno.EIO;
+};
+
+const withCallback = (
+    fn: () => Promise<void>,
+    callback: (errno: number) => void
+) => {
+    fn().then(
+        () => callback(0),
+        (error) => callback(toErrno(error))
+    );
+};
+
+const loadFuseNative = async () => {
+    try {
+        const loaded = (await importOptional("fuse-native")) as {
+            default?: unknown;
+        };
+        return loaded.default ?? loaded;
+    } catch (error) {
+        throw new NativeMountUnavailableError(
+            process.platform === "darwin"
+                ? "macOS native mounts require macFUSE and the optional fuse-native package."
+                : "Linux native mounts require libfuse/FUSE and the optional fuse-native package."
+        );
+    }
+};
+
+export const mountNativeSharedFs = async (
+    target: SharedFsMountBackend | SharedFsMountBackendTarget,
+    options: NativeMountOptions
+): Promise<NativeMountSession> => {
+    if (process.platform === "win32") {
+        throw new NativeMountUnavailableError(
+            "Windows native mounts require the WinFsp adapter. The shared IPC/backend contract is present, but this package does not bundle a WinFsp binary yet."
+        );
+    }
+    if (process.platform !== "linux" && process.platform !== "darwin") {
+        throw new NativeMountUnavailableError(
+            `Native mounts are not supported on ${process.platform}.`
+        );
+    }
+
+    const backend = isBackend(target)
+        ? target
+        : createSharedFsMountBackend(target);
+    const Fuse = (await loadFuseNative()) as any;
+    const fuse = new Fuse(
+        options.mountpoint,
+        {
+            getattr(
+                path: string,
+                callback: (errno: number, stat?: unknown) => void
+            ) {
+                backend.getattr(path).then(
+                    (stat) =>
+                        callback(0, {
+                            mtime: new Date(stat.mtimeMs),
+                            atime: new Date(stat.mtimeMs),
+                            ctime: new Date(stat.ctimeMs),
+                            size: stat.size,
+                            mode: stat.mode,
+                            uid: process.getuid?.() ?? 0,
+                            gid: process.getgid?.() ?? 0,
+                        }),
+                    (error) => callback(toErrno(error))
+                );
+            },
+            readdir(
+                path: string,
+                callback: (errno: number, names?: string[]) => void
+            ) {
+                backend.readdir(path).then(
+                    (entries) =>
+                        callback(
+                            0,
+                            entries.map((entry) => entry.name)
+                        ),
+                    (error) => callback(toErrno(error))
+                );
+            },
+            open(
+                path: string,
+                flags: number,
+                callback: (errno: number, fd?: number) => void
+            ) {
+                backend.open(path, flags).then(
+                    (handle) => callback(0, handle),
+                    (error) => callback(toErrno(error))
+                );
+            },
+            read(
+                _path: string,
+                fd: number,
+                buffer: Buffer,
+                length: number,
+                position: number,
+                callback: (bytesRead: number) => void
+            ) {
+                backend.read(fd, length, position).then(
+                    (bytes) => {
+                        buffer.set(bytes);
+                        callback(bytes.byteLength);
+                    },
+                    () => callback(0)
+                );
+            },
+            write(
+                _path: string,
+                fd: number,
+                buffer: Buffer,
+                length: number,
+                position: number,
+                callback: (bytesWritten: number) => void
+            ) {
+                backend
+                    .write(
+                        fd,
+                        new Uint8Array(buffer.subarray(0, length)),
+                        position
+                    )
+                    .then(
+                        (written) => callback(written),
+                        () => callback(0)
+                    );
+            },
+            flush(
+                _path: string,
+                fd: number,
+                callback: (errno: number) => void
+            ) {
+                withCallback(() => backend.flush(fd), callback);
+            },
+            fsync(
+                _path: string,
+                fd: number,
+                _datasync: boolean,
+                callback: (errno: number) => void
+            ) {
+                withCallback(() => backend.fsync(fd), callback);
+            },
+            release(
+                _path: string,
+                fd: number,
+                callback: (errno: number) => void
+            ) {
+                withCallback(() => backend.release(fd), callback);
+            },
+            mkdir(
+                path: string,
+                _mode: number,
+                callback: (errno: number) => void
+            ) {
+                withCallback(() => backend.mkdir(path), callback);
+            },
+            rmdir(path: string, callback: (errno: number) => void) {
+                withCallback(() => backend.rmdir(path), callback);
+            },
+            rename(
+                from: string,
+                to: string,
+                callback: (errno: number) => void
+            ) {
+                withCallback(() => backend.rename(from, to), callback);
+            },
+            unlink(path: string, callback: (errno: number) => void) {
+                withCallback(() => backend.unlink(path), callback);
+            },
+        },
+        {
+            force: options.force ?? true,
+            mkdir: options.mkdir ?? true,
+        }
+    );
+
+    await new Promise<void>((resolve, reject) => {
+        fuse.mount((error: Error | undefined) => {
+            if (error) {
+                reject(error);
+            } else {
+                resolve();
+            }
+        });
+    });
+
+    return {
+        mountpoint: options.mountpoint,
+        async unmount() {
+            await new Promise<void>((resolve, reject) => {
+                fuse.unmount((error: Error | undefined) => {
+                    if (error) {
+                        reject(error);
+                    } else {
+                        resolve();
+                    }
+                });
+            });
+        },
+    };
+};
+
+export const unmountNativeMountpoint = async (mountpoint: string) => {
+    if (process.platform === "win32") {
+        throw new NativeMountUnavailableError(
+            "Windows unmount requires the WinFsp adapter service."
+        );
+    }
+    const { execFile } = await import("node:child_process");
+    const command = process.platform === "darwin" ? "umount" : "fusermount";
+    const args =
+        process.platform === "darwin" ? [mountpoint] : ["-u", mountpoint];
+    await new Promise<void>((resolve, reject) => {
+        execFile(command, args, (error) => {
+            if (error) {
+                reject(error);
+            } else {
+                resolve();
+            }
+        });
+    });
+};

--- a/packages/shared-fs/library/src/path.ts
+++ b/packages/shared-fs/library/src/path.ts
@@ -1,0 +1,47 @@
+export const ROOT_NODE_ID = "root";
+export const CONFLICTS_DIR = ".peerbit-conflicts";
+
+export const normalizeFsPath = (input: string) => {
+    const raw = input || "/";
+    const parts = raw
+        .replaceAll("\\", "/")
+        .split("/")
+        .filter((part) => part.length > 0 && part !== ".");
+    const stack: string[] = [];
+    for (const part of parts) {
+        if (part === "..") {
+            stack.pop();
+        } else {
+            stack.push(part);
+        }
+    }
+    return "/" + stack.join("/");
+};
+
+export const pathSegments = (input: string) => {
+    const normalized = normalizeFsPath(input);
+    return normalized === "/"
+        ? []
+        : normalized.slice(1).split("/").filter(Boolean);
+};
+
+export const dirname = (input: string) => {
+    const segments = pathSegments(input);
+    segments.pop();
+    return "/" + segments.join("/");
+};
+
+export const basename = (input: string) => {
+    const segments = pathSegments(input);
+    return segments.at(-1) ?? "";
+};
+
+export const joinFsPath = (...parts: string[]) => {
+    return normalizeFsPath(parts.join("/"));
+};
+
+export const encodeConflictPathName = (path: string) =>
+    encodeURIComponent(normalizeFsPath(path)).replaceAll("%", "~");
+
+export const decodeConflictPathName = (name: string) =>
+    normalizeFsPath(decodeURIComponent(name.replaceAll("~", "%")));

--- a/packages/shared-fs/library/tsconfig.json
+++ b/packages/shared-fs/library/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src"],
+    "exclude": ["src/__tests__"],
+    "compilerOptions": {
+        "noEmit": false,
+        "outDir": "lib/esm"
+    }
+}

--- a/packages/shared-fs/library/vitest.setup.ts
+++ b/packages/shared-fs/library/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "../../../vitest.setup.ts";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,10 +175,10 @@ importers:
         version: link:../../social-media-app/app-sdk
       '@peerbit/document-react':
         specifier: ^1.0.42
-        version: 1.0.42(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.0.42(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@peerbit/react':
         specifier: ^1.1.21
-        version: 1.1.21(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.21(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-popover':
         specifier: ^1.0.7
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -205,7 +205,7 @@ importers:
         version: 1.4.0
       peerbit:
         specifier: ^5.2.18
-        version: 5.2.18(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.2.18(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -272,10 +272,10 @@ importers:
         version: 5.18.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@peerbit/document':
         specifier: ^13.0.42
-        version: 13.0.42(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))
+        version: 13.0.42(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/react':
         specifier: ^1.1.21
-        version: 1.1.21(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.21(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@tensorflow/tfjs':
         specifier: ^4.2.0
         version: 4.22.0(seedrandom@3.0.5)
@@ -284,7 +284,7 @@ importers:
         version: 3.3.0
       peerbit:
         specifier: ^5.2.18
-        version: 5.2.18(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.2.18(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -956,6 +956,56 @@ importers:
       vite:
         specifier: ^7.1.3
         version: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+
+  packages/shared-fs/cli:
+    dependencies:
+      '@multiformats/multiaddr':
+        specifier: ^13.0.1
+        version: 13.0.1
+      '@peerbit/shared-fs':
+        specifier: workspace:*
+        version: link:../library
+      chalk:
+        specifier: ^5.3.0
+        version: 5.6.2
+      peerbit:
+        specifier: ^5
+        version: 5.2.18(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
+    devDependencies:
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  packages/shared-fs/library:
+    dependencies:
+      '@dao-xyz/borsh':
+        specifier: ^6.0.0
+        version: 6.0.1
+      '@peerbit/crypto':
+        specifier: ^3
+        version: 3.1.1
+      '@peerbit/document':
+        specifier: ^13
+        version: 13.0.42(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+      '@peerbit/program':
+        specifier: ^6
+        version: 6.0.29(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+      peerbit:
+        specifier: ^5
+        version: 5.2.18(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+      uint8arrays:
+        specifier: ^5.1.0
+        version: 5.1.1
+    devDependencies:
+      '@peerbit/test-utils':
+        specifier: ^3.0.33
+        version: 3.0.33(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
 
   packages/sharedworker-todo/frontend:
     dependencies:
@@ -11156,14 +11206,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 20.19.30
       jest-mock: 29.7.0
 
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 25.6.0
+      '@types/node': 20.19.30
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -11197,7 +11247,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.6.0
+      '@types/node': 20.19.30
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -11255,7 +11305,7 @@ snapshots:
       protons-runtime: 5.6.0
       retimeable-signal: 1.0.1
       uint8arraylist: 2.4.8
-      uint8arrays: 5.1.0
+      uint8arrays: 5.1.1
 
   '@libp2p/circuit-relay-v2@4.2.3':
     dependencies:
@@ -11286,7 +11336,7 @@ snapshots:
       multiformats: 13.4.2
       protons-runtime: 5.6.0
       uint8arraylist: 2.4.8
-      uint8arrays: 5.1.0
+      uint8arrays: 5.1.1
 
   '@libp2p/crypto@5.1.17':
     dependencies:
@@ -11401,7 +11451,7 @@ snapshots:
       '@libp2p/crypto': 5.1.17
       '@libp2p/interface': 3.1.0
       multiformats: 13.4.2
-      uint8arrays: 5.1.0
+      uint8arrays: 5.1.1
 
   '@libp2p/peer-id@6.0.8':
     dependencies:
@@ -11420,7 +11470,7 @@ snapshots:
       protons-runtime: 5.6.0
       uint8-varint: 2.0.4
       uint8arraylist: 2.4.8
-      uint8arrays: 5.1.0
+      uint8arrays: 5.1.1
 
   '@libp2p/peer-record@9.0.9':
     dependencies:
@@ -11486,7 +11536,7 @@ snapshots:
       race-signal: 2.0.0
       uint8-varint: 2.0.4
       uint8arraylist: 2.4.8
-      uint8arrays: 5.1.0
+      uint8arrays: 5.1.1
 
   '@libp2p/utils@7.1.0':
     dependencies:
@@ -11660,7 +11710,7 @@ snapshots:
       p-event: 7.1.0
       progress-events: 1.0.1
       uint8arraylist: 2.4.8
-      uint8arrays: 5.1.0
+      uint8arrays: 5.1.1
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -11773,7 +11823,7 @@ snapshots:
       hashlru: 2.3.0
       p-queue: 9.2.0
       progress-events: 1.1.0
-      uint8arrays: 5.1.0
+      uint8arrays: 5.1.1
 
   '@multiformats/multiaddr-matcher@3.0.1':
     dependencies:
@@ -12080,6 +12130,20 @@ snapshots:
       '@peerbit/program': 6.0.29(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/shared-log-proxy': 2.0.41(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/stream-interface': 6.0.9
+    transitivePeerDependencies:
+      - bufferutil
+      - react-native
+      - supports-color
+      - utf-8-validate
+
+  '@peerbit/document-react@1.0.42(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@peerbit/document': 13.0.42(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))
+      '@peerbit/indexer-interface': 3.0.3
+      '@peerbit/logger': 2.0.1
+      '@peerbit/react': 1.1.21(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      uuid: 10.0.0
     transitivePeerDependencies:
       - bufferutil
       - react-native
@@ -14089,7 +14153,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 20.19.30
 
   '@types/hast@3.0.4':
     dependencies:
@@ -14160,6 +14224,7 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+    optional: true
 
   '@types/offscreencanvas@2019.3.0': {}
 
@@ -15127,7 +15192,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 20.19.30
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -15136,7 +15201,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 20.19.30
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -16719,7 +16784,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 20.19.30
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -16729,7 +16794,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.6.0
+      '@types/node': 20.19.30
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -16756,7 +16821,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 20.19.30
       jest-util: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -16764,7 +16829,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 20.19.30
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -16781,7 +16846,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 20.19.30
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -18257,7 +18322,7 @@ snapshots:
     dependencies:
       uint8-varint: 2.0.4
       uint8arraylist: 2.4.8
-      uint8arrays: 5.1.0
+      uint8arrays: 5.1.1
 
   protons-runtime@6.0.1:
     dependencies:
@@ -19473,12 +19538,12 @@ snapshots:
 
   uint8-varint@2.0.4:
     dependencies:
-      uint8arraylist: 2.4.8
-      uint8arrays: 5.1.0
+      uint8arraylist: 2.4.9
+      uint8arrays: 5.1.1
 
   uint8arraylist@2.4.8:
     dependencies:
-      uint8arrays: 5.1.0
+      uint8arrays: 5.1.1
 
   uint8arraylist@2.4.9:
     dependencies:
@@ -19503,7 +19568,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.19.2: {}
+  undici-types@7.19.2:
+    optional: true
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## Summary
- add experimental `@peerbit/shared-fs` library under `packages/shared-fs/library`
- add `peerbit-fs` CLI package with create/mount/status/conflicts/benchmark/unmount commands
- model signed file versions, directories, tombstones, renames, chunk manifests, explicit conflicts, and commit-on-close mount writes
- add POSIX-ish mount backend plus local JSON-lines IPC boundary; Linux/macOS can use optional `fuse-native`, Windows WinFsp remains an adapter-binary follow-up against the same IPC contract
- add native mount support detection exposed through `peerbit-fs status`
- add two-peer local-first sync and two-peer conflict coverage, a portable native-support probe test, a skipped native mount smoke harness, and a baseline benchmark API/CLI workload
- add focused Shared FS CI for PRs on Ubuntu, macOS, and Windows plus formatting
- add cross-OS interop CI: a Linux seed peer shares one filesystem address, macOS and Windows join it, each OS writes a file, and all peers wait until they can read all OS files
- add manual `Shared FS Native Smoke` workflow for Linux FUSE/native adapter smoke testing

## Tests
- `pnpm -r --sort --filter @peerbit/shared-fs --filter @peerbit/shared-fs-cli run build`
- `pnpm --filter @peerbit/shared-fs run test`
- `pnpm --filter @peerbit/shared-fs-cli run test`
- `pnpm exec prettier --check .github/workflows/shared-fs-native-smoke.yml .github/workflows/shared-fs-ci.yml .github/workflows/shared-fs-cross-os-interop.yml packages/shared-fs`
- `node packages/shared-fs/cli/lib/esm/bin.js status --directory ""`
- local smoke: `node packages/shared-fs/cli/lib/esm/cross-os-interop.js --role seed --machine linux --expected linux --address-file /tmp/pbfs-interop-address/address.txt --timeout-ms 60000 --directory /tmp/pbfs-interop-local`

Note: native mount smoke is opt-in with `PEERBIT_SHARED_FS_NATIVE_SMOKE=1` because it requires local FUSE/macFUSE and optional `fuse-native`. The new manual workflow covers Linux FUSE; macOS/Windows native smoke still need runners with macFUSE/WinFsp and adapter hardening.