### PR TITLE
fix(shared-fs): wait for remote address resolution before mount

### DIFF
--- a/.changeset/mount-address-resolve-retry.md
+++ b/.changeset/mount-address-resolve-retry.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/shared-fs-cli": patch
+---
+
+Wait for transient remote shared-fs address resolution failures before starting a native mount.

--- a/packages/shared-fs/cli/src/__tests__/index.test.ts
+++ b/packages/shared-fs/cli/src/__tests__/index.test.ts
@@ -4,7 +4,12 @@ import path from "node:path";
 import { openSharedFs } from "@peerbit/shared-fs";
 import { Peerbit } from "peerbit";
 import { describe, expect, it, vi } from "vitest";
-import { normalizeNativeMountpoint, runCli } from "../index.js";
+import {
+    isRetryableSharedFsAddressOpenError,
+    normalizeNativeMountpoint,
+    openWithSharedFsAddressResolveRetry,
+    runCli,
+} from "../index.js";
 
 const stopPeer = async (peer: Peerbit) => {
     await peer.stop();
@@ -98,5 +103,96 @@ describe("peerbit-fs cli", () => {
         } finally {
             await Promise.all([stopPeer(writerPeer), stopPeer(readerPeer)]);
         }
+    });
+
+    it("classifies only transient address-open failures as retryable", () => {
+        expect(
+            isRetryableSharedFsAddressOpenError(
+                new Error("Failed to load program")
+            )
+        ).toBe(true);
+        expect(
+            isRetryableSharedFsAddressOpenError(
+                new Error(
+                    "Failed to resolve program with address: zb2rhExample"
+                )
+            )
+        ).toBe(true);
+        expect(
+            isRetryableSharedFsAddressOpenError(
+                new Error("Not allowed to append")
+            )
+        ).toBe(false);
+    });
+
+    it("retries transient shared-fs address-open failures", async () => {
+        let attempts = 0;
+        const retries: number[] = [];
+        const result = await openWithSharedFsAddressResolveRetry(
+            async () => {
+                attempts += 1;
+                if (attempts === 1) {
+                    throw new Error("Failed to load program");
+                }
+                return "mounted";
+            },
+            {
+                address: "zb2rhExample",
+                timeoutMs: 10,
+                retryIntervalMs: 1,
+                sleep: async () => {},
+                onRetry: ({ attempt }) => retries.push(attempt),
+            }
+        );
+
+        expect(result).toBe("mounted");
+        expect(attempts).toBe(2);
+        expect(retries).toEqual([1]);
+    });
+
+    it("times out bounded shared-fs address-open retries", async () => {
+        let now = 0;
+        let attempts = 0;
+
+        await expect(
+            openWithSharedFsAddressResolveRetry(
+                async () => {
+                    attempts += 1;
+                    throw new Error("Failed to load program");
+                },
+                {
+                    address: "zb2rhExample",
+                    timeoutMs: 5,
+                    retryIntervalMs: 2,
+                    now: () => now,
+                    sleep: async (ms) => {
+                        now += ms;
+                    },
+                }
+            )
+        ).rejects.toThrow(
+            "Timed out resolving shared filesystem address after 5ms"
+        );
+        expect(attempts).toBe(4);
+    });
+
+    it("does not retry non-resolution open failures", async () => {
+        let attempts = 0;
+
+        await expect(
+            openWithSharedFsAddressResolveRetry(
+                async () => {
+                    attempts += 1;
+                    throw new Error("Not allowed to append");
+                },
+                {
+                    address: "zb2rhExample",
+                    timeoutMs: 10,
+                    retryIntervalMs: 1,
+                    sleep: async () => {},
+                }
+            )
+        ).rejects.toThrow("Not allowed to append");
+        expect(attempts).toBe(1);
     });
 });

--- a/packages/shared-fs/cli/src/index.ts
+++ b/packages/shared-fs/cli/src/index.ts
@@ -26,6 +26,8 @@ import {
 } from "./native-adapter.js";
 
 const DEFAULT_DIRECTORY_NAME = "peerbit-shared-fs";
