### PR TITLE
docs: add Vue Peerbit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,38 +12,45 @@
 ## Examples
 
 ### [Chat room](./packages/one-chat-room/)
+
 [<img src="./packages/one-chat-room/demo.gif" width="600" />](./packages/one-chat-room/)
 
-
 ### [Lobby + chat rooms](./packages/many-chat-rooms/)
+
 [<img src="./packages/many-chat-rooms/demo.gif" width="600" />](./packages/many-chat-rooms/)
 
 ### [Blog platform](./packages/blog-platform/)
+
 [<img src="./packages/blog-platform/demo-cli.gif" width="600" />](./packages/blog-platform/)
 
-
 ### [Collaborative text document](./packages/text-document/)
+
 [<img src="./packages/text-document/demo.gif" width="600" />](./packages/text-document/)
 
-
 ### [Sync files](./packages/file-share/)
+
 #### [React app](./packages/file-share/)
+
 [<img src="./packages/file-share/demo-frontend.gif" width="600" />](./packages/file-share/)
+
 #### [CLI](./packages/file-share/)
+
 [<img src="./packages/file-share/demo-cli.gif" width="600" />](./packages/file-share/)
 
-
 ### [Video streaming](./packages/media-streaming/video-streaming)
+
 [<img src="./packages/media-streaming/video-streaming/demo.gif" width="600" />](./packages/media-streaming/video-streaming/)
 
-
 ### [Collaborative machine learning](./packages/collaborative-learning/)
+
 [<img src="./packages/collaborative-learning/demo.gif" width="600" />](./packages/collaborative-learning/)
 
 ### [Vue example](./packages/vue-example/)
+
 A minimal Vue 3 + Vite app that opens a Peerbit document store from the browser.
 
 ### React examples
+
 - [Chat room](./packages/one-chat-room/)
 - [Lobby + chat rooms](./packages/many-chat-rooms/)
 - [Sync files React app](./packages/file-share/)
@@ -55,13 +62,13 @@ A minimal Vue 3 + Vite app that opens a Peerbit document store from the browser.
 ## How to run the examples
 
 1.
+
 ```sh
 yarn
 yarn build
 ```
 
-2.
-Go into an example. If it is a frontend app, you can run it locally (if you have a node running (see below)) with
+2.  Go into an example. If it is a frontend app, you can run it locally (if you have a node running (see below)) with
 
 ```sh
 yarn start
@@ -74,17 +81,19 @@ yarn start-remote
 ```
 
 ## How to setup a local relay node
+
 (This is just a basic libp2p-js node)
 
-1.
-Install Node >= 16
+1.  Install Node >= 16
 
-2.
-Install CLI
+2.  Install CLI
+
 ```sh
 npm install -g @peerbit/server
 ```
+
 3.
