### PR TITLE
ci(shared-fs): wait for native adapter release asset

### DIFF
--- a/.github/workflows/shared-fs-package-install.yml
+++ b/.github/workflows/shared-fs-package-install.yml
@@ -97,7 +97,7 @@ jobs:
                   project_dir="$RUNNER_TEMP/shared-fs-install-smoke"
                   adapter_dir="$RUNNER_TEMP/shared-fs-native-adapter"
                   cd "$project_dir"
-                  adapter_path="$(node node_modules/@peerbit/shared-fs-cli/lib/esm/bin.js install-adapter --prefix "$adapter_dir" --print-path)"
+                  adapter_path="$(bash "$GITHUB_WORKSPACE/scripts/shared-fs-install-adapter-with-retry.sh" "$adapter_dir" node node_modules/@peerbit/shared-fs-cli/lib/esm/bin.js)"
                   test -f "$adapter_path"
                   if [ "$RUNNER_OS" != "Windows" ]; then
                     test -x "$adapter_path"

--- a/scripts/shared-fs-install-adapter-with-retry.sh
+++ b/scripts/shared-fs-install-adapter-with-retry.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: $0 <install-dir> <peerbit-fs-command...>" >&2
+  exit 2
+fi
+
+install_dir="$1"
+shift
+
+attempts="${SHARED_FS_NATIVE_INSTALL_ATTEMPTS:-30}"
+delay_seconds="${SHARED_FS_NATIVE_INSTALL_RETRY_SECONDS:-10}"
+error_file="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/peerbit-shared-fs-native-install.err"
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  rm -f "$error_file"
+  if adapter_path="$("$@" install-adapter --prefix "$install_dir" --print-path 2>"$error_file")"; then
+    printf '%s\n' "$adapter_path"
+    exit 0
+  else
+    status=$?
+  fi
+
+  if ! grep -q "HTTP 404" "$error_file"; then
+    cat "$error_file" >&2
+    exit "$status"
+  fi
+
+  if [ "$attempt" -eq "$attempts" ]; then
+    cat "$error_file" >&2
+    exit "$status"
+  fi
+
+  echo "native adapter release asset is not available yet (attempt $attempt/$attempts); retrying in ${delay_seconds}s" >&2
+  sleep "$delay_seconds"
+done


### PR DESCRIPTION
## Summary
- add a bounded retry helper for shared-fs native adapter installs
- use it in the tarball package-install smoke so release-version pushes wait for native adapter assets instead of failing on early 404s

## Why
The Version Packages merge published successfully, but the push-time package-install workflow raced the native adapter release creation. Linux/macOS tried to download shared-fs-native-v0.0.2 before the assets existed, while the later published npm smoke passed.

## Test Plan
- bash -n scripts/shared-fs-install-adapter-with-retry.sh
- pnpm exec prettier --check .github/workflows/shared-fs-package-install.yml
- git diff --check
- local fake installer invocation of scripts/shared-fs-install-adapter-with-retry.sh