### PR TITLE
docs(shared-fs): recommend lean npm install

### DIFF
--- a/.changeset/shared-fs-omit-peer-install.md
+++ b/.changeset/shared-fs-omit-peer-install.md
@@ -1,0 +1,7 @@
+---
+"@peerbit/shared-fs": patch
+"@peerbit/shared-fs-cli": patch
+---
+
+Document and test the lean npm install path using `--omit=peer` so Node.js CLI
+installs avoid optional browser and React Native peer packages.

--- a/.github/workflows/shared-fs-npm-install-smoke.yml
+++ b/.github/workflows/shared-fs-npm-install-smoke.yml
@@ -48,14 +48,14 @@ jobs:
                   mkdir -p "$project_dir"
                   cd "$project_dir"
                   npm init -y
-                  npm install @peerbit/shared-fs
+                  npm install --omit=peer @peerbit/shared-fs
                   node --input-type=module -e "import('@peerbit/shared-fs').then((m) => { if (typeof m.openSharedFs !== 'function') throw new Error('openSharedFs export missing'); })"
 
             - name: Install CLI globally from npm
               shell: bash
               run: |
                   set -euo pipefail
-                  npm install -g @peerbit/shared-fs-cli
+                  npm install -g --omit=peer @peerbit/shared-fs-cli
                   global_prefix="$(npm prefix -g)"
                   if [ "$RUNNER_OS" = "Windows" ]; then
                     echo "$global_prefix" >> "$GITHUB_PATH"

--- a/.github/workflows/shared-fs-package-install.yml
+++ b/.github/workflows/shared-fs-package-install.yml
@@ -86,7 +86,7 @@ jobs:
                   cli_tgz="$(find "$pack_dir" -maxdepth 1 -name 'peerbit-shared-fs-cli-*.tgz' | head -n 1)"
                   test -n "$shared_fs_tgz"
                   test -n "$cli_tgz"
-                  npm install --ignore-scripts "$shared_fs_tgz" "$cli_tgz"
+                  npm install --ignore-scripts --omit=peer "$shared_fs_tgz" "$cli_tgz"
                   node -e "import('@peerbit/shared-fs').then((m) => { if (typeof m.openSharedFs !== 'function') throw new Error('openSharedFs export missing'); })"
                   node node_modules/@peerbit/shared-fs-cli/lib/esm/bin.js --help >/dev/null
 

--- a/packages/shared-fs/cli/README.md
+++ b/packages/shared-fs/cli/README.md
@@ -35,10 +35,13 @@ authorize that writer.
 Install the CLI, then make sure the native adapter is installed:
 
 ```bash
-npm install -g @peerbit/shared-fs-cli
+npm install -g --omit=peer @peerbit/shared-fs-cli
 peerbit-fs install-adapter
 peerbit-fs status
 ```
+
+`--omit=peer` keeps npm from auto-installing optional browser and React Native
+peer packages that are not needed by the Node.js CLI.
 
 `peerbit-fs install-adapter` downloads a prebuilt
 `peerbit-shared-fs-native` binary into `~/.peerbit/shared-fs/bin`. The global

--- a/packages/shared-fs/library/README.md
+++ b/packages/shared-fs/library/README.md
@@ -41,7 +41,7 @@ The companion `@peerbit/shared-fs-cli` package installs `peerbit-fs` for native
 mounts:
 
 ```bash
-npm install -g @peerbit/shared-fs-cli
+npm install -g --omit=peer @peerbit/shared-fs-cli
 peerbit-fs install-adapter
 peerbit-fs status
 ```


### PR DESCRIPTION
## Summary
- document `npm install -g --omit=peer @peerbit/shared-fs-cli` for the Node CLI
- use `--omit=peer` in package install and published npm smoke workflows
- add a patch changeset for @peerbit/shared-fs and @peerbit/shared-fs-cli

## Install impact
Clean install baseline for published CLI with scripts disabled was about 333 MB / 620 packages.
A local packed install of shared-fs + CLI with `--omit=peer` avoided React Native/Hermes and installed at about 119 MB / 335 packages.

## Test Plan
- pnpm exec prettier --check packages/shared-fs/cli/README.md packages/shared-fs/library/README.md .github/workflows/shared-fs-package-install.yml .github/workflows/shared-fs-npm-install-smoke.yml .changeset/shared-fs-omit-peer-install.md
- git diff --check
- pnpm -r --sort --filter @peerbit/shared-fs --filter @peerbit/shared-fs-cli run build
- pnpm changeset status --since=origin/master
- packed @peerbit/shared-fs and @peerbit/shared-fs-cli, then installed both in a clean npm project with --ignore-scripts --omit=peer and verified exports/CLI help
