### PR TITLE
chore: refresh lockfile to dedupe on latest peerbit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,20 +122,20 @@ importers:
     dependencies:
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       '@peerbit/trusted-network':
         specifier: ^6.0.45
-        version: 6.0.45
+        version: 6.0.47
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
     devDependencies:
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -153,11 +153,11 @@ importers:
         version: 4.22.1
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
     devDependencies:
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       '@types/express':
         specifier: ^4
         version: 4.17.25
@@ -175,10 +175,10 @@ importers:
         version: link:../../social-media-app/app-sdk
       '@peerbit/document-react':
         specifier: ^1.0.45
-        version: 1.0.45(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.0.47(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@peerbit/react':
         specifier: ^1.1.24
-        version: 1.1.24(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.26(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-popover':
         specifier: ^1.0.7
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -205,13 +205,13 @@ importers:
         version: 1.4.0
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
       react-chessboard:
         specifier: ^4.7.2
-        version: 4.7.3(@types/node@25.9.1)(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.7.3(@types/node@26.1.0)(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-dom:
         specifier: ^19.1.0
         version: 19.2.4(react@19.2.4)
@@ -227,7 +227,7 @@ importers:
     devDependencies:
       '@peerbit/vite':
         specifier: ^2.0.7
-        version: 2.0.7(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 2.0.7(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       '@tailwindcss/postcss':
         specifier: ^4.0.14
         version: 4.1.18
@@ -239,7 +239,7 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: ^5
-        version: 5.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.1.2(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.23(postcss@8.5.6)
@@ -254,7 +254,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.1.3
-        version: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/collaborative-learning/frontend:
     dependencies:
@@ -272,10 +272,10 @@ importers:
         version: 5.18.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       '@peerbit/react':
         specifier: ^1.1.24
-        version: 1.1.24(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.26(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@tensorflow/tfjs':
         specifier: ^4.2.0
         version: 4.22.0(seedrandom@3.0.5)
@@ -284,7 +284,7 @@ importers:
         version: 3.3.0
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -300,7 +300,7 @@ importers:
     devDependencies:
       '@peerbit/vite':
         specifier: ^2.0.7
-        version: 2.0.7(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 2.0.7(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       '@types/react':
         specifier: ^19.1.8
         version: 19.2.10
@@ -309,13 +309,13 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: ^5
-        version: 5.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.1.2(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
       vite:
         specifier: ^7.1.3
-        version: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/file-share/cli:
     dependencies:
@@ -327,14 +327,14 @@ importers:
         version: 5.6.2
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       yargs:
         specifier: ^17.7.2
-        version: 17.7.2
+        version: 17.7.3
     devDependencies:
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -346,16 +346,16 @@ importers:
         version: 6.0.1
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       '@peerbit/please-lib':
         specifier: workspace:*
         version: link:../library
       '@peerbit/react':
         specifier: ^1.1.24
-        version: 1.1.24(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.26(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@peerbit/shared-log':
         specifier: ^13.2.0
-        version: 13.2.0
+        version: 13.2.2
       '@peerbit/stream':
         specifier: ^5.1.0
         version: 5.1.0
@@ -394,7 +394,7 @@ importers:
         version: 1.3.0
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -413,7 +413,7 @@ importers:
     devDependencies:
       '@peerbit/vite':
         specifier: ^2.0.7
-        version: 2.0.7(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 2.0.7(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       '@playwright/test':
         specifier: ^1.58.0
         version: 1.58.0
@@ -428,7 +428,7 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: ^5
-        version: 5.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.1.2(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.23(postcss@8.5.6)
@@ -443,7 +443,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.1.3
-        version: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/file-share/library:
     dependencies:
@@ -452,22 +452,22 @@ importers:
         version: 6.0.1
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       '@peerbit/program':
         specifier: ^6.0.32
         version: 6.0.32
       '@peerbit/shared-log':
         specifier: ^13.2.0
-        version: 13.2.0
+        version: 13.2.2
       '@peerbit/trusted-network':
         specifier: ^6.0.45
-        version: 6.0.45
+        version: 6.0.47
       '@stablelib/sha256':
         specifier: ^2.0.1
         version: 2.0.1
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       uint8arrays:
         specifier: ^5.1.0
         version: 5.1.1
@@ -477,7 +477,7 @@ importers:
     devDependencies:
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -524,7 +524,7 @@ importers:
         version: 5.18.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       '@peerbit/example-many-chat-rooms':
         specifier: workspace:*
         version: link:../library
@@ -533,10 +533,10 @@ importers:
         version: link:../../name-service/library
       '@peerbit/react':
         specifier: ^1.1.24
-        version: 1.1.24(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.26(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -552,7 +552,7 @@ importers:
     devDependencies:
       '@peerbit/vite':
         specifier: ^2.0.7
-        version: 2.0.7(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 2.0.7(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       '@types/react':
         specifier: ^19.1.8
         version: 19.2.10
@@ -561,22 +561,22 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: ^5
-        version: 5.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.1.2(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
       vite:
         specifier: ^7.1.3
-        version: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/many-chat-rooms/library:
     devDependencies:
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -588,10 +588,10 @@ importers:
         version: link:../../../social-media-app/app-sdk
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       '@peerbit/document-react':
         specifier: ^1.0.45
-        version: 1.0.45(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.0.47(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@peerbit/media-streaming':
         specifier: workspace:*
         version: link:../../streaming-utils
@@ -603,7 +603,7 @@ importers:
         version: link:../music-library-utils
       '@peerbit/react':
         specifier: ^1.1.24
-        version: 1.1.24(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.26(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog':
         specifier: ^1.1.2
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -630,7 +630,7 @@ importers:
         version: 8.1.1
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -652,7 +652,7 @@ importers:
     devDependencies:
       '@peerbit/vite':
         specifier: ^2.0.7
-        version: 2.0.7(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 2.0.7(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       '@tailwindcss/postcss':
         specifier: ^4.0.14
         version: 4.1.18
@@ -673,7 +673,7 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: ^5
-        version: 5.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.1.2(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@webgpu/types':
         specifier: ^0.1.44
         version: 0.1.69
@@ -691,26 +691,26 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.1.3
-        version: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/media-streaming/music-library/music-library-utils:
     dependencies:
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       '@peerbit/media-streaming':
         specifier: workspace:*
         version: link:../../streaming-utils
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
     devDependencies:
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -719,20 +719,20 @@ importers:
     dependencies:
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       '@peerbit/media-streaming':
         specifier: workspace:*
         version: link:../streaming-utils
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
     devDependencies:
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -741,17 +741,17 @@ importers:
     dependencies:
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
     devDependencies:
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -785,10 +785,10 @@ importers:
         version: link:../../../social-media-app/app-sdk
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       '@peerbit/document-react':
         specifier: ^1.0.45
-        version: 1.0.45(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.0.47(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@peerbit/media-streaming':
         specifier: workspace:*
         version: link:../../streaming-utils
@@ -797,7 +797,7 @@ importers:
         version: link:../../playback-utils
       '@peerbit/react':
         specifier: ^1.1.24
-        version: 1.1.24(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.26(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog':
         specifier: ^1.1.2
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -824,7 +824,7 @@ importers:
         version: 8.1.1
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -843,7 +843,7 @@ importers:
     devDependencies:
       '@peerbit/vite':
         specifier: ^2.0.7
-        version: 2.0.7(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 2.0.7(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       '@tailwindcss/postcss':
         specifier: ^4.0.14
         version: 4.1.18
@@ -864,7 +864,7 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: ^5
-        version: 5.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.1.2(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@webgpu/types':
         specifier: ^0.1.44
         version: 0.1.69
@@ -882,16 +882,16 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.1.3
-        version: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/name-service/library:
     devDependencies:
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -912,7 +912,7 @@ importers:
         version: 5.18.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       '@peerbit/peer-names':
         specifier: workspace:*
         version: link:../../name-service/library
@@ -921,10 +921,10 @@ importers:
         version: 0.4.35(react@19.2.4)
       '@peerbit/react':
         specifier: ^1.1.24
-        version: 1.1.24(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.26(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -940,7 +940,7 @@ importers:
     devDependencies:
       '@peerbit/vite':
         specifier: ^2.0.7
-        version: 2.0.7(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 2.0.7(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       '@types/react':
         specifier: ^19.1.8
         version: 19.2.10
@@ -949,19 +949,19 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: ^5
-        version: 5.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.1.2(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
       vite:
         specifier: ^7.1.3
-        version: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/shared-fs/cli:
     dependencies:
       '@multiformats/multiaddr':
         specifier: ^13.0.1
-        version: 13.0.1
+        version: 13.0.3
       '@peerbit/shared-fs':
         specifier: workspace:*
         version: link:../library
@@ -970,10 +970,10 @@ importers:
         version: 5.6.2
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       yargs:
         specifier: ^17.7.2
-        version: 17.7.2
+        version: 17.7.3
     devDependencies:
       typescript:
         specifier: ^5.6.3
@@ -989,23 +989,23 @@ importers:
         version: 3.1.2
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       '@peerbit/program':
         specifier: ^6.0.32
         version: 6.0.32
       '@peerbit/trusted-network':
         specifier: ^6.0.45
-        version: 6.0.45
+        version: 6.0.47
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       uint8arrays:
         specifier: ^5.1.0
         version: 5.1.1
     devDependencies:
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -1023,19 +1023,19 @@ importers:
         version: 10.1.13
       '@peerbit/canonical-host':
         specifier: ^1.0.41
-        version: 1.0.41(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 1.0.43(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       '@peerbit/document-proxy':
         specifier: ^2.0.45
-        version: 2.0.45(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 2.0.47(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/document-react':
         specifier: ^1.0.45
-        version: 1.0.45(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.0.47(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@peerbit/react':
         specifier: ^1.1.24
-        version: 1.1.24(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.26(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -1045,7 +1045,7 @@ importers:
     devDependencies:
       '@peerbit/vite':
         specifier: ^2.0.7
-        version: 2.0.7(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 2.0.7(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       '@types/react':
         specifier: ^19.1.8
         version: 19.2.10
@@ -1054,13 +1054,13 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: ^5
-        version: 5.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.1.2(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
       vite:
         specifier: ^7.1.3
-        version: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/social-media-app/ai/cli:
     dependencies:
@@ -1094,20 +1094,20 @@ importers:
         version: link:../../library
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       ollama:
         specifier: ^0.5.14
         version: 0.5.18
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
     devDependencies:
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -1122,7 +1122,7 @@ importers:
         version: 5.5.8
       '@peerbit/react':
         specifier: ^1.1.24
-        version: 1.1.24(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.26(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@types/react':
         specifier: ^19.1.8
         version: 19.2.10
@@ -1131,7 +1131,7 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -1149,13 +1149,13 @@ importers:
     dependencies:
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       parse5:
         specifier: ^7.1.2
         version: 7.3.0
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
@@ -1165,7 +1165,7 @@ importers:
         version: link:../library
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -1181,7 +1181,7 @@ importers:
     devDependencies:
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       chai:
         specifier: ^6.2.0
         version: 6.2.2
@@ -1205,7 +1205,7 @@ importers:
         version: 2.5.0
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
     devDependencies:
       typescript:
         specifier: ^5.6.3
@@ -1235,7 +1235,7 @@ importers:
     devDependencies:
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       chai:
         specifier: ^6.2.0
         version: 6.2.2
@@ -1259,7 +1259,7 @@ importers:
         version: 2.5.0
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
     devDependencies:
       typescript:
         specifier: ^5.6.3
@@ -1287,7 +1287,7 @@ importers:
         version: 2.2.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@peerbit/document-react':
         specifier: ^1.0.45
-        version: 1.0.45(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.0.47(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@peerbit/identity-supabase':
         specifier: workspace:*
         version: link:../../identity/supabase
@@ -1299,7 +1299,7 @@ importers:
         version: 0.4.35(react@19.2.4)
       '@peerbit/react':
         specifier: ^1.1.24
-        version: 1.1.24(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.26(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-radio-group':
         specifier: ^1.3.7
         version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1329,7 +1329,7 @@ importers:
         version: 4.0.0
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -1363,13 +1363,13 @@ importers:
     devDependencies:
       '@peerbit/vite':
         specifier: ^2.0.7
-        version: 2.0.7(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 2.0.7(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       '@playwright/test':
         specifier: ^1.57.0
         version: 1.58.0
       '@tailwindcss/vite':
         specifier: ^4.0.14
-        version: 4.1.18(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.18(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/lodash':
         specifier: ^4.17.16
         version: 4.17.23
@@ -1390,10 +1390,10 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-basic-ssl':
         specifier: ^2.1.0
-        version: 2.1.4(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 2.1.4(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitejs/plugin-react':
         specifier: ^5
-        version: 5.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.1.2(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.23(postcss@8.5.6)
@@ -1408,16 +1408,16 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.1.3
-        version: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/social-media-app/library:
     dependencies:
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -1427,7 +1427,7 @@ importers:
     devDependencies:
       '@peerbit/test-utils':
         specifier: ^3.1.0
-        version: 3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       '@types/qrcode':
         specifier: ^1.5.5
         version: 1.5.6
@@ -1436,7 +1436,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.9.1)(happy-dom@20.3.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@26.1.0)(happy-dom@20.3.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/social-media-app/network:
     devDependencies:
@@ -1448,23 +1448,23 @@ importers:
     dependencies:
       '@peerbit/document':
         specifier: ^13.1.0
-        version: 13.1.0
+        version: 13.1.2
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       uuid:
         specifier: ^10
         version: 10.0.0
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^6.1.0
-        version: 6.1.1(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.48.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 6.1.1(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.48.4)(typescript@5.9.3)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@sveltejs/kit':
         specifier: ^2.0.0
-        version: 2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.48.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.48.4)(typescript@5.9.3)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.0
-        version: 6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/uuid':
         specifier: ^8
         version: 8.3.4
@@ -1479,22 +1479,22 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.1.4
-        version: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/text-document/frontend:
     dependencies:
       '@peerbit/react':
         specifier: ^1.1.24
-        version: 1.1.24(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+        version: 1.1.26(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       '@peerbit/string':
         specifier: ^5.1.67
-        version: 5.1.67
+        version: 5.1.69
       fast-diff:
         specifier: ^1.3.0
         version: 1.3.0
       peerbit:
         specifier: ^5.3.0
-        version: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+        version: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -1510,7 +1510,7 @@ importers:
     devDependencies:
       '@peerbit/vite':
         specifier: ^2.0.7
-        version: 2.0.7(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 2.0.7(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       '@tailwindcss/postcss':
         specifier: ^4.0.14
         version: 4.1.18
@@ -1522,7 +1522,7 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: ^5
-        version: 5.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 5.1.2(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.23(postcss@8.5.6)
@@ -1537,7 +1537,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.1.3
-        version: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
 packages:
 
@@ -2868,44 +2868,44 @@ packages:
   '@libp2p/circuit-relay-v2@4.2.5':
     resolution: {integrity: sha512-IYOPXO5CReoM4KUQpZE7TnOi0LaCZ96PYMZE0mf5zALtQjvaMRucDW6aOzDy4BEq9P4QpKZyp7s3fX9OGOPSFw==}
 
-  '@libp2p/crypto@5.1.18':
-    resolution: {integrity: sha512-sCm+dFFZmH4LJIHTCzPy7+EBRhzkndFUcIU8bui6iaxK6SDSRVa11+/O6DzW8hn/U9LgDXe6jXnzWM8bM7OoCA==}
+  '@libp2p/crypto@5.1.20':
+    resolution: {integrity: sha512-sPz+CvDWPDb+O8xYsueXDdrV6Kf7PciNEYvcCjOR/VqM0iHwzC7aaM0xPiQqrUDj1nggswbY/E/vNZYJ4aCQaA==}
 
   '@libp2p/identify@4.1.6':
     resolution: {integrity: sha512-CP04KjoMpsavEtaHz+m2Hfyg9t4h/RijVa57xOso3ApjQ2obYbVdxyKALv4GrtRVLRTQYJsHtXC6oxne2TjqJQ==}
 
-  '@libp2p/interface-internal@3.1.5':
-    resolution: {integrity: sha512-xbFB0eAv/MkixmQKkvD0jmPSzF8my92ago2ss5PVa3QFKXz0XtpQSRnj22sfzLyURs1QSRQd+iK+ZJaHdZ0DMg==}
+  '@libp2p/interface-internal@3.1.7':
+    resolution: {integrity: sha512-5qzZOx1JU+CdT8UKLWKtM3LOQ3C9aSlRzVLJkLZXVN0ULhmctlAeZckPEEZ5z4pDtLpgFHjr+H9bd7NSTHqtVQ==}
 
-  '@libp2p/interface@3.2.2':
-    resolution: {integrity: sha512-IU78g6uF8Ls0//4v9VE1rL5Jvy+i6I8LI/DssojFICbaDJSkL59Sn5XRfHrY5OCxTnUnUxnWK7pHz/3+UZcRNQ==}
+  '@libp2p/interface@3.2.4':
+    resolution: {integrity: sha512-o/ZMbsplniVQhz0AW1CinZcfZPEfr7ttu4w7aivrFAs6xDpnJYmN3FTeEgTt93EHs+AEOcIT76V3KMFDZmIEcQ==}
 
   '@libp2p/keychain@6.1.0':
     resolution: {integrity: sha512-X/AdUB53uV00VRIRf2mX8fByvSx6bpfQbEdx8nHtLTVgcfnSDfFYIw8krd8ZnzgBNCbN+osMJn151Ft+QHkeBQ==}
 
-  '@libp2p/logger@6.2.7':
-    resolution: {integrity: sha512-IVEz5+0kE4mRWwMzXP34AlXe2k1FLzBqKkjeASyhPVdMz0A4qH9nYmCBwonzmRzymklGjFIEDa1s7Vjhd9V4Rg==}
+  '@libp2p/logger@6.2.9':
+    resolution: {integrity: sha512-hjuF81KSt9dWNPJZcdJ4SHEuygMLHrPZVTGNzCWu+2jxpJqOHWy9CJS8llLH7pgbDtlq4jJ4uuqihCR5Gjo4gA==}
 
-  '@libp2p/multistream-select@7.0.20':
-    resolution: {integrity: sha512-YMcOcSaS0au6B1pBDmEXRqNlzwGXFLWbyUFDxfYMW+/o4JEqPaimEBZmLdOVY7dl4tStsUzZMEokp+AqV9JDpQ==}
+  '@libp2p/multistream-select@7.0.22':
+    resolution: {integrity: sha512-KJ1/i6NVAdPjsGFByB7eECW1j/c54nZIfCyDH3/gl4cLX+l1Pnkm2AgLRuk/3D/tNNVjsSJC2VOwJg6Z8NW3ww==}
 
-  '@libp2p/peer-collections@7.0.20':
-    resolution: {integrity: sha512-OYohC9qQHUp1KSXRe4qgPk+IxxVgMG/+7TL7Nt3Pw1tWKLQ93DzRRZHUBRwvYDOv6M4jD/Qn1pxXOwNQsSQgCg==}
+  '@libp2p/peer-collections@7.0.22':
+    resolution: {integrity: sha512-46Mq8ly8uqcpnADo0wWqTEuP8tRDyRtxz/CbTwVSZfz6TbRM/nIRlhoxZu8EIrYBqBZAu3F+3EB7hrzJDyUerQ==}
 
-  '@libp2p/peer-id@6.0.9':
-    resolution: {integrity: sha512-MlofyOOpxzZA4tIcOVPjd1FQIa0TA0g+bn+d08vfo9znCjfe6Lh0RBFyLdlICbyogVN6wn7+29SYch78wCuuCQ==}
+  '@libp2p/peer-id@6.0.11':
+    resolution: {integrity: sha512-p2Sw8y12gcrmDYGTrbvGQzMhM7ypquCfQX5WdhitI0+ArTSRHHXt7ozdpUWzcq7CNaK5r2q6FIbpz9Yxywg9Hw==}
 
-  '@libp2p/peer-record@9.0.10':
-    resolution: {integrity: sha512-pbDHpOPzE2vLlyiIAitpKG+aDNcnVmtLCYb1wGeRRAnarZC/vREZGM6JmR8Y79INu7jQ1IwTN1iKMj9jaXdAGg==}
+  '@libp2p/peer-record@9.0.12':
+    resolution: {integrity: sha512-tYGHo9gSO1ZqQripsEtpzxMrWDnmCMgFe8c1TKcml8dZUBCAsM9k5js25RKb0HA1aqZ2VX54XPFazpbjVs3tow==}
 
-  '@libp2p/peer-store@12.0.20':
-    resolution: {integrity: sha512-aRWtnaWkuJDFBwu3OS1sBUDP04+6hJ643hpuabIu/z9dR8uHxs3fzYXZg5DCGhNIG/8GXF62fKYOi5gmhvZJHA==}
+  '@libp2p/peer-store@12.0.22':
+    resolution: {integrity: sha512-LoBq4uZp5TvPVcU1DtEsuBEC8Fcq1sprgY+KBoIoecL2bsUpCaQsbPIqbByLR6hCfDgWPv5ChFvIoZwn3YCyDw==}
 
   '@libp2p/tcp@11.0.20':
     resolution: {integrity: sha512-u3pO7EO2QOmIcurC5ejDS8+0nGHC67X3YWO9T49dK9inBuJkYekHnuNHODUX4pNyf+ocugB80rmwd6JdCQZkDg==}
 
-  '@libp2p/utils@7.2.1':
-    resolution: {integrity: sha512-tRBQHUqgggXATgTY8S0A8amdhljZ7Xx9nAWDOpfvW/ojDVY89BpIJfKLEe0TUD9Lc/3pSmlAC6oBYaHe2jP9UA==}
+  '@libp2p/utils@7.2.3':
+    resolution: {integrity: sha512-7RN1UtSYga3LbpOuW5XsMseQIGawrz5jfWFsgQGI9B130VA6UXKHhzgQbDGHfXLjoNv2RWALp8u6laUvcL65lg==}
 
   '@libp2p/webrtc@6.0.21':
     resolution: {integrity: sha512-q7Qiqs/vrdECNRmOfLuYvcH7gLOk94vO8tHpkaIDJv2OxRLDcwAGqQ51K0932shU4DozDJ6203HdWaRJs3MMzg==}
@@ -3007,8 +3007,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@multiformats/dns@1.0.13':
-    resolution: {integrity: sha512-yr4bxtA3MbvJ+2461kYIYMsiiZj/FIqKI64hE4SdvWJUdWF9EtZLar38juf20Sf5tguXKFUruluswAO6JsjS2w==}
+  '@multiformats/dns@1.0.15':
+    resolution: {integrity: sha512-W0zAMABtAn+3chgFcPGvllKND7M6GblMAAFcJQTy+iMmGiyFErZYPzAh2b50Y3SFf340iFV7+ckVgZkGfUyxzA==}
 
   '@multiformats/multiaddr-matcher@3.0.2':
     resolution: {integrity: sha512-iphGQJliZxe2yKu57bdRDgeS+3znc5uXtMybDO1Wau3rIjas4zjrjlyxmFz3wqyUL9f3VDQwas/ZqA7N4QeSfw==}
@@ -3016,8 +3016,8 @@ packages:
   '@multiformats/multiaddr-to-uri@12.0.0':
     resolution: {integrity: sha512-3uIEBCiy8tfzxYYBl81x1tISiNBQ7mHU4pGjippbJRoQYHzy/ZdZM/7JvTldr8pc/dzpkaNJxnsuxxlhsPOJsA==}
 
-  '@multiformats/multiaddr@13.0.1':
-    resolution: {integrity: sha512-XToN915cnfr6Lr9EdGWakGJbPT0ghpg/850HvdC+zFX8XvpLZElwa8synCiwa8TuvKNnny6m8j8NVBNCxhIO3g==}
+  '@multiformats/multiaddr@13.0.3':
+    resolution: {integrity: sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==}
 
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
@@ -3097,8 +3097,8 @@ packages:
   '@peerbit/any-store-opfs@1.1.8':
     resolution: {integrity: sha512-WJwAZQYUVQXyD9ssMjfXxw1bYcXC4HIr+V+EWtBOOh2cmVZps1GbMD1vyCKRTXd9wt3erLNx+lFAL0roUP1ZWQ==}
 
-  '@peerbit/any-store-rust@0.1.0':
-    resolution: {integrity: sha512-cFvt01riE8JTHQp3F4THQBh/e33EqLWaU8966qUqm5dkq+5aj6aBl8hZa6US2AqKGhB950HbNpF0e93FfXsM1Q==}
+  '@peerbit/any-store-rust@0.1.1':
+    resolution: {integrity: sha512-oJ6xb/vjGk3LKykKONabg625EV3EHT2aNJhOz/tnfr0NcCWxRKF1RauK2g8ioFs459V+K83lecLojMLvQ7TU0Q==}
 
   '@peerbit/any-store@2.2.10':
     resolution: {integrity: sha512-IBX6sJrOGMVZpr1AMHVa+l4VHhMjjEuxV9piaGHIVZ2yPDjlPJqkV2wpbNfmoiKBfiD8p2fTTOpolmWQS6UTyg==}
@@ -3121,8 +3121,8 @@ packages:
     resolution: {integrity: sha512-w4QNk8NhAwq+DrwyDevcdpQiBdhQNn1hsjiVAksMkr3KpovGE4swv3WgwGScEURY3/xpOCaOS+KaxheJhWl+Ig==}
     engines: {node: '>=18'}
 
-  '@peerbit/canonical-host@1.0.41':
-    resolution: {integrity: sha512-GsboHlVqwpg/zjJh7+SgdQoetTKtly5xOAAbv90DuPXAhV37xHhG/h6yb9S/qm1MlC3AjH9X078DEklr79KshQ==}
+  '@peerbit/canonical-host@1.0.43':
+    resolution: {integrity: sha512-4799/8gXcUwCL/l3TfOnsd91vj95Mcnik2oz5SfZHkj2ICzNTLdr5sC6bhBCdYxaPebVUhPFLNr8wYwiyo5b9w==}
     engines: {node: '>=18'}
 
   '@peerbit/canonical-transport@1.0.0':
@@ -3135,23 +3135,23 @@ packages:
   '@peerbit/diagnostics@0.0.1':
     resolution: {integrity: sha512-a6jB9mdQfLzO96ITnrqwxkk76QY0w7c88p6eGO4J9h1b/I6MgMhORcOcFEOWZsw84/7GGBq8T5DYgAh8pkOh1w==}
 
-  '@peerbit/document-interface@3.2.43':
-    resolution: {integrity: sha512-3GvPfakbjJN8SySLlZmQLY+/v+U1TYoDGk6sm3HpiA0YGnQNq5xm7gLbY8PpqYipRpK8RyZ4MswBXfE/IY+Qcw==}
+  '@peerbit/document-interface@3.2.45':
+    resolution: {integrity: sha512-0o/aM6aiJzLYpm4pOke4kgBbBAIEoNdQMpOQYM3nBaFblEtRR0lgtAIFI/36IrEdhJN1wCjFzU5lDzjQ7W1y+A==}
 
-  '@peerbit/document-proxy@2.0.45':
-    resolution: {integrity: sha512-8zBQ9suCqoPWneWhdMHFciUCaMDUpSTX9Oi+bVyGJirP0bV+FT8e7Au8OfALy0N5SCjOXiCFRsP7FLL0kXJnQg==}
+  '@peerbit/document-proxy@2.0.47':
+    resolution: {integrity: sha512-jnNj3HGOs/IMKFVaMUs5bwOmTGgAaJZNxwpSttxrclUeVtp3cYKH/gMWWIJ56V/FGzxlqw2dUb29DItqrKAfmg==}
     engines: {node: '>=18'}
 
-  '@peerbit/document-react@1.0.45':
-    resolution: {integrity: sha512-qq/bF1Yv4YqbKxVE3aACVhlbrqpoYrX1l6KbX7wg88U5FWcD+KTgAZjkVksbbdICRd/d9/SpmYwnluMpDp7vkg==}
+  '@peerbit/document-react@1.0.47':
+    resolution: {integrity: sha512-UeeukPKO/loK7uiyd/zoTMHHrIqa5Yu+nIRAvaGsmvSXtvoxncMNJQF/Qstfqu3YCr5t5gOaaKF8ZgVLdDNrxQ==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
-  '@peerbit/document-rust@0.1.0':
-    resolution: {integrity: sha512-AG5CBgcyBvuLWUKEJy7jNlZ1ge05sU3P+HjrKl2C688Fa2sNgbHJFoxJmIFMGmuDI2n5si884VAp0G/53ing6A==}
+  '@peerbit/document-rust@0.1.1':
+    resolution: {integrity: sha512-2Lu9j2ohjIFIC7YzeBovWk4mehGEh73kYYRT7HKs+iVD8L/8rjl7TxFrgSDkuPbBBK/yMYvYjK81v176dUNZGA==}
 
-  '@peerbit/document@13.1.0':
-    resolution: {integrity: sha512-EppH+jii06j1OwoDdCJLquwL42uL3OPQqV+0cnDckVOgXV+poBdXEeNo3DTQ6YIIRGjCMfY1l4GiKXvFmkRWkQ==}
+  '@peerbit/document@13.1.2':
+    resolution: {integrity: sha512-HQ85i/k1H6iZ75BFNiHm+rjJtV2v0I31UzwImXo+/a1aru5CWW8+qV1aGj8aSJ9fh4YIPeyKD04L9Ds+XdbJfA==}
 
   '@peerbit/indexer-cache@0.2.8':
     resolution: {integrity: sha512-vgShvIWYWd0A1+tXVvcaGDYrEMgbaEN86RV035QgqvUK92D7hrcI2xcWji+GR56EKDjvQgLJ4C9HDI84eq4QyA==}
@@ -3159,8 +3159,8 @@ packages:
   '@peerbit/indexer-interface@3.0.5':
     resolution: {integrity: sha512-m6lzQkIfneaAXa1dpssbyoPMb0jMH3vD+5htf1VipbsabjZmTWNW316smDgHBNbDUMBFuMBpnlqcstwkxrNr2Q==}
 
-  '@peerbit/indexer-rust@1.0.1':
-    resolution: {integrity: sha512-/SgegRz+CwKAR78qDwqkZt/yF+Rc+b+vMcN+/WefEn/J5MLtLHg83smNd0sFO0dj0rFra864r0nfoYbSnkdpJA==}
+  '@peerbit/indexer-rust@1.0.2':
+    resolution: {integrity: sha512-Knhm6MYJH1iAakC5CrwOWvMWGw48BfKQ9b3oZPUPdrucdG/a14mAosw6ruMBlhweqoP/5G1Dar5I6i1hJuR4aQ==}
 
   '@peerbit/indexer-simple@1.2.8':
     resolution: {integrity: sha512-uy57yqOVWnptlTqJa5pnX+OURwLkTr3HYtbN+eMlUUw9AbYbZFkE2bl2RvSXpigkqnbKtVR6283k1szicPcdzA==}
@@ -3175,21 +3175,21 @@ packages:
     resolution: {integrity: sha512-9uLUOAyQiY4iFR3E3dS/9umZdsI/uRHqdQ/RR4ZpOdrlxAxAwz/VU/LGgcWFympC5hU06CGitYaN1vAUkREpEg==}
     engines: {node: '>=16.15.1'}
 
-  '@peerbit/log-rust@1.1.0':
-    resolution: {integrity: sha512-ea3ow5pNvQPSKf9SGYexrfMJJM5KKZv/eGgtF3egwsUEKBKqUqvHIX/gRSRdvLuPVZsgNai2h4KiAsYkAapcNA==}
+  '@peerbit/log-rust@1.1.2':
+    resolution: {integrity: sha512-Nf3FE/R9SqMPG2JEvvP9HkgTaSndm2c1v2aSQhdMttFE9Yp90+hLmKh9va4Zz+9Nu0pjoLPQGixor5y+cert+Q==}
 
-  '@peerbit/log@6.2.0':
-    resolution: {integrity: sha512-Q/oSc7uAoEZRL1dyAwy7nc+VG9FIU7HnT/dU1pt+m36wfUI+mTOBFldOpvPJH+Qjkdm5c1iDasLsqVLUmS98Lg==}
+  '@peerbit/log@6.2.2':
+    resolution: {integrity: sha512-wmIIzxYiapX0cMdqz4ZIjbHma+Cx73Rg2zNjcmUVBzXjnihX7+WOZHp8BbESp/1a7GSfDjK6uXY/opQRygYnYA==}
     engines: {node: '>=16.15.1'}
 
   '@peerbit/logger@2.0.1':
     resolution: {integrity: sha512-CRs8SbcdW4XXk/UPFgcx05AtrwxEP5bW5CVxTUlWhRTCQTFx1JWLRNet5rLEA7kawGfJ7bn8+edd9AJTfHGWOg==}
 
-  '@peerbit/native-backbone@0.1.0':
-    resolution: {integrity: sha512-Q9A83r4FcXPo9SvT+6aA2duoN0lh2Fq4JeNjac12+CKDuNjubVtYUhjC3e+66TuYBCyjnCqU1N7g93zw6T3fMw==}
+  '@peerbit/native-backbone@0.1.2':
+    resolution: {integrity: sha512-FXIbwjyOs6r3U085PVrWB5RoTUpDIpJ+ZAWpgj2qyaz0fUdV8N2inpfXv0pO7kI7UEQ3Oh6FXgAToNZK1stDbw==}
 
-  '@peerbit/network-rust@0.1.0':
-    resolution: {integrity: sha512-GvyTY7E/1XlTjhwtxDU5PudtL41ykV3QfY9Tdg/qQlSK2cfLF58EAg2LTQJKeqP7BrbHVVwuM3A4YpMSQRjsJg==}
+  '@peerbit/network-rust@0.1.1':
+    resolution: {integrity: sha512-1r9+TxSR5zZCHD5izOX9N3yDPxju6HL8Xo5VgWo7Y3VoFuwdBEgpS1GNQpA/M7WJ0+YM6SQXviigdKfGjvLuGA==}
 
   '@peerbit/program-react@0.4.35':
     resolution: {integrity: sha512-2xbCXDtfuVvNoAIBF4m3t6OIvKUTaBGg18KJv+SnPJfKQiQtpKJlnWBdz1MFjEm9rVUT3/icvBC7PD/A6GWVFg==}
@@ -3207,8 +3207,8 @@ packages:
     resolution: {integrity: sha512-xvKtixtH652DRh272mC4hqxCZJ3a/fvcF+8C2+Km5qnC8wFhrJw90q4fQJwQ01YkjYM17KgtEoQl69RwpSCUjQ==}
     engines: {node: '>=16.15.1'}
 
-  '@peerbit/react@1.1.24':
-    resolution: {integrity: sha512-S+4Z0a99YRJ0NZgdAaHFFOWOKvikSufzLeP6RqIJq2VMa29mEAjiCbLl5cXR2XtnBQAGD4B8+rkhwrva6wdtjQ==}
+  '@peerbit/react@1.1.26':
+    resolution: {integrity: sha512-V5ALriNYB6Sx+0LE6oMtgWqsP2u+NHN/C3W5PS7aHt8JtAEYDfk/Hrus3ko+ZoDFIBnXnRe+tfnT60Nj2KuxHQ==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
@@ -3218,15 +3218,15 @@ packages:
   '@peerbit/rpc@6.1.0':
     resolution: {integrity: sha512-vKuMRzdcOflxj/g9Njqpyei0B8O1ovTxRHgivJWkA6S1OSH0cO00HFy+rIKJP4AUBfo1vdfibwf7UqauZlCPlQ==}
 
-  '@peerbit/shared-log-proxy@2.0.44':
-    resolution: {integrity: sha512-kxPwndOiQvnnq8/WGBOHHC1pSxkfwQLlFKVL1WjOW3fR7B98F/3hIcTX67EGGD8AUI/Fuc2ZlC0nSKXi4QBaLQ==}
+  '@peerbit/shared-log-proxy@2.0.46':
+    resolution: {integrity: sha512-tkESXK8nlezAWouUTZ5lDNZ1aB6dVemRyGeOzreXqGEjet05ogUfuGj9MaMvJ8UuYpi1vHwrM0VVo0Zs53oyoQ==}
     engines: {node: '>=18'}
 
-  '@peerbit/shared-log-rust@0.1.0':
-    resolution: {integrity: sha512-hU9IHMtQZKIayZuOgVxvJYdaleInkbYNhaSSd22e8fgcReSbJ6RmLDs0JAntOjrMHpcJN/oVeQ4+Rm84K1StgA==}
+  '@peerbit/shared-log-rust@0.1.1':
+    resolution: {integrity: sha512-UqCHPaewrZBsnne4njlUF/BBvnqe7M3ISYPtKnoD1sdLOVa3hPhNYNsWYSZO38je3+77CfJJ8fS2cLj2JeWRsg==}
 
-  '@peerbit/shared-log@13.2.0':
-    resolution: {integrity: sha512-NuaQ3QWxxcp6hbRdRkjD5/1+E2Gmocqh+PQZsiDdgaaRm7s3C2uU2kqXWU8sTvMMSCxUh8+2FFCjOn+HTlLVGQ==}
+  '@peerbit/shared-log@13.2.2':
+    resolution: {integrity: sha512-6Qm/I5Chn/MVB8Ou3ityjurS5+3MX2bifPxGPQdYAJ4DqXnEYyES6Ojs9rwMsurGRi1HeIeqZgMkEqlq7jIfWg==}
 
   '@peerbit/stream-interface@6.0.11':
     resolution: {integrity: sha512-s7knnyPCkTftSHazStFPDU5yyLLzZjWIf9N5V45ErQyR3ebPshlx3jnjaVPI3MOkkAJb76Q0gZZ5mrQkEq4YCA==}
@@ -3236,18 +3236,18 @@ packages:
     resolution: {integrity: sha512-ylrObYHdEKHVdc0p8aItz18EOn4m8F0UYyDU1AbbcjwFgIjFnegbyvk+9R92j/xWTisOk4hK11xeKPUKRK221w==}
     engines: {node: '>=16.15.1'}
 
-  '@peerbit/string@5.1.67':
-    resolution: {integrity: sha512-TKIlTRhsp27zO1lY6ACvMVZlP57w2xm6NFvbHPeNOmmDg/PEss/ZYzbx/wk+7kB6u4t1CvPUcXgJ1XiHRdvXpA==}
+  '@peerbit/string@5.1.69':
+    resolution: {integrity: sha512-Tn1YecBa7XHggGojLriDauPrPYP+LU3e+caHKL+sXAy526VxsIX15DBYnrc6ncdUI5Xnk6j37JGFqOeN04meeQ==}
 
-  '@peerbit/test-utils@3.1.0':
-    resolution: {integrity: sha512-Y3ihs87skQIcH9SnGY5mlBbzIl8fDH1uZ3fkQWipzMt0+bCscsXYaG1giKfQBO1vBIWIs3FDTVBeqKuFGD1oLQ==}
+  '@peerbit/test-utils@3.1.2':
+    resolution: {integrity: sha512-txlHvYP0iC/7eLCK9sZdeVdZwhWsVqqVGaqlmEC5UyZWRfzDFy9yaq+8ZUCYqtuN/1hfZhE4htO4F7/kcyzZ+A==}
     engines: {node: '>=16.15.1'}
 
   '@peerbit/time@3.0.0':
     resolution: {integrity: sha512-UpFwxHkS9qTFFDPqZji5J1yHJdNEzlGObmZFj9yg1kl+4jEuxhjL7sjL+KYx5W9O1E45RMZUTw1mMvUEhCr18Q==}
 
-  '@peerbit/trusted-network@6.0.45':
-    resolution: {integrity: sha512-jXIiBZcIHFqfPvpBYR5WSXPwXi1lVxPVcPTYKZztCRcbmrGG0YccDnpiBBWeoWxFyJah4jlTj/X/ygUPEUCtLA==}
+  '@peerbit/trusted-network@6.0.47':
+    resolution: {integrity: sha512-zOKSlFKqK1+xQTswBEoBq+xv6rjuQ1u8mUjhJiUNwzZmwWtn4gZVo50PdOCpPAWFUSqejKB6PL+ct3/LvL8SmQ==}
 
   '@peerbit/vite@2.0.7':
     resolution: {integrity: sha512-4q6U9WaUgGYpGre03MhD5xVdqRN0YoFDVdMAvEmsDj/3BFi6bPBmz98PJpbbbxc3gAeza7bQrStdtZ27xsMafQ==}
@@ -4663,8 +4663,8 @@ packages:
   '@types/node@22.19.7':
     resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
 
-  '@types/node@25.9.1':
-    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+  '@types/node@26.1.0':
+    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
   '@types/offscreencanvas@2019.3.0':
     resolution: {integrity: sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q==}
@@ -5008,8 +5008,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -5335,8 +5335,8 @@ packages:
   caniuse-lite@1.0.30001766:
     resolution: {integrity: sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==}
 
-  cborg@5.1.1:
-    resolution: {integrity: sha512-BDbSRIp6XrQXkTc7g+DN0RB9RrDPTUfals2ecWUlt3juPLjbAvy/V72mJcXY0Ehu0Dq/3WpNCOCT68HUTbW+lw==}
+  cborg@5.1.7:
+    resolution: {integrity: sha512-rGg2MG9zZEUKtKqjkBppIWUecTXf9N1vs1Qru43vJWoDaODhCrtmzdehCaA/aq/c1cPI5A0kPrJ5Tf+jIfhV4w==}
     hasBin: true
 
   ccount@2.0.1:
@@ -5610,6 +5610,9 @@ packages:
 
   datastore-core@11.0.4:
     resolution: {integrity: sha512-k755ayqP66Q8NuzvVKTZiaTgcTJU1/EMmQAQ0OtZNA13JX1pFw+aCu42Db6/Q7LuyJUcBtqAJdfOjM7zA8/8Lw==}
+
+  datastore-core@12.0.1:
+    resolution: {integrity: sha512-pfgIE5LG0Z5oyc6TxiLaF/0j4Gh1Yrs2+Ck/qssf9Oxw4s4YKC3zpqifuzThnKakAFWONr/vRv+66Koc0yJvyA==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -6489,11 +6492,17 @@ packages:
   inline-style-prefixer@7.0.1:
     resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
+  interface-datastore@10.0.1:
+    resolution: {integrity: sha512-DYMj/Og5Cz1Qwkx6/x5KRvR8SYEX7rVAv3KKCm2NzTwWSfpNAC4PahjcYbHyoZBP6zPWrhQv5n5wE+vaDdgSAg==}
+
   interface-datastore@9.0.3:
     resolution: {integrity: sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==}
 
   interface-store@7.0.2:
     resolution: {integrity: sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==}
+
+  interface-store@8.0.0:
+    resolution: {integrity: sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -6714,14 +6723,17 @@ packages:
   it-length-prefixed@10.0.2:
     resolution: {integrity: sha512-RrNBs4d7baK8AKGHleC55l/JtvzxDw6DPXs3CvFgQwdwFzLBFDvlpKgDDNDFwXJjPSy1nEX1A44nL110+EKc3g==}
 
+  it-length-prefixed@11.0.1:
+    resolution: {integrity: sha512-0Cy4RHFiL2CH060Lkigq0N37VaPg7oSylG6YjXErq+ccJFYcNEWNzxNjbqceio/sY1C+q84vZXOCE6/C0flYfQ==}
+
   it-map@3.1.6:
     resolution: {integrity: sha512-wCix0FXImtIPIxhCnbz35RqWs00e/CReSZX9nZq1j46JcAzBBp57ob9/2l1WnDYEaUURIR8xCyg2NsWbOwBJFQ==}
 
   it-merge@3.0.14:
     resolution: {integrity: sha512-D3t1Go2G2SQMkTujaA6EVojJPJKA9pFksxlSPDRBfrHKhWl6O40vEP7Itr5eCAjyCQH5p9+BFFVIy9bhLM4ZuQ==}
 
-  it-parallel@3.0.15:
-    resolution: {integrity: sha512-1iUV4wg7cDy40N32/XosK7mcwKM+oeSGq0r7czxNaUGGSQvbdSmkIoK4Vu/XPsXZIqBLt9tO+LDPi8RJBJ/Qwg==}
+  it-parallel@3.0.16:
+    resolution: {integrity: sha512-qr3nTgj4fraSfr6Ix9JkHsy/Yb/4vmS3QIAu3fsX52r2SOTLbohXoixKp6AIhTJcorpKwjP0VFcpHr5V54jivA==}
 
   it-peekable@3.0.10:
     resolution: {integrity: sha512-2E6+p1pelZOhzp69aaiiBuEybWzAl10uYbIdCR3Pxy8bFNnS/kgpbLtGbNbIZ6RVdU7yHHkmATYwjy52GfFEKA==}
@@ -6733,8 +6745,8 @@ packages:
   it-protobuf-stream@2.0.6:
     resolution: {integrity: sha512-yr1ll0PN4DFrI4gyEMXy4OgcO3Glb7U0J+Scpx1lxOVnuszpcSc0idhxXHMZcDqAIUJgo8JmNHT9Ry6m6vVeJw==}
 
-  it-pushable@3.2.3:
-    resolution: {integrity: sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==}
+  it-pushable@3.2.4:
+    resolution: {integrity: sha512-WSD7Ss4oCRfDZJT4ldLWr0Bom/muY90xxoJ5PQnU3uSKf0kxCOeehqZtiJX1ARqn+ymXGh1bxpDW9bDNHp2ivQ==}
 
   it-queue@1.1.3:
     resolution: {integrity: sha512-RP+zN7tq+4EtuUZw5uXDpOmpgd66oKb15I4rKNvNMuB278nMJVRBHakQjnQAjqcVUySo4hEA3XnT3Ge6EvHH5w==}
@@ -6745,6 +6757,9 @@ packages:
   it-reader@6.0.5:
     resolution: {integrity: sha512-xdSVkCsVyWmKaE7ZIlqb1QbzitY7Zty7//F2YeZ/9Py5i3RzQHVoPqlHELH+1EouumUdPyfuKoANJ7Q5w4IEBg==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  it-reader@7.0.0:
+    resolution: {integrity: sha512-bTWQPHH1if8N1K9XeidDjhTDm51ALbOksMa9uCZVVsQkoIPXP0XVKM88/Ynqr7HS18La/P1Kvu7C73j4rRoKWQ==}
 
   it-sort@3.0.11:
     resolution: {integrity: sha512-eZ22LAoNLx4i4gVV44tJPoUYf/o+mHKa6+OigdVH/hmsdA2qoJN6MNPvKZyZKBf6+S/8PBE44zyvkzdYGkRhbA==}
@@ -6820,8 +6835,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.1.1:
@@ -6929,8 +6944,8 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  libp2p@3.3.1:
-    resolution: {integrity: sha512-4o2b0OyY7m4fu5JrTyBV/rnM86J3riHtrnbl0q36sQM3uJ6Y46nYy8ddxNg36s/AiBFL4aMH+74gObMBpPUhMA==}
+  libp2p@3.3.4:
+    resolution: {integrity: sha512-K/B7XNepJcDB8g+M36Uh6wQDmhPyN5pyEsVwJPBtrXjouC0xBFmU9z5gRh2phRD0oRj9xvIZQwklo2v3zH4AiQ==}
 
   libsodium-wrappers@0.7.15:
     resolution: {integrity: sha512-E4anqJQwcfiC6+Yrl01C1m8p99wEhLmJSs0VQqST66SbQXXBoaJY0pF4BNjRYa/sOQAxx6lXAaAFIlx+15tXJQ==}
@@ -7421,6 +7436,9 @@ packages:
   multiformats@13.4.2:
     resolution: {integrity: sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==}
 
+  multiformats@14.0.4:
+    resolution: {integrity: sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==}
+
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -7624,8 +7642,8 @@ packages:
     resolution: {integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==}
     engines: {node: '>=18'}
 
-  p-queue@9.2.0:
-    resolution: {integrity: sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==}
+  p-queue@9.3.1:
+    resolution: {integrity: sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw==}
     engines: {node: '>=20'}
 
   p-retry@8.0.0:
@@ -7709,8 +7727,8 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
-  peerbit@5.3.0:
-    resolution: {integrity: sha512-xBgxZjJoMvdPL3FykynTLf1ZvM2eK8Uc8UprURygEBih6fvZsqMpAs74uP15qJNMspBjHzcP8qtT6+j+Tpn95w==}
+  peerbit@5.3.2:
+    resolution: {integrity: sha512-aztHqx63dlKPs4ch5AURGxCC5Ehx8jseLkJ19XgFed08jq6pJeT/M8YiYry+fEvq1mM2FXvlJ+5q47KtwOxYGQ==}
     engines: {node: '>=18'}
 
   picocolors@1.1.1:
@@ -7831,6 +7849,9 @@ packages:
 
   protons-runtime@6.0.2:
     resolution: {integrity: sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==}
+
+  protons-runtime@7.0.0:
+    resolution: {integrity: sha512-r/e72006xoVND4Uvf1aIs4OQOkJaASBU3ip4DzOWAktoKAkTiOYqKoS3TYMBm8HnnYU8+h0uEzr5gIRwk/pmTg==}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -8258,8 +8279,8 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -8308,8 +8329,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
   shelljs@0.8.5:
@@ -8802,11 +8823,20 @@ packages:
   uint8-varint@2.0.5:
     resolution: {integrity: sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==}
 
+  uint8-varint@3.0.0:
+    resolution: {integrity: sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==}
+
   uint8arraylist@2.4.9:
     resolution: {integrity: sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==}
 
+  uint8arraylist@3.0.2:
+    resolution: {integrity: sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==}
+
   uint8arrays@5.1.1:
     resolution: {integrity: sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==}
+
+  uint8arrays@6.1.1:
+    resolution: {integrity: sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -8818,8 +8848,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -9231,8 +9261,8 @@ packages:
     resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
     engines: {node: '>=10'}
 
-  yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
 
   yn@3.1.1:
@@ -10186,10 +10216,10 @@ snapshots:
     dependencies:
       '@chainsafe/as-chacha20poly1305': 0.1.0
       '@chainsafe/as-sha256': 1.2.4
-      '@libp2p/crypto': 5.1.18
-      '@libp2p/interface': 3.2.2
-      '@libp2p/peer-id': 6.0.9
-      '@libp2p/utils': 7.2.1
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/utils': 7.2.3
       '@noble/ciphers': 2.2.0
       '@noble/curves': 2.2.0
       '@noble/hashes': 2.2.0
@@ -10200,8 +10230,8 @@ snapshots:
 
   '@chainsafe/libp2p-yamux@8.0.1':
     dependencies:
-      '@libp2p/interface': 3.2.2
-      '@libp2p/utils': 7.2.1
+      '@libp2p/interface': 3.2.4
+      '@libp2p/utils': 7.2.3
       race-signal: 2.0.0
       uint8arraylist: 2.4.9
 
@@ -10223,7 +10253,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.8.1
+      semver: 7.8.5
 
   '@changesets/assemble-release-plan@6.0.9':
     dependencies:
@@ -10232,7 +10262,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.8.1
+      semver: 7.8.5
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -10265,7 +10295,7 @@ snapshots:
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.8.1
+      semver: 7.8.5
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
@@ -10290,7 +10320,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.8.1
+      semver: 7.8.5
 
   '@changesets/get-release-plan@4.0.14':
     dependencies:
@@ -10900,7 +10930,7 @@ snapshots:
 
   '@ipld/dag-cbor@9.2.7':
     dependencies:
-      cborg: 5.1.1
+      cborg: 5.1.7
       multiformats: 13.4.2
 
   '@isaacs/ttlcache@1.4.1': {}
@@ -10910,7 +10940,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -11005,14 +11035,14 @@ snapshots:
 
   '@libp2p/circuit-relay-v2@4.2.5':
     dependencies:
-      '@libp2p/crypto': 5.1.18
-      '@libp2p/interface': 3.2.2
-      '@libp2p/interface-internal': 3.1.5
-      '@libp2p/peer-collections': 7.0.20
-      '@libp2p/peer-id': 6.0.9
-      '@libp2p/peer-record': 9.0.10
-      '@libp2p/utils': 7.2.1
-      '@multiformats/multiaddr': 13.0.1
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
+      '@libp2p/peer-collections': 7.0.22
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/peer-record': 9.0.12
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
       any-signal: 4.2.0
       main-event: 1.0.4
@@ -11024,53 +11054,53 @@ snapshots:
       uint8arraylist: 2.4.9
       uint8arrays: 5.1.1
 
-  '@libp2p/crypto@5.1.18':
+  '@libp2p/crypto@5.1.20':
     dependencies:
-      '@libp2p/interface': 3.2.2
+      '@libp2p/interface': 3.2.4
       '@noble/curves': 2.2.0
       '@noble/hashes': 2.2.0
-      multiformats: 13.4.2
-      protons-runtime: 6.0.2
-      uint8arraylist: 2.4.9
-      uint8arrays: 5.1.1
+      multiformats: 14.0.4
+      protons-runtime: 7.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
 
   '@libp2p/identify@4.1.6':
     dependencies:
-      '@libp2p/crypto': 5.1.18
-      '@libp2p/interface': 3.2.2
-      '@libp2p/interface-internal': 3.1.5
-      '@libp2p/peer-id': 6.0.9
-      '@libp2p/peer-record': 9.0.10
-      '@libp2p/utils': 7.2.1
-      '@multiformats/multiaddr': 13.0.1
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/peer-record': 9.0.12
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
       it-drain: 3.0.12
-      it-parallel: 3.0.15
+      it-parallel: 3.0.16
       main-event: 1.0.4
       protons-runtime: 6.0.2
       uint8arraylist: 2.4.9
       uint8arrays: 5.1.1
 
-  '@libp2p/interface-internal@3.1.5':
+  '@libp2p/interface-internal@3.1.7':
     dependencies:
-      '@libp2p/interface': 3.2.2
-      '@libp2p/peer-collections': 7.0.20
-      '@multiformats/multiaddr': 13.0.1
+      '@libp2p/interface': 3.2.4
+      '@libp2p/peer-collections': 7.0.22
+      '@multiformats/multiaddr': 13.0.3
       progress-events: 1.1.0
 
-  '@libp2p/interface@3.2.2':
+  '@libp2p/interface@3.2.4':
     dependencies:
-      '@multiformats/dns': 1.0.13
-      '@multiformats/multiaddr': 13.0.1
+      '@multiformats/dns': 1.0.15
+      '@multiformats/multiaddr': 13.0.3
       main-event: 1.0.4
-      multiformats: 13.4.2
+      multiformats: 14.0.4
       progress-events: 1.1.0
-      uint8arraylist: 2.4.9
+      uint8arraylist: 3.0.2
 
   '@libp2p/keychain@6.1.0':
     dependencies:
-      '@libp2p/crypto': 5.1.18
-      '@libp2p/interface': 3.2.2
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
       '@noble/hashes': 2.2.0
       asn1js: 3.0.10
       interface-datastore: 9.0.3
@@ -11078,93 +11108,92 @@ snapshots:
       sanitize-filename: 1.6.4
       uint8arrays: 5.1.1
 
-  '@libp2p/logger@6.2.7':
+  '@libp2p/logger@6.2.9':
     dependencies:
-      '@libp2p/interface': 3.2.2
-      '@multiformats/multiaddr': 13.0.1
-      interface-datastore: 9.0.3
-      multiformats: 13.4.2
+      '@libp2p/interface': 3.2.4
+      '@multiformats/multiaddr': 13.0.3
+      interface-datastore: 10.0.1
+      multiformats: 14.0.4
       weald: 1.1.3
 
-  '@libp2p/multistream-select@7.0.20':
+  '@libp2p/multistream-select@7.0.22':
     dependencies:
-      '@libp2p/interface': 3.2.2
-      '@libp2p/utils': 7.2.1
-      it-length-prefixed: 10.0.2
-      uint8arraylist: 2.4.9
-      uint8arrays: 5.1.1
+      '@libp2p/interface': 3.2.4
+      '@libp2p/utils': 7.2.3
+      it-length-prefixed: 11.0.1
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
 
-  '@libp2p/peer-collections@7.0.20':
+  '@libp2p/peer-collections@7.0.22':
     dependencies:
-      '@libp2p/interface': 3.2.2
-      '@libp2p/peer-id': 6.0.9
-      '@libp2p/utils': 7.2.1
-      multiformats: 13.4.2
+      '@libp2p/interface': 3.2.4
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/utils': 7.2.3
+      multiformats: 14.0.4
 
-  '@libp2p/peer-id@6.0.9':
+  '@libp2p/peer-id@6.0.11':
     dependencies:
-      '@libp2p/crypto': 5.1.18
-      '@libp2p/interface': 3.2.2
-      multiformats: 13.4.2
-      uint8arrays: 5.1.1
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      multiformats: 14.0.4
+      uint8arrays: 6.1.1
 
-  '@libp2p/peer-record@9.0.10':
+  '@libp2p/peer-record@9.0.12':
     dependencies:
-      '@libp2p/crypto': 5.1.18
-      '@libp2p/interface': 3.2.2
-      '@libp2p/peer-id': 6.0.9
-      '@multiformats/multiaddr': 13.0.1
-      multiformats: 13.4.2
-      protons-runtime: 6.0.2
-      uint8-varint: 2.0.5
-      uint8arraylist: 2.4.9
-      uint8arrays: 5.1.1
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/peer-id': 6.0.11
+      '@multiformats/multiaddr': 13.0.3
+      multiformats: 14.0.4
+      protons-runtime: 7.0.0
+      uint8-varint: 3.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
 
-  '@libp2p/peer-store@12.0.20':
+  '@libp2p/peer-store@12.0.22':
     dependencies:
-      '@libp2p/crypto': 5.1.18
-      '@libp2p/interface': 3.2.2
-      '@libp2p/peer-collections': 7.0.20
-      '@libp2p/peer-id': 6.0.9
-      '@libp2p/peer-record': 9.0.10
-      '@multiformats/multiaddr': 13.0.1
-      interface-datastore: 9.0.3
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/peer-collections': 7.0.22
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/peer-record': 9.0.12
+      '@multiformats/multiaddr': 13.0.3
+      interface-datastore: 10.0.1
       it-all: 3.0.11
       main-event: 1.0.4
       mortice: 3.3.1
-      multiformats: 13.4.2
-      protons-runtime: 6.0.2
-      uint8arraylist: 2.4.9
-      uint8arrays: 5.1.1
+      multiformats: 14.0.4
+      protons-runtime: 7.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
 
   '@libp2p/tcp@11.0.20':
     dependencies:
-      '@libp2p/interface': 3.2.2
-      '@libp2p/utils': 7.2.1
-      '@multiformats/multiaddr': 13.0.1
+      '@libp2p/interface': 3.2.4
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
       main-event: 1.0.4
       p-event: 7.1.0
       progress-events: 1.1.0
       uint8arraylist: 2.4.9
 
-  '@libp2p/utils@7.2.1':
+  '@libp2p/utils@7.2.3':
     dependencies:
       '@chainsafe/is-ip': 2.1.0
       '@chainsafe/netmask': 2.0.0
-      '@libp2p/crypto': 5.1.18
-      '@libp2p/interface': 3.2.2
-      '@libp2p/logger': 6.2.7
-      '@multiformats/multiaddr': 13.0.1
+      '@libp2p/interface': 3.2.4
+      '@libp2p/logger': 6.2.9
+      '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
       '@sindresorhus/fnv1a': 3.1.0
       any-signal: 4.2.0
-      cborg: 5.1.1
+      cborg: 5.1.7
       delay: 7.0.0
       is-loopback-addr: 2.0.2
-      it-length-prefixed: 10.0.2
+      it-length-prefixed: 11.0.1
       it-pipe: 3.0.1
-      it-pushable: 3.2.3
+      it-pushable: 3.2.4
       it-stream-types: 2.0.4
       main-event: 1.0.4
       netmask: 2.1.1
@@ -11172,21 +11201,21 @@ snapshots:
       p-event: 7.1.0
       progress-events: 1.1.0
       race-signal: 2.0.0
-      uint8-varint: 2.0.5
-      uint8arraylist: 2.4.9
-      uint8arrays: 5.1.1
+      uint8-varint: 3.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
 
   '@libp2p/webrtc@6.0.21(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))':
     dependencies:
       '@chainsafe/is-ip': 2.1.0
       '@chainsafe/libp2p-noise': 17.0.0
-      '@libp2p/crypto': 5.1.18
-      '@libp2p/interface': 3.2.2
-      '@libp2p/interface-internal': 3.1.5
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
       '@libp2p/keychain': 6.1.0
-      '@libp2p/peer-id': 6.0.9
-      '@libp2p/utils': 7.2.1
-      '@multiformats/multiaddr': 13.0.1
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
       '@peculiar/webcrypto': 1.7.1
       '@peculiar/x509': 2.0.0
@@ -11194,7 +11223,7 @@ snapshots:
       interface-datastore: 9.0.3
       it-length-prefixed: 10.0.2
       it-protobuf-stream: 2.0.6
-      it-pushable: 3.2.3
+      it-pushable: 3.2.4
       it-stream-types: 2.0.4
       main-event: 1.0.4
       multiformats: 13.4.2
@@ -11217,9 +11246,9 @@ snapshots:
 
   '@libp2p/websockets@10.1.13':
     dependencies:
-      '@libp2p/interface': 3.2.2
-      '@libp2p/utils': 7.2.1
-      '@multiformats/multiaddr': 13.0.1
+      '@libp2p/interface': 3.2.4
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
       '@multiformats/multiaddr-to-uri': 12.0.0
       main-event: 1.0.4
@@ -11332,29 +11361,29 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.10
 
-  '@multiformats/dns@1.0.13':
+  '@multiformats/dns@1.0.15':
     dependencies:
       '@dnsquery/dns-packet': 6.1.1
-      '@libp2p/interface': 3.2.2
+      '@libp2p/interface': 3.2.4
       hashlru: 2.3.0
-      p-queue: 9.2.0
+      p-queue: 9.3.1
       progress-events: 1.1.0
-      uint8arrays: 5.1.1
+      uint8arrays: 6.1.1
 
   '@multiformats/multiaddr-matcher@3.0.2':
     dependencies:
-      '@multiformats/multiaddr': 13.0.1
+      '@multiformats/multiaddr': 13.0.3
 
   '@multiformats/multiaddr-to-uri@12.0.0':
     dependencies:
-      '@multiformats/multiaddr': 13.0.1
+      '@multiformats/multiaddr': 13.0.3
 
-  '@multiformats/multiaddr@13.0.1':
+  '@multiformats/multiaddr@13.0.3':
     dependencies:
       '@chainsafe/is-ip': 2.1.0
-      multiformats: 13.4.2
-      uint8-varint: 2.0.5
-      uint8arrays: 5.1.1
+      multiformats: 14.0.4
+      uint8-varint: 3.0.0
+      uint8arrays: 6.1.1
 
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     dependencies:
@@ -11500,7 +11529,7 @@ snapshots:
       elliptic: 6.6.1
       uuid: 10.0.0
 
-  '@peerbit/any-store-rust@0.1.0':
+  '@peerbit/any-store-rust@0.1.1':
     dependencies:
       '@peerbit/any-store-interface': 1.1.0
     optional: true
@@ -11530,7 +11559,7 @@ snapshots:
     dependencies:
       '@dao-xyz/borsh': 6.0.1
       '@ipld/dag-cbor': 9.2.7
-      '@libp2p/interface': 3.2.2
+      '@libp2p/interface': 3.2.4
       '@libp2p/tcp': 11.0.20
       '@libp2p/websockets': 10.1.13
       '@peerbit/any-store': 2.2.10
@@ -11559,9 +11588,9 @@ snapshots:
   '@peerbit/canonical-client@1.1.35':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
-      '@libp2p/interface': 3.2.2
-      '@libp2p/peer-id': 6.0.9
-      '@multiformats/multiaddr': 13.0.1
+      '@libp2p/interface': 3.2.4
+      '@libp2p/peer-id': 6.0.11
+      '@multiformats/multiaddr': 13.0.3
       '@peerbit/canonical-transport': 1.0.0
       '@peerbit/crypto': 3.1.2
       '@peerbit/program': 6.0.32
@@ -11569,13 +11598,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@peerbit/canonical-host@1.0.41(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))':
+  '@peerbit/canonical-host@1.0.43(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
-      '@libp2p/peer-id': 6.0.9
+      '@libp2p/peer-id': 6.0.11
       '@peerbit/canonical-transport': 1.0.0
       '@peerbit/crypto': 3.1.2
-      peerbit: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+      peerbit: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
     transitivePeerDependencies:
       - bufferutil
       - react-native
@@ -11592,9 +11621,9 @@ snapshots:
       '@ethersproject/bytes': 5.8.0
       '@ethersproject/strings': 5.8.0
       '@ethersproject/wallet': 5.8.0
-      '@libp2p/crypto': 5.1.18
-      '@libp2p/interface': 3.2.2
-      '@libp2p/peer-id': 6.0.9
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/peer-id': 6.0.11
       '@peerbit/cache': 3.1.0
       '@protobufjs/utf8': 1.1.1
       '@stablelib/sha256': 2.0.1
@@ -11604,27 +11633,27 @@ snapshots:
 
   '@peerbit/diagnostics@0.0.1': {}
 
-  '@peerbit/document-interface@3.2.43':
+  '@peerbit/document-interface@3.2.45':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
       '@peerbit/crypto': 3.1.2
       '@peerbit/indexer-interface': 3.0.5
-      '@peerbit/log': 6.2.0
+      '@peerbit/log': 6.2.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@peerbit/document-proxy@2.0.45(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))':
+  '@peerbit/document-proxy@2.0.47(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
       '@dao-xyz/borsh-rpc': 2.0.5
       '@peerbit/canonical-client': 1.1.35
-      '@peerbit/canonical-host': 1.0.41(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
-      '@peerbit/document': 13.1.0
-      '@peerbit/document-interface': 3.2.43
+      '@peerbit/canonical-host': 1.0.43(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+      '@peerbit/document': 13.1.2
+      '@peerbit/document-interface': 3.2.45
       '@peerbit/indexer-interface': 3.0.5
       '@peerbit/program': 6.0.32
-      '@peerbit/shared-log-proxy': 2.0.44(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+      '@peerbit/shared-log-proxy': 2.0.46(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/stream-interface': 6.0.11
     transitivePeerDependencies:
       - bufferutil
@@ -11632,12 +11661,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@peerbit/document-react@1.0.45(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)':
+  '@peerbit/document-react@1.0.47(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@peerbit/document': 13.1.0
+      '@peerbit/document': 13.1.2
       '@peerbit/indexer-interface': 3.0.5
       '@peerbit/logger': 2.0.1
-      '@peerbit/react': 1.1.24(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
+      '@peerbit/react': 1.1.26(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       uuid: 10.0.0
     transitivePeerDependencies:
@@ -11646,34 +11675,34 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@peerbit/document-rust@0.1.0':
+  '@peerbit/document-rust@0.1.1':
     optional: true
 
-  '@peerbit/document@13.1.0':
+  '@peerbit/document@13.1.2':
     dependencies:
       '@chainsafe/libp2p-yamux': 8.0.1
       '@dao-xyz/borsh': 6.0.1
-      '@libp2p/interface': 3.2.2
+      '@libp2p/interface': 3.2.4
       '@libp2p/tcp': 11.0.20
-      '@multiformats/multiaddr': 13.0.1
+      '@multiformats/multiaddr': 13.0.3
       '@peerbit/cache': 3.1.0
       '@peerbit/crypto': 3.1.2
-      '@peerbit/document-interface': 3.2.43
+      '@peerbit/document-interface': 3.2.45
       '@peerbit/indexer-cache': 0.2.8
       '@peerbit/indexer-interface': 3.0.5
       '@peerbit/indexer-simple': 1.2.8
       '@peerbit/indexer-sqlite3': 3.0.8
-      '@peerbit/log': 6.2.0
+      '@peerbit/log': 6.2.2
       '@peerbit/logger': 2.0.1
       '@peerbit/program': 6.0.32
       '@peerbit/pubsub': 5.3.0
       '@peerbit/rpc': 6.1.0
-      '@peerbit/shared-log': 13.2.0
+      '@peerbit/shared-log': 13.2.2
       '@peerbit/stream-interface': 6.0.11
       p-defer: 4.0.1
       uint8arrays: 5.1.1
     optionalDependencies:
-      '@peerbit/document-rust': 0.1.0
+      '@peerbit/document-rust': 0.1.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11692,7 +11721,7 @@ snapshots:
       uint8-varint: 2.0.5
       uuid: 10.0.0
 
-  '@peerbit/indexer-rust@1.0.1':
+  '@peerbit/indexer-rust@1.0.2':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
       '@peerbit/indexer-interface': 3.0.5
@@ -11723,7 +11752,7 @@ snapshots:
   '@peerbit/keychain@1.2.10':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
-      '@libp2p/interface': 3.2.2
+      '@libp2p/interface': 3.2.4
       '@libp2p/keychain': 6.1.0
       '@peerbit/any-store': 2.2.10
       '@peerbit/crypto': 3.1.2
@@ -11734,14 +11763,14 @@ snapshots:
       '@chainsafe/libp2p-yamux': 8.0.1
       '@libp2p/circuit-relay-v2': 4.2.5
       '@libp2p/identify': 4.1.6
-      '@libp2p/interface': 3.2.2
+      '@libp2p/interface': 3.2.4
       '@libp2p/tcp': 11.0.20
       '@libp2p/webrtc': 6.0.21(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       '@libp2p/websockets': 10.1.13
-      '@multiformats/multiaddr': 13.0.1
+      '@multiformats/multiaddr': 13.0.3
       '@peerbit/crypto': 3.1.2
-      it-pushable: 3.2.3
-      libp2p: 3.3.1
+      it-pushable: 3.2.4
+      libp2p: 3.3.4
       libsodium-wrappers: 0.7.16
     transitivePeerDependencies:
       - bufferutil
@@ -11749,10 +11778,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@peerbit/log-rust@1.1.0':
+  '@peerbit/log-rust@1.1.2':
     optional: true
 
-  '@peerbit/log@6.2.0':
+  '@peerbit/log@6.2.2':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
       '@peerbit/any-store': 2.2.10
@@ -11768,7 +11797,7 @@ snapshots:
       '@peerbit/pubsub-interface': 5.1.5
       '@peerbit/stream-interface': 6.0.11
       '@peerbit/time': 3.0.0
-      libp2p: 3.3.1
+      libp2p: 3.3.4
       libsodium-wrappers: 0.7.15
       p-queue: 8.1.1
       path-browserify: 1.0.1
@@ -11777,21 +11806,21 @@ snapshots:
       uint8arrays: 5.1.1
       uuid: 10.0.0
     optionalDependencies:
-      '@peerbit/log-rust': 1.1.0
+      '@peerbit/log-rust': 1.1.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
   '@peerbit/logger@2.0.1':
     dependencies:
-      '@libp2p/logger': 6.2.7
+      '@libp2p/logger': 6.2.9
 
-  '@peerbit/native-backbone@0.1.0':
+  '@peerbit/native-backbone@0.1.2':
     dependencies:
       '@peerbit/blocks-interface': 2.1.0
     optional: true
 
-  '@peerbit/network-rust@0.1.0':
+  '@peerbit/network-rust@0.1.1':
     dependencies:
       '@peerbit/time': 3.0.0
       p-defer: 4.0.1
@@ -11809,8 +11838,8 @@ snapshots:
   '@peerbit/program@6.0.32':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
-      '@libp2p/interface': 3.2.2
-      '@multiformats/multiaddr': 13.0.1
+      '@libp2p/interface': 3.2.4
+      '@multiformats/multiaddr': 13.0.3
       '@peerbit/any-store-interface': 1.1.0
       '@peerbit/blocks': 4.2.0
       '@peerbit/blocks-interface': 2.1.0
@@ -11831,7 +11860,7 @@ snapshots:
   '@peerbit/pubsub-interface@5.1.5':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
-      '@libp2p/interface': 3.2.2
+      '@libp2p/interface': 3.2.4
       '@peerbit/crypto': 3.1.2
       '@peerbit/stream-interface': 6.0.11
       uint8arraylist: 2.4.9
@@ -11840,12 +11869,12 @@ snapshots:
     dependencies:
       '@dao-xyz/borsh': 6.0.1
       '@libp2p/circuit-relay-v2': 4.2.5
-      '@libp2p/crypto': 5.1.18
+      '@libp2p/crypto': 5.1.20
       '@libp2p/identify': 4.1.6
-      '@libp2p/interface': 3.2.2
+      '@libp2p/interface': 3.2.4
       '@libp2p/tcp': 11.0.20
       '@libp2p/websockets': 10.1.13
-      '@multiformats/multiaddr': 13.0.1
+      '@multiformats/multiaddr': 13.0.3
       '@peerbit/any-store-interface': 1.1.0
       '@peerbit/crypto': 3.1.2
       '@peerbit/logger': 2.0.1
@@ -11856,7 +11885,7 @@ snapshots:
       any-signal: 4.2.0
       it-length-prefixed: 10.0.2
       it-pipe: 3.0.1
-      it-pushable: 3.2.3
+      it-pushable: 3.2.4
       p-defer: 4.0.1
       uint8arraylist: 2.4.9
       uint8arrays: 5.1.1
@@ -11864,17 +11893,17 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@peerbit/react@1.1.24(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)':
+  '@peerbit/react@1.1.26(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@chainsafe/libp2p-noise': 17.0.0
       '@chainsafe/libp2p-yamux': 8.0.1
       '@dao-xyz/borsh': 6.0.1
       '@libp2p/circuit-relay-v2': 4.2.5
-      '@libp2p/crypto': 5.1.18
-      '@libp2p/interface': 3.2.2
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
       '@libp2p/webrtc': 6.0.21(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       '@libp2p/websockets': 10.1.13
-      '@multiformats/multiaddr': 13.0.1
+      '@multiformats/multiaddr': 13.0.3
       '@peerbit/canonical-client': 1.1.35
       '@peerbit/crypto': 3.1.2
       '@peerbit/indexer-interface': 3.0.5
@@ -11884,7 +11913,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       detectincognitojs: 1.6.2
       libsodium-wrappers: 0.7.15
-      peerbit: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+      peerbit: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       react: 19.2.4
       uuid: 10.0.0
     transitivePeerDependencies:
@@ -11910,30 +11939,30 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@peerbit/shared-log-proxy@2.0.44(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))':
+  '@peerbit/shared-log-proxy@2.0.46(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
       '@dao-xyz/borsh-rpc': 2.0.5
       '@peerbit/canonical-client': 1.1.35
-      '@peerbit/canonical-host': 1.0.41(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+      '@peerbit/canonical-host': 1.0.43(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       '@peerbit/crypto': 3.1.2
       '@peerbit/indexer-interface': 3.0.5
-      '@peerbit/log': 6.2.0
+      '@peerbit/log': 6.2.2
       '@peerbit/program': 6.0.32
-      '@peerbit/shared-log': 13.2.0
+      '@peerbit/shared-log': 13.2.2
     transitivePeerDependencies:
       - bufferutil
       - react-native
       - supports-color
       - utf-8-validate
 
-  '@peerbit/shared-log-rust@0.1.0':
+  '@peerbit/shared-log-rust@0.1.1':
     optional: true
 
-  '@peerbit/shared-log@13.2.0':
+  '@peerbit/shared-log@13.2.2':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
-      '@libp2p/crypto': 5.1.18
+      '@libp2p/crypto': 5.1.20
       '@peerbit/any-store': 2.2.10
       '@peerbit/blocks': 4.2.0
       '@peerbit/blocks-interface': 2.1.0
@@ -11942,7 +11971,7 @@ snapshots:
       '@peerbit/diagnostics': 0.0.1
       '@peerbit/indexer-interface': 3.0.5
       '@peerbit/indexer-sqlite3': 3.0.8
-      '@peerbit/log': 6.2.0
+      '@peerbit/log': 6.2.2
       '@peerbit/logger': 2.0.1
       '@peerbit/program': 6.0.32
       '@peerbit/pubsub': 5.3.0
@@ -11959,8 +11988,8 @@ snapshots:
       pino: 9.14.0
       uint8arrays: 5.1.1
     optionalDependencies:
-      '@peerbit/native-backbone': 0.1.0
-      '@peerbit/shared-log-rust': 0.1.0
+      '@peerbit/native-backbone': 0.1.2
+      '@peerbit/shared-log-rust': 0.1.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11968,7 +11997,7 @@ snapshots:
   '@peerbit/stream-interface@6.0.11':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
-      '@libp2p/interface': 3.2.2
+      '@libp2p/interface': 3.2.4
       '@peerbit/crypto': 3.1.2
       uint8arraylist: 2.4.9
 
@@ -11977,11 +12006,11 @@ snapshots:
       '@chainsafe/libp2p-noise': 17.0.0
       '@chainsafe/libp2p-yamux': 8.0.1
       '@dao-xyz/borsh': 6.0.1
-      '@libp2p/interface': 3.2.2
-      '@libp2p/interface-internal': 3.1.5
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
       '@libp2p/tcp': 11.0.20
       '@libp2p/websockets': 10.1.13
-      '@multiformats/multiaddr': 13.0.1
+      '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
       '@peerbit/cache': 3.1.0
       '@peerbit/crypto': 3.1.2
@@ -11994,8 +12023,8 @@ snapshots:
       it-all: 3.0.11
       it-length-prefixed: 10.0.2
       it-pipe: 3.0.1
-      it-pushable: 3.2.3
-      libp2p: 3.3.1
+      it-pushable: 3.2.4
+      libp2p: 3.3.4
       p-defer: 4.0.1
       p-queue: 8.1.1
       uint8arraylist: 2.4.9
@@ -12005,26 +12034,26 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@peerbit/string@5.1.67':
+  '@peerbit/string@5.1.69':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
       '@peerbit/crypto': 3.1.2
-      '@peerbit/log': 6.2.0
+      '@peerbit/log': 6.2.2
       '@peerbit/logger': 2.0.1
       '@peerbit/program': 6.0.32
       '@peerbit/rpc': 6.1.0
-      '@peerbit/shared-log': 13.2.0
+      '@peerbit/shared-log': 13.2.2
       '@peerbit/time': 3.0.0
       uint8arrays: 5.1.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@peerbit/test-utils@3.1.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))':
+  '@peerbit/test-utils@3.1.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))':
     dependencies:
       '@chainsafe/libp2p-yamux': 8.0.1
-      '@libp2p/interface': 3.2.2
-      '@multiformats/multiaddr': 13.0.1
+      '@libp2p/interface': 3.2.4
+      '@multiformats/multiaddr': 13.0.3
       '@peerbit/any-store': 2.2.10
       '@peerbit/blocks': 4.2.0
       '@peerbit/crypto': 3.1.2
@@ -12034,10 +12063,10 @@ snapshots:
       '@peerbit/program': 6.0.32
       '@peerbit/pubsub': 5.3.0
       '@peerbit/stream': 5.1.0
-      it-pushable: 3.2.3
-      libp2p: 3.3.1
+      it-pushable: 3.2.4
+      libp2p: 3.3.4
       libsodium-wrappers: 0.7.16
-      peerbit: 5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+      peerbit: 5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       tty-table: 4.2.3
     transitivePeerDependencies:
       - bufferutil
@@ -12047,25 +12076,25 @@ snapshots:
 
   '@peerbit/time@3.0.0': {}
 
-  '@peerbit/trusted-network@6.0.45':
+  '@peerbit/trusted-network@6.0.47':
     dependencies:
       '@dao-xyz/borsh': 6.0.1
-      '@libp2p/interface': 3.2.2
+      '@libp2p/interface': 3.2.4
       '@peerbit/crypto': 3.1.2
-      '@peerbit/document': 13.1.0
-      '@peerbit/log': 6.2.0
+      '@peerbit/document': 13.1.2
+      '@peerbit/log': 6.2.2
       '@peerbit/program': 6.0.32
-      '@peerbit/shared-log': 13.2.0
+      '@peerbit/shared-log': 13.2.2
       uint8arrays: 5.1.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@peerbit/vite@2.0.7(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)':
+  '@peerbit/vite@2.0.7(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)':
     dependencies:
       '@peerbit/build-assets': 1.1.0
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vite-plugin-static-copy: 3.3.0(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vite: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite-plugin-static-copy: 3.3.0(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -12856,7 +12885,7 @@ snapshots:
       hermes-parser: 0.32.0
       invariant: 2.2.4
       nullthrows: 1.1.1
-      yargs: 17.7.2
+      yargs: 17.7.3
 
   '@react-native/community-cli-plugin@0.83.1':
     dependencies:
@@ -12866,7 +12895,7 @@ snapshots:
       metro: 0.83.7
       metro-config: 0.83.7
       metro-core: 0.83.7
-      semver: 7.8.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -13077,21 +13106,21 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@sveltejs/acorn-typescript@1.0.8(acorn@8.16.0)':
+  '@sveltejs/acorn-typescript@1.0.8(acorn@8.17.0)':
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
-  '@sveltejs/adapter-auto@6.1.1(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.48.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@sveltejs/adapter-auto@6.1.1(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.48.4)(typescript@5.9.3)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
-      '@sveltejs/kit': 2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.48.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/kit': 2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.48.4)(typescript@5.9.3)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
-  '@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.48.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.48.4)(typescript@5.9.3)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.17.0)
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/cookie': 0.6.0
-      acorn: 8.16.0
+      acorn: 8.17.0
       cookie: 0.6.0
       devalue: 5.6.2
       esm-env: 1.2.2
@@ -13102,26 +13131,26 @@ snapshots:
       set-cookie-parser: 2.7.2
       sirv: 3.0.2
       svelte: 5.48.4
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.48.4)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.48.4)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       obug: 2.1.1
       svelte: 5.48.4
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.48.4)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.4)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.48.4)(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.48.4
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vitefu: 1.1.1(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vite: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.1(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@swc/helpers@0.5.18':
     dependencies:
@@ -13196,12 +13225,12 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@tanstack/react-virtual@3.13.18(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -13467,9 +13496,9 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@25.9.1':
+  '@types/node@26.1.0':
     dependencies:
-      undici-types: 7.24.6
+      undici-types: 8.3.0
     optional: true
 
   '@types/offscreencanvas@2019.3.0': {}
@@ -13574,7 +13603,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
-      semver: 7.8.1
+      semver: 7.8.5
       tsutils: 3.21.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -13594,7 +13623,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      semver: 7.8.1
+      semver: 7.8.5
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -13679,7 +13708,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.8.1
+      semver: 7.8.5
       tsutils: 3.21.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -13694,7 +13723,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.8.1
+      semver: 7.8.5
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -13711,7 +13740,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
       eslint: 8.57.1
       eslint-scope: 5.1.1
-      semver: 7.8.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -13725,7 +13754,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
       eslint: 8.57.1
-      semver: 7.8.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -13742,11 +13771,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-basic-ssl@2.1.4(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-basic-ssl@2.1.4(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
@@ -13754,7 +13783,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.53
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13775,13 +13804,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -13877,17 +13906,17 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-jsx@5.3.2(acorn@8.16.0):
+  acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   acorn@8.1.0: {}
 
-  acorn@8.16.0: {}
+  acorn@8.17.0: {}
 
   aes-js@3.0.0: {}
 
@@ -14310,7 +14339,7 @@ snapshots:
 
   caniuse-lite@1.0.30001766: {}
 
-  cborg@5.1.1: {}
+  cborg@5.1.7: {}
 
   ccount@2.0.1: {}
 
@@ -14596,9 +14625,23 @@ snapshots:
 
   datastore-core@11.0.4:
     dependencies:
-      '@libp2p/logger': 6.2.7
+      '@libp2p/logger': 6.2.9
       interface-datastore: 9.0.3
       interface-store: 7.0.2
+      it-drain: 3.0.12
+      it-filter: 3.1.6
+      it-map: 3.1.6
+      it-merge: 3.0.14
+      it-pipe: 3.0.1
+      it-sort: 3.0.11
+      it-take: 3.0.11
+
+  datastore-core@12.0.1:
+    dependencies:
+      '@libp2p/logger': 6.2.9
+      abort-error: 1.0.2
+      interface-datastore: 10.0.1
+      interface-store: 8.0.0
       it-drain: 3.0.12
       it-filter: 3.1.6
       it-map: 3.1.6
@@ -15145,8 +15188,8 @@ snapshots:
 
   espree@9.6.1:
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 3.4.3
 
   esprima@4.0.1: {}
@@ -15671,12 +15714,22 @@ snapshots:
     dependencies:
       css-in-js-utils: 3.1.0
 
+  interface-datastore@10.0.1:
+    dependencies:
+      abort-error: 1.0.2
+      interface-store: 8.0.0
+      uint8arrays: 6.1.1
+
   interface-datastore@9.0.3:
     dependencies:
       interface-store: 7.0.2
       uint8arrays: 5.1.1
 
   interface-store@7.0.2: {}
+
+  interface-store@8.0.0:
+    dependencies:
+      abort-error: 1.0.2
 
   internal-slot@1.1.0:
     dependencies:
@@ -15902,6 +15955,14 @@ snapshots:
       uint8arraylist: 2.4.9
       uint8arrays: 5.1.1
 
+  it-length-prefixed@11.0.1:
+    dependencies:
+      it-reader: 7.0.0
+      it-stream-types: 2.0.4
+      uint8-varint: 3.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
+
   it-map@3.1.6:
     dependencies:
       it-peekable: 3.0.10
@@ -15910,7 +15971,7 @@ snapshots:
     dependencies:
       it-queueless-pushable: 2.0.5
 
-  it-parallel@3.0.15:
+  it-parallel@3.0.16:
     dependencies:
       p-defer: 4.0.1
 
@@ -15919,7 +15980,7 @@ snapshots:
   it-pipe@3.0.1:
     dependencies:
       it-merge: 3.0.14
-      it-pushable: 3.2.3
+      it-pushable: 3.2.4
       it-stream-types: 2.0.4
 
   it-protobuf-stream@2.0.6:
@@ -15929,14 +15990,14 @@ snapshots:
       it-stream-types: 2.0.4
       uint8arraylist: 2.4.9
 
-  it-pushable@3.2.3:
+  it-pushable@3.2.4:
     dependencies:
       p-defer: 4.0.1
 
   it-queue@1.1.3:
     dependencies:
       abort-error: 1.0.2
-      it-pushable: 3.2.3
+      it-pushable: 3.2.4
       main-event: 1.0.4
       race-event: 1.6.1
       race-signal: 2.0.0
@@ -15951,6 +16012,11 @@ snapshots:
     dependencies:
       it-stream-types: 2.0.4
       uint8arraylist: 2.4.9
+
+  it-reader@7.0.0:
+    dependencies:
+      it-stream-types: 2.0.4
+      uint8arraylist: 3.0.2
 
   it-sort@3.0.11:
     dependencies:
@@ -16060,7 +16126,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -16182,35 +16248,35 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libp2p@3.3.1:
+  libp2p@3.3.4:
     dependencies:
       '@chainsafe/is-ip': 2.1.0
       '@chainsafe/netmask': 2.0.0
-      '@libp2p/crypto': 5.1.18
-      '@libp2p/interface': 3.2.2
-      '@libp2p/interface-internal': 3.1.5
-      '@libp2p/logger': 6.2.7
-      '@libp2p/multistream-select': 7.0.20
-      '@libp2p/peer-collections': 7.0.20
-      '@libp2p/peer-id': 6.0.9
-      '@libp2p/peer-store': 12.0.20
-      '@libp2p/utils': 7.2.1
-      '@multiformats/dns': 1.0.13
-      '@multiformats/multiaddr': 13.0.1
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
+      '@libp2p/logger': 6.2.9
+      '@libp2p/multistream-select': 7.0.22
+      '@libp2p/peer-collections': 7.0.22
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/peer-store': 12.0.22
+      '@libp2p/utils': 7.2.3
+      '@multiformats/dns': 1.0.15
+      '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
       any-signal: 4.2.0
-      datastore-core: 11.0.4
-      interface-datastore: 9.0.3
+      datastore-core: 12.0.1
+      interface-datastore: 10.0.1
       it-merge: 3.0.14
-      it-parallel: 3.0.15
+      it-parallel: 3.0.16
       main-event: 1.0.4
-      multiformats: 13.4.2
+      multiformats: 14.0.4
       p-defer: 4.0.1
       p-event: 7.1.0
       p-retry: 8.0.0
       progress-events: 1.1.0
       race-signal: 2.0.0
-      uint8arrays: 5.1.1
+      uint8arrays: 6.1.1
 
   libsodium-wrappers@0.7.15:
     dependencies:
@@ -16691,7 +16757,7 @@ snapshots:
       source-map: 0.5.7
       throat: 5.0.0
       ws: 7.5.11
-      yargs: 17.7.2
+      yargs: 17.7.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -16959,6 +17025,8 @@ snapshots:
 
   multiformats@13.4.2: {}
 
+  multiformats@14.0.4: {}
+
   mute-stream@1.0.0: {}
 
   nano-css@5.6.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -16994,7 +17062,7 @@ snapshots:
 
   node-abi@3.91.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   node-datachannel@0.32.3:
     dependencies:
@@ -17017,7 +17085,7 @@ snapshots:
       ignore-by-default: 1.0.1
       minimatch: 3.1.5
       pstree.remy: 1.1.8
-      semver: 7.8.1
+      semver: 7.8.5
       simple-update-notifier: 2.0.0
       supports-color: 5.5.0
       touch: 3.1.1
@@ -17154,7 +17222,7 @@ snapshots:
       eventemitter3: 5.0.4
       p-timeout: 6.1.4
 
-  p-queue@9.2.0:
+  p-queue@9.3.1:
     dependencies:
       eventemitter3: 5.0.4
       p-timeout: 7.0.1
@@ -17218,7 +17286,7 @@ snapshots:
       klaw-sync: 6.0.0
       minimist: 1.2.8
       open: 7.4.2
-      semver: 7.8.1
+      semver: 7.8.5
       slash: 2.0.0
       tmp: 0.2.5
       yaml: 2.9.0
@@ -17241,21 +17309,21 @@ snapshots:
 
   pathval@2.0.1: {}
 
-  peerbit@5.3.0(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4)):
+  peerbit@5.3.2(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4)):
     dependencies:
       '@chainsafe/libp2p-noise': 17.0.0
       '@chainsafe/libp2p-yamux': 8.0.1
       '@dao-xyz/borsh': 6.0.1
       '@dao-xyz/datastore-level': 11.2.0
       '@libp2p/circuit-relay-v2': 4.2.5
-      '@libp2p/crypto': 5.1.18
+      '@libp2p/crypto': 5.1.20
       '@libp2p/identify': 4.1.6
-      '@libp2p/interface': 3.2.2
+      '@libp2p/interface': 3.2.4
       '@libp2p/keychain': 6.1.0
       '@libp2p/tcp': 11.0.20
       '@libp2p/webrtc': 6.0.21(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
       '@libp2p/websockets': 10.1.13
-      '@multiformats/multiaddr': 13.0.1
+      '@multiformats/multiaddr': 13.0.3
       '@peerbit/any-store': 2.2.10
       '@peerbit/any-store-opfs': 1.1.8
       '@peerbit/blocks': 4.2.0
@@ -17273,18 +17341,18 @@ snapshots:
       '@peerbit/time': 3.0.0
       '@sqlite.org/sqlite-wasm': 3.51.1-build2
       level: 10.0.0
-      libp2p: 3.3.1
+      libp2p: 3.3.4
       libsodium-wrappers: 0.7.15
       memory-level: 3.1.0
       p-queue: 8.1.1
       path-browserify: 1.0.1
       uint8arrays: 5.1.1
     optionalDependencies:
-      '@peerbit/any-store-rust': 0.1.0
-      '@peerbit/indexer-rust': 1.0.1
-      '@peerbit/log-rust': 1.1.0
-      '@peerbit/native-backbone': 0.1.0
-      '@peerbit/network-rust': 0.1.0
+      '@peerbit/any-store-rust': 0.1.1
+      '@peerbit/indexer-rust': 1.0.2
+      '@peerbit/log-rust': 1.1.2
+      '@peerbit/native-backbone': 0.1.2
+      '@peerbit/network-rust': 0.1.1
     transitivePeerDependencies:
       - bufferutil
       - react-native
@@ -17434,6 +17502,12 @@ snapshots:
       uint8arraylist: 2.4.9
       uint8arrays: 5.1.1
 
+  protons-runtime@7.0.0:
+    dependencies:
+      uint8-varint: 3.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -17500,10 +17574,10 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-chessboard@4.7.3(@types/node@25.9.1)(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-chessboard@4.7.3(@types/node@26.1.0)(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
-      react-dnd: 16.0.1(@types/node@25.9.1)(@types/react@19.2.10)(react@19.2.4)
+      react-dnd: 16.0.1(@types/node@26.1.0)(@types/react@19.2.10)(react@19.2.4)
       react-dnd-html5-backend: 16.0.1
       react-dnd-touch-backend: 16.0.1
       react-dom: 19.2.4(react@19.2.4)
@@ -17525,7 +17599,7 @@ snapshots:
 
   react-devtools-core@6.1.5:
     dependencies:
-      shell-quote: 1.8.4
+      shell-quote: 1.9.0
       ws: 7.5.11
     transitivePeerDependencies:
       - bufferutil
@@ -17540,7 +17614,7 @@ snapshots:
       '@react-dnd/invariant': 4.0.2
       dnd-core: 16.0.1
 
-  react-dnd@16.0.1(@types/node@25.9.1)(@types/react@19.2.10)(react@19.2.4):
+  react-dnd@16.0.1(@types/node@26.1.0)(@types/react@19.2.10)(react@19.2.4):
     dependencies:
       '@react-dnd/invariant': 4.0.2
       '@react-dnd/shallowequal': 4.0.2
@@ -17549,7 +17623,7 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       react: 19.2.4
     optionalDependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.0
       '@types/react': 19.2.10
 
   react-dom@19.2.4(react@19.2.4):
@@ -17645,11 +17719,11 @@ snapshots:
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.11
       scheduler: 0.27.0
-      semver: 7.8.1
+      semver: 7.8.5
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
       ws: 7.5.11
-      yargs: 17.7.2
+      yargs: 17.7.3
     optionalDependencies:
       '@types/react': 19.2.10
     transitivePeerDependencies:
@@ -17754,7 +17828,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -17983,7 +18057,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.8.1: {}
+  semver@7.8.5: {}
 
   send@0.19.2:
     dependencies:
@@ -18050,7 +18124,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.9.0: {}
 
   shelljs@0.8.5:
     dependencies:
@@ -18107,7 +18181,7 @@ snapshots:
 
   simple-update-notifier@2.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   sirv@3.0.2:
     dependencies:
@@ -18325,9 +18399,9 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.16.0)
+      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.17.0)
       '@types/estree': 1.0.8
-      acorn: 8.16.0
+      acorn: 8.17.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
       clsx: 2.1.1
@@ -18367,7 +18441,7 @@ snapshots:
   terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -18466,7 +18540,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 20.19.30
-      acorn: 8.16.0
+      acorn: 8.17.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
@@ -18511,7 +18585,7 @@ snapshots:
       smartwrap: 2.0.2
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
-      yargs: 17.7.2
+      yargs: 17.7.3
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -18586,13 +18660,26 @@ snapshots:
       uint8arraylist: 2.4.9
       uint8arrays: 5.1.1
 
+  uint8-varint@3.0.0:
+    dependencies:
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
+
   uint8arraylist@2.4.9:
     dependencies:
       uint8arrays: 5.1.1
 
+  uint8arraylist@3.0.2:
+    dependencies:
+      uint8arrays: 6.1.1
+
   uint8arrays@5.1.1:
     dependencies:
       multiformats: 13.4.2
+
+  uint8arrays@6.1.1:
+    dependencies:
+      multiformats: 14.0.4
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -18605,7 +18692,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.24.6:
+  undici-types@8.3.0:
     optional: true
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
@@ -18713,13 +18800,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -18734,13 +18821,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-static-copy@3.3.0(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vite-plugin-static-copy@3.3.0(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.4
       picocolors: 1.1.1
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   vite@7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
@@ -18759,7 +18846,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
+  vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -18768,7 +18855,7 @@ snapshots:
       rollup: 4.57.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.0
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
@@ -18776,15 +18863,15 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vitefu@1.1.1(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitefu@1.1.1(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.9.1)(happy-dom@20.3.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@26.1.0)(happy-dom@20.3.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -18802,12 +18889,12 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 25.9.1
+      '@types/node': 26.1.0
       happy-dom: 20.3.9
       jsdom: 27.4.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
@@ -19042,7 +19129,7 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 20.2.9
 
-  yargs@17.7.2:
+  yargs@17.7.3:
     dependencies:
       cliui: 8.0.1
       escalade: 3.2.0


### PR DESCRIPTION
## What

Refreshes `pnpm-lock.yaml` so the workspace resolves on the latest published peerbit packages. The committed lockfile pinned `@peerbit/document@13.1.0` via a stale `@peerbit/trusted-network@6.0.45` resolution; combined with the app's direct `@peerbit/document` dep resolving higher, that produced **two** `Documents` borsh classes and a `BorshError: Deserialization of Documents yielded another Class` crash when a second peer opened a shared program.

No `package.json` changes were needed — the existing caret ranges already allow the latest. The lockfile is refreshed with a targeted `pnpm update -r peerbit "@peerbit/*"` on top of master's lockfile (not a full regeneration), so only the peerbit family and its transitive deps move. A follow-up targeted `pnpm dedupe` on the libp2p ecosystem (`@libp2p/*`, `@multiformats/*`, `libp2p`, `it-*`, `uint8*`, …) collapses the transitive duplicates the update introduced — without it the hoisted install ends up with two `@multiformats/multiaddr` / `@libp2p/interface` copies and the shared-fs CLI TypeScript build fails on cross-copy `Multiaddr` type identity. In particular the `@radix-ui/*` resolutions that the repo's `patch-package` patches target stay exactly where master pinned them, and a clean `pnpm install --frozen-lockfile` — including the postinstall patch step — passes, as do the shared-fs build and both test suites locally.

## Result

- Exactly **one** `@peerbit/document` (13.1.2) in the tree — verified via `pnpm why @peerbit/document -r` (the direct dep, the copy through trusted-network 6.0.47, and the one via document-react all collapse onto 13.1.2).
- Resolves: peerbit 5.3.2, @peerbit/document 13.1.2, @peerbit/shared-log 13.2.2, @peerbit/native-backbone 0.1.2, @peerbit/trusted-network 6.0.47.
- The dual-`Documents` borsh crash is **gone** — a two-peer share+open smoke that previously threw now completes (256 KiB file, sha256 match).
- file-share (library + cli) builds clean.

As a bonus this unblocks the native-backend path on file-share: on these deduped latest packages a native observer's `replicate:false` download works for all file sizes (the earlier hang was on the stale 13.1.0 graph).