+const DEFAULT_ADDRESS_RESOLVE_TIMEOUT_MS = 60_000;
+const DEFAULT_ADDRESS_RESOLVE_RETRY_INTERVAL_MS = 2_000;
 const CLI_REPLICATION_ARGS = {
     replicate: {
         limits: {
@@ -42,6 +44,20 @@ type CliProgramArgs =
     | {
           replicate: false;
       };
+
+type AddressResolveRetryOptions = {
+    address?: string;
+    timeoutMs?: number;
+    retryIntervalMs?: number;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+    onRetry?: (event: {
+        attempt: number;
+        elapsedMs: number;
+        retryInMs: number;
+        error: Error;
+    }) => void;
+};
 
 let peerbitRejectionGuardInstalled = false;
 
@@ -87,6 +103,82 @@ const installPeerbitRejectionGuard = () => {
         }
         throw reason instanceof Error ? reason : new Error(String(reason));
     });
+};
+
+const sleep = (ms: number) =>
+    new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const normalizeDurationMs = (
+    value: number | undefined,
+    fallback: number,
+    minimum: number
+) => {
+    if (value === undefined || !Number.isFinite(value)) {
+        return fallback;
+    }
+    return Math.max(minimum, value);
+};
+
+export const isRetryableSharedFsAddressOpenError = (
+    error: unknown
+): error is Error => {
+    return (
+        error instanceof Error &&
+        (error.message.includes("Failed to load program") ||
+            error.message.includes("Failed to resolve program with address"))
+    );
+};
+
+export const openWithSharedFsAddressResolveRetry = async <T>(
+    open: () => Promise<T>,
+    options: AddressResolveRetryOptions = {}
+) => {
+    const timeoutMs = normalizeDurationMs(
+        options.timeoutMs,
+        DEFAULT_ADDRESS_RESOLVE_TIMEOUT_MS,
+        0
+    );
+    if (!options.address || timeoutMs === 0) {
+        return open();
+    }
+
+    const retryIntervalMs = normalizeDurationMs(
+        options.retryIntervalMs,
+        DEFAULT_ADDRESS_RESOLVE_RETRY_INTERVAL_MS,
+        1
+    );
+    const now = options.now ?? Date.now;
+    const wait = options.sleep ?? sleep;
+    const startedAt = now();
+    let attempt = 0;
+
+    while (true) {
+        attempt += 1;
+        try {
+            return await open();
+        } catch (error) {
+            if (!isRetryableSharedFsAddressOpenError(error)) {
+                throw error;
+            }
+
+            const elapsedMs = now() - startedAt;
+            if (elapsedMs >= timeoutMs) {
+                throw new Error(
+                    `Timed out resolving shared filesystem address after ${timeoutMs}ms`,
+                    { cause: error }
+                );
+            }
+
+            const retryInMs = Math.min(retryIntervalMs, timeoutMs - elapsedMs);
+            options.onRetry?.({
+                attempt,
+                elapsedMs,
+                retryInMs,
+                error,
+            });
+            await wait(retryInMs);
+        }
+    }
 };
 
 const resolveDirectory = (directoryArg?: string) => {
@@ -548,6 +640,18 @@ export const runCli = async (args = hideBin(process.argv)) => {
                         type: "string",
                         description:
                             "External native adapter command. Can also be set with PEERBIT_SHARED_FS_NATIVE_ADAPTER.",
+                    })
+                    .option("resolve-timeout", {
+                        type: "number",
+                        default: DEFAULT_ADDRESS_RESOLVE_TIMEOUT_MS,
+                        description:
+                            "Milliseconds to wait for a remote filesystem address to become loadable before mounting.",
+                    })
+                    .option("resolve-retry-interval", {
+                        type: "number",
+                        default: DEFAULT_ADDRESS_RESOLVE_RETRY_INTERVAL_MS,
+                        description:
+                            "Milliseconds between remote filesystem address resolve attempts.",
                     }),
             async (argv) => {
                 const directory = resolveDirectory(argv.directory);
@@ -563,11 +667,26 @@ export const runCli = async (args = hideBin(process.argv)) => {
                     await connectToNetwork(peerbit, argv.peer, {
                         bootstrap: argv.replicate !== false,
                     });
-                    const fsHandle = await openCliFs(peerbit, {
-                        address: argv.address,
-                        machineLabel: argv.machine,
-                        replicate: argv.replicate,
-                    });
+                    const fsHandle = await openWithSharedFsAddressResolveRetry(
+                        () =>
+                            openCliFs(peerbit, {
+                                address: argv.address,
+                                machineLabel: argv.machine,
+                                replicate: argv.replicate,
+                            }),
+                        {
+                            address: argv.address,
+                            timeoutMs: argv.resolveTimeout,
+                            retryIntervalMs: argv.resolveRetryInterval,
+                            onRetry: ({ attempt, retryInMs, error }) => {
+                                console.warn(
+                                    chalk.yellow(
+                                        `Shared filesystem address is not loadable yet (${error.message}); retrying in ${retryInMs}ms, attempt ${attempt}.`
+                                    )
+                                );
+                            },
+                        }
+                    );
                     const backend = createSharedFsMountBackend(fsHandle);
                     const externalAdapter = await resolveExternalNativeAdapter(
                         argv.nativeAdapter


### PR DESCRIPTION
## Summary
- retry transient shared-fs address-open failures inside peerbit-fs mount before launching the native adapter
- expose bounded mount resolve timeout/retry interval CLI options
- keep auth/correctness failures fail-fast by only retrying address resolution errors

## Test Plan
- pnpm --filter @peerbit/shared-fs-cli build
- pnpm --filter @peerbit/shared-fs-cli test