### PR TITLE
ci(shared-fs): retry transient native load failures

### DIFF
--- a/scripts/shared-fs-native-cross-os-interop.ps1
+++ b/scripts/shared-fs-native-cross-os-interop.ps1
@@ -126,7 +126,10 @@ function Get-MountLogsText {
 
 function Test-RetryableMountResolveFailure {
   $Logs = Get-MountLogsText
-  return $Logs -match "Failed to resolve program with address"
+  return (
+    $Logs -match "Failed to resolve program with address" -or
+    $Logs -match "Failed to load program"
+  )
 }
 
 function Stop-MountProcess {
@@ -151,7 +154,7 @@ Add-Phase -Name "adapterBuild" -StartMs $AdapterBuildStartMs -EndMs $AdapterBuil
 
 $AddressStartMs = Get-NowMs
 if ($Role -eq "seed") {
-  $Address = (node packages/shared-fs/cli/lib/esm/bin.js create --directory $State).Trim()
+  $Address = (node packages/shared-fs/cli/lib/esm/bin.js create --directory $State --no-auth).Trim()
   Set-FileText -Path $AddressFile -Value $Address
 } else {
   $Address = (Get-Content -Raw -Path $AddressFile).Trim()

--- a/scripts/shared-fs-native-cross-os-interop.sh
+++ b/scripts/shared-fs-native-cross-os-interop.sh
@@ -214,7 +214,7 @@ adapter_build_ms=$((adapter_build_end_ms - adapter_build_start_ms))
 
 address_start_ms="$(now_ms)"
 if [ "$role" = "seed" ]; then
-  address="$(node packages/shared-fs/cli/lib/esm/bin.js create --directory "$state")"
+  address="$(node packages/shared-fs/cli/lib/esm/bin.js create --directory "$state" --no-auth)"
   mkdir -p "$(dirname "$address_file")"
   printf "%s\n" "$address" > "$address_file"
 else
@@ -283,7 +283,7 @@ while true; do
   fi
 
   if [ "$mount_status" = "exited" ] &&
-    grep -q "Failed to resolve program with address" "$log" &&
+    grep -Eq "Failed to resolve program with address|Failed to load program" "$log" &&
     [ "$mount_attempt" -lt "$mount_resolve_attempts" ]; then
     cat "$log"
     echo "Mount could not resolve the shared filesystem address; retrying ($mount_attempt/$mount_resolve_attempts)..."


### PR DESCRIPTION
## Summary
- retry native interop mount startup when the CLI exits with transient address-open errors (`Failed to resolve program with address` or `Failed to load program`)
- create the native cross-OS smoke filesystem with `--no-auth` because this harness intentionally has independent ephemeral OS identities writing into one shared folder
- keep product CLI behavior unchanged: auth remains default-on outside this explicit test harness

## Validation
- `bash -n scripts/shared-fs-native-cross-os-interop.sh`
- `git diff --check`
- Remote validation in progress via Shared FS Native Cross-OS Interop on this branch
