### PR TITLE
docs(shared-fs): document published install flow

### DIFF
--- a/.changeset/shared-fs-install-polish.md
+++ b/.changeset/shared-fs-install-polish.md
@@ -1,0 +1,7 @@
+---
+"@peerbit/shared-fs": patch
+"@peerbit/shared-fs-cli": patch
+---
+
+Document the published shared filesystem install path, native adapter setup,
+platform prerequisites, and authenticated multi-machine mount flow.

--- a/packages/shared-fs/cli/README.md
+++ b/packages/shared-fs/cli/README.md
@@ -32,25 +32,30 @@ authorize that writer.
 
 ## Install
 
-Install the CLI and native adapter:
+Install the CLI, then make sure the native adapter is installed:
 
 ```bash
 npm install -g @peerbit/shared-fs-cli
 peerbit-fs install-adapter
+peerbit-fs status
 ```
 
 `peerbit-fs install-adapter` downloads a prebuilt
-`peerbit-shared-fs-native` binary into `~/.peerbit/shared-fs/bin`. `mount` and
+`peerbit-shared-fs-native` binary into `~/.peerbit/shared-fs/bin`. The global
+package install also tries this automatically, but the explicit command is safe
+to rerun and is the easiest way to repair a missing adapter. `mount` and
 `status` auto-detect that managed adapter, a `peerbit-shared-fs-native` command
 on `PATH`, or `PEERBIT_SHARED_FS_NATIVE_ADAPTER`.
 
-Native runtime prerequisites are still platform-specific:
+Native runtime prerequisites are platform-specific:
 
-- Linux: FUSE/libfuse.
-- macOS: macFUSE, with one-time approval in System Settings when required.
-- Windows: WinFsp runtime.
+- Linux: FUSE/libfuse. On Debian or Ubuntu, install `fuse3` and
+  `libfuse3-dev`.
+- macOS: macFUSE. With Homebrew, run `brew install --cask macfuse`, then approve
+  macFUSE in System Settings and reboot if macOS requires it.
+- Windows: WinFsp runtime must be installed before mounting.
 
-Then create and mount:
+Create and mount an authenticated shared filesystem:
 
 ```bash
 peerbit-fs status
@@ -58,6 +63,43 @@ ADDRESS=$(peerbit-fs create)
 mkdir -p "$HOME/PeerbitShared"
 peerbit-fs mount "$ADDRESS" "$HOME/PeerbitShared"
 ```
+
+On Windows PowerShell:
+
+```powershell
+peerbit-fs status
+$address = peerbit-fs create
+New-Item -ItemType Directory -Force "$env:USERPROFILE\PeerbitShared"
+peerbit-fs mount $address "$env:USERPROFILE\PeerbitShared"
+```
+
+Authentication is on by default. Use `peerbit-fs create --no-auth` only for
+explicitly unauthenticated tests or demos.
+
+## Share With Another Machine
+
+On the joining machine, print the local Peerbit writer key:
+
+```bash
+peerbit-fs whoami
+```
+
+On a machine that already owns or can write the filesystem, authorize that key:
+
+```bash
+peerbit-fs trust "$ADDRESS" <public-key>
+```
+
+The joining machine can then mount the same address:
+
+```bash
+mkdir -p "$HOME/PeerbitShared"
+peerbit-fs mount "$ADDRESS" "$HOME/PeerbitShared"
+```
+
+Run `peerbit-fs status "$ADDRESS"` when diagnosing a host. It checks the native
+adapter, platform prerequisites, local Peerbit state, and whether the address can
+be opened.
 
 ## macOS from this repo
 

--- a/packages/shared-fs/library/README.md
+++ b/packages/shared-fs/library/README.md
@@ -5,6 +5,10 @@ Experimental shared filesystem primitives for Peerbit.
 This package is intentionally marked experimental. It provides the Peerbit-backed
 metadata and content model used by the `peerbit-fs` CLI and native mount adapters.
 
+```bash
+npm install @peerbit/shared-fs
+```
+
 ```ts
 import { openSharedFs } from "@peerbit/shared-fs";
 import { Peerbit } from "peerbit";
@@ -33,7 +37,24 @@ entry signer. Use `authorizeWriter(publicKey)` to trust another writer.
 
 ## CLI
 
-The companion `@peerbit/shared-fs-cli` package installs `peerbit-fs`:
+The companion `@peerbit/shared-fs-cli` package installs `peerbit-fs` for native
+mounts:
+
+```bash
+npm install -g @peerbit/shared-fs-cli
+peerbit-fs install-adapter
+peerbit-fs status
+```
+
+Then create and mount an authenticated filesystem:
+
+```bash
+ADDRESS=$(peerbit-fs create)
+mkdir -p "$HOME/PeerbitShared"
+peerbit-fs mount "$ADDRESS" "$HOME/PeerbitShared"
+```
+
+The CLI commands are:
 
 ```bash
 peerbit-fs create
@@ -53,15 +74,9 @@ Mounted writes are buffered by the native adapter and committed as one signed
 Peerbit file version on `flush`, `fsync`, or `release`/close.
 
 `peerbit-fs create` is access-controlled by default. Use `peerbit-fs create
---no-auth` only for explicitly unauthenticated test/demo filesystems.
-
-The normal package install path is:
-
-```bash
-npm install -g @peerbit/shared-fs-cli
-peerbit-fs install-adapter
-peerbit-fs status
-```
+--no-auth` only for explicitly unauthenticated test/demo filesystems. Another
+machine can join by running `peerbit-fs whoami`; an authorized writer can then
+run `peerbit-fs trust <address> <public-key>`.
 
 From this repository on macOS, the local development install path is:
 


### PR DESCRIPTION
## Summary
- document the published shared-fs CLI install and adapter repair flow
- add platform prerequisite notes for Linux, macOS, and Windows
- document default authenticated creation plus the multi-machine trust flow
- add a patch changeset for @peerbit/shared-fs and @peerbit/shared-fs-cli

## Test Plan
- pnpm exec prettier --check packages/shared-fs/cli/README.md packages/shared-fs/library/README.md .changeset/shared-fs-install-polish.md
- pnpm changeset status --since=origin/master
- git diff --check