+
 ```sh
 peerbit start
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@
 ### [Collaborative machine learning](./packages/collaborative-learning/)
 [<img src="./packages/collaborative-learning/demo.gif" width="600" />](./packages/collaborative-learning/)
 
+### [Vue example](./packages/vue-example/)
+A minimal Vue 3 + Vite app that opens a Peerbit document store from the browser.
+
+### React examples
+- [Chat room](./packages/one-chat-room/)
+- [Lobby + chat rooms](./packages/many-chat-rooms/)
+- [Sync files React app](./packages/file-share/)
+
 ## Requirements
 
 1. Node.js >= 22 (You can switch to Node 22 using `nvm use 22`)

--- a/packages/vue-example/README.md
+++ b/packages/vue-example/README.md
@@ -1,0 +1,34 @@
+# Peerbit Vue example
+
+A small Vue 3 + Vite example that opens a Peerbit document store in the browser.
+Open the app in multiple tabs to see messages replicate through Peerbit.
+
+Peerbit-specific setup lives in [`src/db.ts`](./src/db.ts), mirroring the direct Peerbit usage in the Svelte example while showing how to wire it into Vue's Composition API.
+
+## Setup
+
+From the root of the `peerbit-examples` repo:
+
+```bash
+pnpm install
+```
+
+## Developing
+
+Inside this project run:
+
+```bash
+pnpm run dev
+```
+
+To use the public relay bootstrap flow, run:
+
+```bash
+pnpm run start-remote
+```
+
+To verify the example builds:
+
+```bash
+pnpm run build
+```

--- a/packages/vue-example/index.html
+++ b/packages/vue-example/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Peerbit Vue Example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/vue-example/index.html
+++ b/packages/vue-example/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Peerbit Vue Example</title>
-  </head>
-  <body>
-    <div id="app"></div>
-    <script type="module" src="/src/main.ts"></script>
-  </body>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Peerbit Vue Example</title>
+    </head>
+    <body>
+        <div id="app"></div>
+        <script type="module" src="/src/main.ts"></script>
+    </body>
 </html>

--- a/packages/vue-example/package.json
+++ b/packages/vue-example/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "vue-example",
+    "version": "0.0.1",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "dev": "vite dev",
+        "start": "vite dev",
+        "start-remote": "vite dev --mode staging",
+        "build": "vite build",
+        "preview": "vite preview"
+    },
+    "dependencies": {
+        "@peerbit/document": "^13.0.43",
+        "peerbit": "^5.2.19",
+        "uuid": "^10",
+        "vue": "^3.5.35"
+    },
+    "devDependencies": {
+        "@peerbit/vite": "^2.0.6",
+        "@vitejs/plugin-vue": "^6.0.7",
+        "@types/uuid": "^8",
+        "typescript": "^5.6.3",
+        "vite": "^7.1.4",
+        "vue-tsc": "^3.3.3"
+    }
+}

--- a/packages/vue-example/src/App.vue
+++ b/packages/vue-example/src/App.vue
@@ -26,12 +26,13 @@ onMounted(async () => {
         };
 
         store.documents.events.addEventListener("change", onChange);
-        cleanup = () => store?.documents.events.removeEventListener("change", onChange);
+        cleanup = () =>
+            store?.documents.events.removeEventListener("change", onChange);
 
         await store.documents.put(
             new SimpleDocument({
                 content: `Hello from ${peerId.value}`,
-            }),
+            })
         );
     } catch (err) {
         error.value = err instanceof Error ? err.message : String(err);
@@ -61,7 +62,8 @@ const sendMessage = async () => {
         <p class="eyebrow">Peerbit + Vue 3</p>
         <h1>Peerbit Vue Example</h1>
         <p class="intro">
-            Open this app in multiple tabs to see document updates replicated with Peerbit.
+            Open this app in multiple tabs to see document updates replicated
+            with Peerbit.
         </p>
 
         <section class="panel">

--- a/packages/vue-example/src/App.vue
+++ b/packages/vue-example/src/App.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from "vue";
+
+import { createClient, ExampleStore, SimpleDocument } from "./db";
+
+const loading = ref(true);
+const error = ref<string | undefined>();
+const message = ref("");
+const messages = ref<string[]>([]);
+const peerId = ref<string>("");
+
+let store: ExampleStore | undefined;
+let cleanup: (() => void) | undefined;
+
+onMounted(async () => {
+    try {
+        const client = await createClient();
+        peerId.value = client.libp2p.peerId.toString();
+        store = await client.open(new ExampleStore());
+
+        const onChange = (evt: Event) => {
+            const changeEvent = evt as CustomEvent<{ added: SimpleDocument[] }>;
+            for (const doc of changeEvent.detail.added) {
+                messages.value = [...messages.value, doc.content];
+            }
+        };
+
+        store.documents.events.addEventListener("change", onChange);
+        cleanup = () => store?.documents.events.removeEventListener("change", onChange);
+
+        await store.documents.put(
+            new SimpleDocument({
+                content: `Hello from ${peerId.value}`,
+            }),
+        );
+    } catch (err) {
+        error.value = err instanceof Error ? err.message : String(err);
+    } finally {
+        loading.value = false;
+    }
+});
+
+onBeforeUnmount(() => {
+    cleanup?.();
+});
+
+const sendMessage = async () => {
+    const content = message.value.trim();
+
+    if (!content || !store) {
+        return;
+    }
+
+    await store.documents.put(new SimpleDocument({ content }));
+    message.value = "";
+};
+</script>
+
+<template>
+    <main>
+        <p class="eyebrow">Peerbit + Vue 3</p>
+        <h1>Peerbit Vue Example</h1>
+        <p class="intro">
+            Open this app in multiple tabs to see document updates replicated with Peerbit.
+        </p>
+
+        <section class="panel">
+            <p v-if="loading">Connecting to Peerbit…</p>
+            <p v-else-if="error" class="error">{{ error }}</p>
+            <template v-else>
+                <p class="peer">Peer ID: {{ peerId }}</p>
+                <form @submit.prevent="sendMessage">
+                    <input
+                        v-model="message"
+                        type="text"
+                        placeholder="Write a message"
+                        aria-label="Message"
+                    />
+                    <button type="submit">Share</button>
+                </form>
+
+                <ul>
+                    <li v-for="item in messages" :key="item">{{ item }}</li>
+                </ul>
+            </template>
+        </section>
+    </main>
+</template>

--- a/packages/vue-example/src/db.ts
+++ b/packages/vue-example/src/db.ts
@@ -7,15 +7,22 @@ import { Program } from "@peerbit/program";
 import { Peerbit } from "peerbit";
 import { v4 as uuid } from "uuid";
 
+const borshField = field as unknown as (
+    properties: Parameters<typeof field>[0]
+) => PropertyDecorator;
+const borshVariant = variant as unknown as (
+    index: Parameters<typeof variant>[0]
+) => ClassDecorator;
+
 const relayTransport = circuitRelayTransport({}) as unknown as ReturnType<
     typeof webSockets
 >;
 
 export class SimpleDocument {
-    @field({ type: "string" })
+    @borshField({ type: "string" })
     id: string;
 
-    @field({ type: "string" })
+    @borshField({ type: "string" })
     content: string;
 
     constructor(properties: { content: string }) {
@@ -24,9 +31,9 @@ export class SimpleDocument {
     }
 }
 
-@variant("vue-example-store")
+@borshVariant("vue-example-store")
 export class ExampleStore extends Program {
-    @field({ type: Documents })
+    @borshField({ type: Documents })
     documents: Documents<SimpleDocument>;
 
     constructor() {
@@ -61,7 +68,7 @@ export const createClient = async (localNetwork = false) => {
     if (localNetwork) {
         await client.dial(
             "/ip4/127.0.0.1/tcp/8002/ws/p2p/" +
-                (await (await fetch("http://localhost:8082/peer/id")).text()),
+                (await (await fetch("http://localhost:8082/peer/id")).text())
         );
     } else {
         await client.bootstrap();

--- a/packages/vue-example/src/db.ts
+++ b/packages/vue-example/src/db.ts
@@ -1,0 +1,71 @@
+import { field, variant } from "@dao-xyz/borsh";
+import { circuitRelayTransport } from "@libp2p/circuit-relay-v2";
+import { webSockets } from "@libp2p/websockets";
+import { sha256Sync } from "@peerbit/crypto";
+import { Documents } from "@peerbit/document";
+import { Program } from "@peerbit/program";
+import { Peerbit } from "peerbit";
+import { v4 as uuid } from "uuid";
+
+const relayTransport = circuitRelayTransport({}) as unknown as ReturnType<
+    typeof webSockets
+>;
+
+export class SimpleDocument {
+    @field({ type: "string" })
+    id: string;
+
+    @field({ type: "string" })
+    content: string;
+
+    constructor(properties: { content: string }) {
+        this.id = uuid();
+        this.content = properties.content;
+    }
+}
+
+@variant("vue-example-store")
+export class ExampleStore extends Program {
+    @field({ type: Documents })
+    documents: Documents<SimpleDocument>;
+
+    constructor() {
+        super();
+        this.documents = new Documents({
+            id: sha256Sync(new TextEncoder().encode("vue-example-store")),
+        });
+    }
+
+    async open(): Promise<void> {
+        await this.documents.open({
+            type: SimpleDocument,
+        });
+    }
+}
+
+export const createClient = async (localNetwork = false) => {
+    const client = await Peerbit.create({
+        libp2p: {
+            addresses: {
+                listen: [],
+            },
+            connectionGater: localNetwork
+                ? {
+                      denyDialMultiaddr: () => false,
+                  }
+                : undefined,
+            transports: [webSockets({}), relayTransport],
+        },
+    });
+
+    if (localNetwork) {
+        await client.dial(
+            "/ip4/127.0.0.1/tcp/8002/ws/p2p/" +
+                (await (await fetch("http://localhost:8082/peer/id")).text()),
+        );
+    } else {
+        await client.bootstrap();
+    }
+
+    return client;
+};

--- a/packages/vue-example/src/main.ts
+++ b/packages/vue-example/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+import "./style.css";
+
+createApp(App).mount("#app");

--- a/packages/vue-example/src/style.css
+++ b/packages/vue-example/src/style.css
@@ -1,0 +1,91 @@
+body {
+    margin: 0;
+    min-width: 320px;
+    min-height: 100vh;
+    color: #172033;
+    background: #f4f7fb;
+    font-family:
+        Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+main {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 4rem 1.5rem;
+}
+
+h1 {
+    margin: 0;
+    font-size: clamp(2rem, 7vw, 4rem);
+}
+
+.eyebrow {
+    margin: 0 0 0.75rem;
+    color: #5368ff;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.intro {
+    color: #526071;
+    font-size: 1.1rem;
+}
+
+.panel {
+    margin-top: 2rem;
+    padding: 1.5rem;
+    background: white;
+    border: 1px solid #dde5f0;
+    border-radius: 20px;
+    box-shadow: 0 20px 60px rgb(16 35 71 / 8%);
+}
+
+.peer {
+    overflow-wrap: anywhere;
+    color: #526071;
+    font-size: 0.9rem;
+}
+
+form {
+    display: flex;
+    gap: 0.75rem;
+    margin: 1.25rem 0;
+}
+
+input {
+    flex: 1;
+    min-width: 0;
+    padding: 0.8rem 1rem;
+    border: 1px solid #c8d2e1;
+    border-radius: 12px;
+    font: inherit;
+}
+
+button {
+    padding: 0.8rem 1rem;
+    border: 0;
+    border-radius: 12px;
+    color: white;
+    background: #5368ff;
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.error {
+    color: #b00020;
+}
+
+ul {
+    display: grid;
+    gap: 0.5rem;
+    padding: 0;
+    list-style: none;
+}
+
+li {
+    padding: 0.75rem 1rem;
+    background: #f7f9fc;
+    border-radius: 12px;
+}

--- a/packages/vue-example/src/style.css
+++ b/packages/vue-example/src/style.css
@@ -5,7 +5,13 @@ body {
     color: #172033;
     background: #f4f7fb;
     font-family:
-        Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        sans-serif;
 }
 
 main {

--- a/packages/vue-example/src/vite-env.d.ts
+++ b/packages/vue-example/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module "*.vue" {
+    import type { DefineComponent } from "vue";
+    const component: DefineComponent<object, object, unknown>;
+    export default component;
+}

--- a/packages/vue-example/tsconfig.json
+++ b/packages/vue-example/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "useDefineForClassFields": false,
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "strict": true,
+        "jsx": "preserve",
+        "sourceMap": true,
+        "resolveJsonModule": true,
+        "esModuleInterop": true,
+        "lib": ["ESNext", "DOM", "DOM.Iterable"],
+        "skipLibCheck": true,
+        "experimentalDecorators": true
+    },
+    "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+    "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/packages/vue-example/tsconfig.node.json
+++ b/packages/vue-example/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "composite": true,
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "allowSyntheticDefaultImports": true,
+        "lib": ["ESNext"],
+        "skipLibCheck": true
+    },
+    "include": ["vite.config.ts"]
+}

--- a/packages/vue-example/vite.config.ts
+++ b/packages/vue-example/vite.config.ts
@@ -1,0 +1,15 @@
+import vue from "@vitejs/plugin-vue";
+import peerbit from "@peerbit/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+    plugins: [vue(), peerbit()],
+    optimizeDeps: {
+        esbuildOptions: {
+            target: "esnext",
+        },
+    },
+    build: {
+        target: "esnext",
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1396,7 +1396,7 @@ importers:
         version: 5.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.4.20
-        version: 10.4.23(postcss@8.5.6)
+        version: 10.4.23(postcss@8.5.15)
       tailwindcss:
         specifier: ^4.0.14
         version: 4.1.18
@@ -1473,7 +1473,7 @@ importers:
         version: 5.48.4
       svelte-check:
         specifier: ^4.3.1
-        version: 4.3.5(picomatch@4.0.3)(svelte@5.48.4)(typescript@5.9.3)
+        version: 4.3.5(picomatch@4.0.4)(svelte@5.48.4)(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -1538,6 +1538,40 @@ importers:
       vite:
         specifier: ^7.1.3
         version: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  packages/vue-example:
+    dependencies:
+      '@peerbit/document':
+        specifier: ^13.0.43
+        version: 13.0.44
+      peerbit:
+        specifier: ^5.2.19
+        version: 5.2.20(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+      uuid:
+        specifier: ^10
+        version: 10.0.0
+      vue:
+        specifier: ^3.5.35
+        version: 3.5.35(typescript@5.9.3)
+    devDependencies:
+      '@peerbit/vite':
+        specifier: ^2.0.6
+        version: 2.0.6(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      '@types/uuid':
+        specifier: ^8
+        version: 8.3.4
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.7
+        version: 6.0.7(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3))
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.1.4
+        version: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vue-tsc:
+        specifier: ^3.3.3
+        version: 3.3.3(typescript@5.9.3)
 
 packages:
 
@@ -4285,6 +4319,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
 
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rollup/rollup-android-arm-eabi@4.57.0':
     resolution: {integrity: sha512-tPgXB6cDTndIe1ah7u6amCI1T0SsnlOuKgg10Xh3uizJk4e5M1JGaUMk7J4ciuAUcFpbOiNhm2XIjP9ON0dUqA==}
     cpu: [arm]
@@ -5057,6 +5094,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-basic-ssl@2.1.4':
     resolution: {integrity: sha512-HXciTXN/sDBYWgeAD4V4s0DN0g72x5mlxQhHxtYu3Tt8BLa6MzcJZUyDVFCdtjNs3bfENVHVzOsmooTVuNgAAw==}
@@ -5069,6 +5107,13 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitejs/plugin-vue@6.0.7':
+    resolution: {integrity: sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: ^3.2.25
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -5127,6 +5172,47 @@ packages:
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
+  '@vue/compiler-core@3.5.35':
+    resolution: {integrity: sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==}
+
+  '@vue/compiler-dom@3.5.35':
+    resolution: {integrity: sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==}
+
+  '@vue/compiler-sfc@3.5.35':
+    resolution: {integrity: sha512-G5VPMcXTSywXBgtFOZOnHKBxKSrwXUcvY1iaF5/hRcy7t0J6CH/d8ha9F4nzi00Fax1eLV0QHM7v4mQu68jydw==}
+
+  '@vue/compiler-ssr@3.5.35':
+    resolution: {integrity: sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==}
+
+  '@vue/language-core@3.3.3':
+    resolution: {integrity: sha512-X6p+7nfY7vVT6dQwUJ+v0Jfq/lwIfhL2jMi91dQ3ln4hnlGXlxsDu/FNkeyHYgvYtyQy18ZX76IZy7X4diDbiQ==}
+
+  '@vue/reactivity@3.5.35':
+    resolution: {integrity: sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==}
+
+  '@vue/runtime-core@3.5.35':
+    resolution: {integrity: sha512-A/xFNX9loIcWDygeQuNCfKuh0CoYBzxhqEMNah5TSFg9Z53DrFYEN2qi5CU9necjM1OWYegYREUTHmXTmhfXtg==}
+
+  '@vue/runtime-dom@3.5.35':
+    resolution: {integrity: sha512-odrJ1C391dbGnyDRh8U+rnP7J2amIEzfmRk5vXy7xi3aZhEXofTvpi0T4HJb6jlNqQZTNPR5MPHSB3RHNkIORA==}
+
+  '@vue/server-renderer@3.5.35':
+    resolution: {integrity: sha512-NkebSOYdB97wi8OQcO3HqzZSlymJi/aWsN/7h74OSVhRTm6qGs3Jp3e0rCXynmWwSlKeRrnlIug+ilYoHBmQDA==}
+    peerDependencies:
+      vue: 3.5.35
+
+  '@vue/shared@3.5.35':
+    resolution: {integrity: sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==}
 
   '@webgpu/types@0.1.38':
     resolution: {integrity: sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==}
@@ -5195,6 +5281,9 @@ packages:
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
@@ -5979,6 +6068,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
@@ -6211,6 +6304,9 @@ packages:
 
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -7622,6 +7718,9 @@ packages:
     resolution: {integrity: sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==}
     engines: {node: '>=20'}
 
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
   multiformats@13.4.2:
     resolution: {integrity: sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==}
 
@@ -7637,6 +7736,11 @@ packages:
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7945,6 +8049,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pidusage@4.0.1:
     resolution: {integrity: sha512-yCH2dtLHfEBnzlHUJymR/Z1nN2ePG3m392Mv8TFlTP1B0xkpMQNHAnfkY0n2tAi6ceKO6YWhxYfZ96V4vVkh/g==}
     engines: {node: '>=18'}
@@ -7987,6 +8095,10 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -9306,6 +9418,23 @@ packages:
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-tsc@3.3.3:
+    resolution: {integrity: sha512-SWUEG7YRUeDJHT7Xsuhf02elYX2gxPzzAII7OxDAh4KNOr4QHQ0Lls0YfnaO5GNd560CwVa2HTfdqmA5MqvRqQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
+  vue@3.5.35:
+    resolution: {integrity: sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -9637,7 +9766,7 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.7
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -9693,7 +9822,7 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
       '@babel/traverse': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9731,7 +9860,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.7
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
@@ -9758,7 +9887,7 @@ snapshots:
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
       '@babel/traverse': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9778,7 +9907,7 @@ snapshots:
     dependencies:
       '@babel/template': 7.28.6
       '@babel/traverse': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10270,7 +10399,7 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.6)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -10392,7 +10521,7 @@ snapshots:
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.6)
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10403,7 +10532,7 @@ snapshots:
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10583,7 +10712,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.7
       esutils: 2.0.3
 
   '@babel/preset-react@7.28.5(@babel/core@7.28.6)':
@@ -14229,6 +14358,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rollup/rollup-android-arm-eabi@4.57.0':
     optional: true
 
@@ -15059,6 +15190,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-vue@6.0.7(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vue: 3.5.35(typescript@5.9.3)
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -15140,6 +15277,82 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vue/compiler-core@3.5.35':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.35
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.35':
+    dependencies:
+      '@vue/compiler-core': 3.5.35
+      '@vue/shared': 3.5.35
+
+  '@vue/compiler-sfc@3.5.35':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.35
+      '@vue/compiler-dom': 3.5.35
+      '@vue/compiler-ssr': 3.5.35
+      '@vue/shared': 3.5.35
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.15
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.35':
+    dependencies:
+      '@vue/compiler-dom': 3.5.35
+      '@vue/shared': 3.5.35
+
+  '@vue/language-core@3.3.3':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.35
+      '@vue/shared': 3.5.35
+      alien-signals: 3.2.1
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.4
+
+  '@vue/reactivity@3.5.35':
+    dependencies:
+      '@vue/shared': 3.5.35
+
+  '@vue/runtime-core@3.5.35':
+    dependencies:
+      '@vue/reactivity': 3.5.35
+      '@vue/shared': 3.5.35
+
+  '@vue/runtime-dom@3.5.35':
+    dependencies:
+      '@vue/reactivity': 3.5.35
+      '@vue/runtime-core': 3.5.35
+      '@vue/shared': 3.5.35
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.35(vue@3.5.35(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.35
+      '@vue/shared': 3.5.35
+      vue: 3.5.35(typescript@5.9.3)
+
+  '@vue/shared@3.5.35': {}
+
   '@webgpu/types@0.1.38': {}
 
   '@webgpu/types@0.1.69': {}
@@ -15202,6 +15415,8 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  alien-signals@3.2.1: {}
 
   anser@1.4.10: {}
 
@@ -15344,6 +15559,15 @@ snapshots:
   atomic-sleep@1.0.0: {}
 
   auto-console-group@1.3.0: {}
+
+  autoprefixer@10.4.23(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.1
+      caniuse-lite: 1.0.30001766
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
 
   autoprefixer@10.4.23(postcss@8.5.6):
     dependencies:
@@ -16111,6 +16335,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
@@ -16517,6 +16743,8 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -16631,6 +16859,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -18286,7 +18518,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -18358,6 +18590,8 @@ snapshots:
 
   ms@4.0.0-nightly.202508271359: {}
 
+  muggle-string@0.4.1: {}
+
   multiformats@13.4.2: {}
 
   mute-stream@1.0.0: {}
@@ -18376,6 +18610,8 @@ snapshots:
       stylis: 4.3.6
 
   nanoid@3.3.11: {}
+
+  nanoid@3.3.12: {}
 
   nanoid@5.1.11: {}
 
@@ -18826,6 +19062,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pidusage@4.0.1:
     dependencies:
       safe-buffer: 5.2.1
@@ -18867,6 +19105,12 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.6:
     dependencies:
@@ -19907,11 +20151,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.3.5(picomatch@4.0.3)(svelte@5.48.4)(typescript@5.9.3):
+  svelte-check@4.3.5(picomatch@4.0.4)(svelte@5.48.4)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
-      fdir: 6.5.0(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.4)
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.48.4
@@ -20475,6 +20719,24 @@ snapshots:
       - yaml
 
   vlq@1.0.1: {}
+
+  vscode-uri@3.1.0: {}
+
+  vue-tsc@3.3.3(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.3
+      typescript: 5.9.3
+
+  vue@3.5.35(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.35
+      '@vue/compiler-sfc': 3.5.35
+      '@vue/runtime-dom': 3.5.35
+      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@5.9.3))
+      '@vue/shared': 3.5.35
+    optionalDependencies:
+      typescript: 5.9.3
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds a new `packages/vue-example` Vite app that opens a Peerbit `Documents` store in the browser.
- Documents how to run the Vue example locally/remotely.
- Updates the root README to surface the new Vue example and the existing React examples already in this repo.

Related to dao-xyz/peerbit#24.

## Test plan
- `corepack pnpm --filter vue-example run build`
- `corepack pnpm --filter vue-example exec vue-tsc --noEmit`
- `corepack pnpm exec prettier --check 'packages/vue-example/**/*.{ts,vue,json,md}' README.md`
- `git diff --check origin/master...HEAD`

## Notes
- This keeps scope intentionally small: a runnable Vue example plus README pointers to existing React examples, rather than publishing framework bindings to npm.
- The original issue mentions both Vue and React; this repo already has React examples, so this PR adds the missing Vue path and makes both framework paths discoverable.
