### PR TITLE
fix(file-share): harden large transfers and hot paths

### DIFF
--- a/.changeset/fast-files-flow.md
+++ b/.changeset/fast-files-flow.md
@@ -1,0 +1,8 @@
+---
+"@peerbit/please": patch
+"@peerbit/please-lib": patch
+---
+
+Make large-file uploads transactional and memory-bounded with normalized source chunks, bounded concurrent puts, pending-to-ready manifests, exact-head rollback, and ownership-safe deletion. Stream reads now use cancellation-aware shared deadlines, bounded adaptive prefetch, exact manifest-head lookup, immutable per-transfer persistence policy, constant-space retention, integrity checks, and separate indexed-versus-local-block diagnostics.
+
+Improve the file-share clients with stable provider configuration, explicit direct-peer dial evidence, local-first root listing, stale-safe remote reconciliation, coalesced refreshes, transfer cleanup, and quieter unconstrained adaptive rebalancing. Expand production transfer benchmarks with deterministic 64/256 MiB fixtures, cohort and topology validation, browser and process memory measurements, strict browser/external-file streaming verification, and exact demand-persistence checks.

--- a/.github/workflows/file-share-benchmarks.yml
+++ b/.github/workflows/file-share-benchmarks.yml
@@ -20,15 +20,16 @@ on:
                 description: Number of benchmark runs
                 required: true
                 type: number
-                default: 1
-            reader_role:
-                description: Reader replication role
+                default: 5
+            reader_cohort:
+                description: Reader benchmark cohort
                 required: true
                 type: choice
-                default: adaptive
+                default: live-replicator
                 options:
-                    - adaptive
-                    - observer
+                    - live-replicator
+                    - cold-observer
+                    - cold-persisted-read
             min_upload_mbps:
                 description: Fail if median upload throughput is below this value (0 disables)
                 required: true
@@ -80,7 +81,7 @@ jobs:
               env:
                   PW_BENCH: "1"
                   PW_BENCH_SCENARIO: ${{ inputs.scenario }}
-                  PW_READER_ROLE: ${{ inputs.reader_role }}
+                  PW_READER_COHORT: ${{ inputs.reader_cohort }}
                   PW_FILE_MB: ${{ inputs.file_mb }}
                   PW_BASE_URL: ${{ inputs.scenario == 'prod' && 'https://files.dao.xyz' || '' }}
               working-directory: packages/file-share/frontend
@@ -95,7 +96,7 @@ jobs:
             - name: Summarize results
               env:
                   BENCH_SCENARIO: ${{ inputs.scenario }}
-                  BENCH_READER_ROLE: ${{ inputs.reader_role }}
+                  BENCH_READER_COHORT: ${{ inputs.reader_cohort }}
                   BENCH_FILE_MB: ${{ inputs.file_mb }}
                   BENCH_RUNS: ${{ inputs.runs }}
                   BENCH_MIN_UPLOAD_MBPS: ${{ inputs.min_upload_mbps }}
@@ -126,6 +127,17 @@ jobs:
                     );
                   }
 
+                  const wrongCohort = results.filter(
+                    (result) => result.readerCohort !== process.env.BENCH_READER_COHORT
+                  );
+                  if (wrongCohort.length > 0) {
+                    throw new Error(
+                      `Benchmark results used an unexpected reader cohort: ${wrongCohort
+                        .map((result) => result.readerCohort || "missing")
+                        .join(", ")}`
+                    );
+                  }
+
                   const median = (values) => {
                     const sorted = [...values].sort((a, b) => a - b);
                     const mid = Math.floor(sorted.length / 2);
@@ -145,7 +157,7 @@ jobs:
 
                   const summary = {
                     scenario: process.env.BENCH_SCENARIO,
-                    readerRole: process.env.BENCH_READER_ROLE,
+                    readerCohort: process.env.BENCH_READER_COHORT,
                     fileSizeMb: Number(process.env.BENCH_FILE_MB),
                     runs: Number(process.env.BENCH_RUNS),
                     medianUploadMbps: median(uploadMbps),
@@ -167,7 +179,7 @@ jobs:
                     "# File-share benchmark",
                     "",
                     `- Scenario: \`${summary.scenario}\``,
-                    `- Reader role: \`${summary.readerRole}\``,
+                    `- Reader cohort: \`${summary.readerCohort}\``,
                     `- File size: \`${summary.fileSizeMb} MiB\``,
                     `- Runs: \`${summary.runs}\``,
                     `- Median upload: \`${summary.medianUploadSeconds.toFixed(2)}s\` at \`${summary.medianUploadMbps.toFixed(2)} Mbps\``,

--- a/packages/file-share/cli/src/bin.ts
+++ b/packages/file-share/cli/src/bin.ts
@@ -26,10 +26,7 @@ const coerceAddresses = (addrs: string | string[]) => {
     return (Array.isArray(addrs) ? addrs : [addrs]).map((x) => multiaddr(x));
 };
 
-const connectToNetwork = async (
-    peerbit: Peerbit,
-    peer?: string | string[]
-) => {
+const connectToNetwork = async (peerbit: Peerbit, peer?: string | string[]) => {
     if (peer) {
         await peerbit.dial(coerceAddresses(peer));
         return;
@@ -41,9 +38,11 @@ const FILE_LOOKUP_TIMEOUT_MS = 2 * 60 * 1000;
 const FILE_LOOKUP_ATTEMPT_TIMEOUT_MS = 2 * 1000;
 const FILE_LOOKUP_POLL_INTERVAL_MS = 1 * 1000;
 const DEFAULT_DIRECTORY_NAME = "peerbit-file-share";
+const CLI_REBALANCE_INTERVAL_MS = 5 * 60 * 1000;
 const CLI_REPLICATION_ARGS = {
     replicate: {
         limits: {
+            interval: CLI_REBALANCE_INTERVAL_MS,
             cpu: {
                 max: 1,
                 monitor: undefined,
@@ -101,10 +100,7 @@ const stripDirectoryArgs = (args: string[]) => {
             i++;
             continue;
         }
-        if (
-            arg.startsWith("--directory=") ||
-            arg.startsWith("--dir=")
-        ) {
+        if (arg.startsWith("--directory=") || arg.startsWith("--dir=")) {
             continue;
         }
         nextArgs.push(arg);
@@ -300,11 +296,13 @@ const cli = async (args?: string[]) => {
                     ? await openLegacyFiles()
                     : await openShareFiles(CLI_REPLICATION_ARGS, {
                           share: shareAddress,
-                          shareName:
-                              args.spaceName || path.basename(args.path),
+                          shareName: args.spaceName || path.basename(args.path),
                       });
                 const source = await createPathSource(args.path);
-                const id = await files.addSource(path.basename(args.path), source);
+                const id = await files.addSource(
+                    path.basename(args.path),
+                    source
+                );
                 const fetchCommand = args.legacyGlobal
                     ? `please get ${id} --legacy-global`
                     : `please get ${id} --space ${files.address}`;
@@ -350,8 +348,7 @@ const cli = async (args?: string[]) => {
                     type: "string",
                     describe:
                         "Peer address to dial. Shard roots are discovered automatically after connecting. --bootstrap and --relay remain accepted as aliases.",
-                    defaultDescription:
-                        "Peerbit bootstrap addresses",
+                    defaultDescription: "Peerbit bootstrap addresses",
                     default: undefined,
                 });
                 yargs.option("replicate", {
@@ -408,7 +405,9 @@ const cli = async (args?: string[]) => {
                 }
                 console.log(
                     `Fetching file with id: ${args.id} (${args.replicate ? "replicator" : "observer"} mode${
-                        shareAddress ? `, share ${shareAddress}` : ", legacy global space"
+                        shareAddress
+                            ? `, share ${shareAddress}`
+                            : ", legacy global space"
                     })`
                 );
                 let file;
@@ -463,7 +462,8 @@ const cli = async (args?: string[]) => {
                         const downloadFinishedAt = Date.now();
                         const sizeBytes = file.size;
                         const lookupMs = lookupFinishedAt - lookupStartedAt;
-                        const downloadMs = downloadFinishedAt - downloadStartedAt;
+                        const downloadMs =
+                            downloadFinishedAt - downloadStartedAt;
                         const totalMs = downloadFinishedAt - lookupStartedAt;
                         console.log(
                             chalk.greenBright(

--- a/packages/file-share/frontend/playwright.config.ts
+++ b/packages/file-share/frontend/playwright.config.ts
@@ -32,6 +32,7 @@ if (!REQUESTED_PORT) {
 const explicitBaseUrl = process.env.PW_BASE_URL
     ? normalizeBaseUrl(process.env.PW_BASE_URL)
     : undefined;
+const isBenchmark = process.env.PW_BENCH === "1";
 const viteMode = process.env.PW_VITE_MODE || "development";
 const viteConfig = process.env.PW_VITE_CONFIG;
 const viteConfigArg = viteConfig ? ` --config ${viteConfig}` : "";
@@ -43,6 +44,9 @@ const baseURL = explicitBaseUrl || localBaseUrl;
 const ignoreHTTPSErrors =
     process.env.PW_IGNORE_HTTPS_ERRORS === "1" ||
     (!explicitBaseUrl && localProtocol === "https");
+const localWebServerCommand = isBenchmark
+    ? `pnpm --filter @peerbit/please-lib build && pnpm run build && pnpm exec vite preview${viteConfigArg} --port ${PORT} --strictPort --host ${HOST}`
+    : `pnpm --filter @peerbit/please-lib build && pnpm exec vite dev --mode ${viteMode}${viteConfigArg} --port ${PORT} --strictPort --host ${HOST}`;
 
 export default defineConfig({
     testDir: "./tests",
@@ -64,9 +68,9 @@ export default defineConfig({
     },
     projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
     webServer: explicitBaseUrl
-          ? undefined
+        ? undefined
         : {
-              command: `pnpm --filter @peerbit/please-lib build && pnpm exec vite dev --mode ${viteMode}${viteConfigArg} --port ${PORT} --strictPort --host ${HOST}`,
+              command: localWebServerCommand,
               ignoreHTTPSErrors,
               url: localBaseUrl,
               reuseExistingServer: false,

--- a/packages/file-share/frontend/src/App.tsx
+++ b/packages/file-share/frontend/src/App.tsx
@@ -3,8 +3,14 @@ import { BaseRoutes } from "./routes";
 
 import { HashRouter } from "react-router";
 import { Footer } from "./Footer";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Spinner } from "./Spinner";
+import {
+    getPeerAddressConfiguration,
+    getPeerDialOutcome,
+    getPeerOverrideAction,
+    type PeerHintSource,
+} from "./app-connection";
 /* import { enable } from "@libp2p/logger";
 enable("libp2p:*"); */
 /* import { logger } from "@peerbit/logger";
@@ -13,38 +19,12 @@ const loggefr = logger({ module: "shared-log" })
 loggefr.level = 'trace'
 loggefr.trace("hello") */
 
-const getPeerAddresses = (): string[] | undefined => {
-    const params = new URLSearchParams(window.location.search);
-    const hashQueryIndex = window.location.hash.indexOf("?");
-    const hashParams =
-        hashQueryIndex !== -1
-            ? new URLSearchParams(window.location.hash.slice(hashQueryIndex + 1))
-            : undefined;
-
-    const peer = params.get("peer") ??
-        hashParams?.get("peer") ??
-        params.get("bootstrap") ??
-        hashParams?.get("bootstrap");
-    if (peer == null) {
-        return undefined;
-    }
-
-    const normalized = peer.trim().toLowerCase();
-    if (normalized === "" || normalized === "offline") {
-        return [];
-    }
-
-    return peer
-        .split(",")
-        .map((value) => value.trim())
-        .filter(Boolean);
-};
-
 document.documentElement.classList.add("dark");
 
 type AppDiagnostics = {
     mountedAt: number;
     peersProvided: boolean;
+    peerHintSource: PeerHintSource;
     peerAddressCount: number;
     peerAddresses: string[];
     connectionState: "pending" | "ready" | "failed";
@@ -63,10 +43,12 @@ type AppDiagnostics = {
 
 const createAppDiagnostics = (
     peers: string[] | undefined,
+    peerHintSource: PeerHintSource,
     connectionState: AppDiagnostics["connectionState"]
 ): AppDiagnostics => ({
     mountedAt: Date.now(),
     peersProvided: peers !== undefined,
+    peerHintSource,
     peerAddressCount: peers?.length ?? 0,
     peerAddresses: peers ?? [],
     connectionState,
@@ -106,11 +88,16 @@ const PeerOverride = ({
     const { peer } = usePeer();
 
     useEffect(() => {
-        if (!peer || peers == null || peers.length === 0) {
-            if (peer) {
-                onDiagnostics({ peerReadyAt: Date.now() });
-            }
+        const action = getPeerOverrideAction(Boolean(peer), peers);
+        if (action === "wait-for-peer") {
+            return;
+        }
+        if (action === "ready-without-explicit-dial") {
+            onDiagnostics({ peerReadyAt: Date.now() });
             onReady();
+            return;
+        }
+        if (!peer || !peers) {
             return;
         }
 
@@ -131,46 +118,64 @@ const PeerOverride = ({
             dialError: null,
             dialResults,
         });
-        Promise.all(
-            peers.map((address, index) =>
-                peer
-                    .dial(address)
-                    .then(() => {
-                        dialResults[index] = {
-                            ...dialResults[index],
-                            status: "fulfilled",
-                            finishedAt: Date.now(),
-                        };
+        const dialPromises = peers.map((address, index) =>
+            Promise.resolve()
+                .then(() => peer.dial(address))
+                .then(() => {
+                    dialResults[index] = {
+                        ...dialResults[index],
+                        status: "fulfilled",
+                        finishedAt: Date.now(),
+                    };
+                    if (!cancelled) {
                         onDiagnostics({ dialResults: [...dialResults] });
-                    })
-                    .catch((error) => {
-                        dialResults[index] = {
-                            ...dialResults[index],
-                            status: "rejected",
-                            finishedAt: Date.now(),
-                            error: getErrorMessage(error),
-                        };
+                    }
+                })
+                .catch((error) => {
+                    dialResults[index] = {
+                        ...dialResults[index],
+                        status: "rejected",
+                        finishedAt: Date.now(),
+                        error: getErrorMessage(error),
+                    };
+                    if (!cancelled) {
                         onDiagnostics({ dialResults: [...dialResults] });
-                        throw error;
-                    })
-            )
-        )
-            .then(() => {
-                if (!cancelled) {
-                    onDiagnostics({ dialFinishedAt: Date.now() });
-                    onReady();
-                }
-            })
-            .catch((error) => {
-                console.error("Failed to connect to peer:", error);
-                if (!cancelled) {
-                    onDiagnostics({
-                        dialFinishedAt: Date.now(),
-                        dialError: getErrorMessage(error),
-                    });
-                    onError(error);
-                }
+                    }
+                    throw error;
+                })
+        );
+        Promise.allSettled(dialPromises).then(() => {
+            if (cancelled) {
+                return;
+            }
+            const dialFinishedAt = Date.now();
+            const outcome = getPeerDialOutcome(dialResults);
+            if (outcome === "ready") {
+                onDiagnostics({
+                    dialFinishedAt,
+                    dialError: null,
+                    dialResults: [...dialResults],
+                });
+                onReady();
+                return;
+            }
+            const rejected = dialResults
+                .filter((result) => result.status === "rejected")
+                .map(
+                    (result) =>
+                        `${result.address}: ${result.error ?? "unknown error"}`
+                );
+            const error = new Error(
+                `Failed to connect to all supplied peers: ${rejected.join("; ")}`
+            );
+            console.error("Failed to connect to supplied peers:", error);
+            onDiagnostics({
+                dialFinishedAt,
+                dialError: error.message,
+                dialResults: [...dialResults],
             });
+            onError(error);
+        });
         return () => {
             cancelled = true;
         };
@@ -180,16 +185,22 @@ const PeerOverride = ({
 };
 
 export const App = () => {
-    const peers = getPeerAddresses();
+    const peerConfiguration = useMemo(
+        () => getPeerAddressConfiguration(window.location.href),
+        []
+    );
+    const peers = peerConfiguration.peers;
     const [connectionState, setConnectionState] = useState<
         "pending" | "ready" | "failed"
-    >(
-        peers !== undefined && peers.length > 0 ? "pending" : "ready"
-    );
+    >(peers !== undefined && peers.length > 0 ? "pending" : "ready");
     const diagnosticsRef = useRef(
-        createAppDiagnostics(peers, connectionState)
+        createAppDiagnostics(peers, peerConfiguration.source, connectionState)
     );
     diagnosticsRef.current.connectionState = connectionState;
+    diagnosticsRef.current.peersProvided = peers !== undefined;
+    diagnosticsRef.current.peerHintSource = peerConfiguration.source;
+    diagnosticsRef.current.peerAddressCount = peers?.length ?? 0;
+    diagnosticsRef.current.peerAddresses = peers ?? [];
     const updateDiagnostics = useCallback(
         (diagnostics: Partial<AppDiagnostics>) => {
             diagnosticsRef.current = {
@@ -215,25 +226,25 @@ export const App = () => {
             delete testWindow.__peerbitFileShareAppDiagnostics;
         };
     }, []);
-    const network =
-        peers !== undefined
-            ? { bootstrap: [] }
-            : import.meta.env.MODE === "development"
-              ? "local"
-              : "remote";
+    const peerProviderConfig = useMemo(
+        () => ({
+            runtime: "node" as const,
+            network:
+                peers !== undefined
+                    ? { bootstrap: [] }
+                    : import.meta.env.MODE === "development"
+                      ? ("local" as const)
+                      : ("remote" as const),
+            waitForConnected:
+                peers !== undefined || import.meta.env.MODE === "development"
+                    ? true
+                    : ("in-flight" as const),
+        }),
+        [peers]
+    );
 
     return (
-        <PeerProvider
-            config={{
-                runtime: "node",
-                network,
-                waitForConnected:
-                    peers !== undefined ||
-                    import.meta.env.MODE === "development"
-                        ? true
-                        : "in-flight",
-            }}
-        >
+        <PeerProvider config={peerProviderConfig}>
             <div className="h-screen">
                 <PeerOverride
                     peers={peers}

--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -9,7 +9,7 @@ import { File } from "./File";
 import { Spinner } from "./Spinner";
 import * as Switch from "@radix-ui/react-switch";
 import * as Slider from "@radix-ui/react-slider";
-import { SearchRequest } from "@peerbit/document";
+import { IsNull, SearchRequest } from "@peerbit/document";
 import * as Popover from "@radix-ui/react-popover";
 import { useStorageUsage } from "./MemoryUsage";
 import { useNetworkUsage } from "./NetworkUsage";
@@ -18,12 +18,58 @@ import * as Progress from "@radix-ui/react-progress";
 import { ReplicationOptions } from "@peerbit/shared-log";
 import {
     applyRootFileChangeToList,
+    getPendingReadyRootReconciliation,
     getReadyLargeFileSignature,
     getRootFileChange,
     shouldRefreshRootListForFileChange,
     sortRootFilesForDisplay,
 } from "./root-list";
 import { getPeerDialAddresses, withSharePeerHints } from "./share-url";
+import {
+    bindRefreshContext,
+    callEvenInterval,
+    createRefreshContextGuard,
+    drainCoalescedRefreshQueue,
+    isRefreshContextActive,
+    queueCoalescedRefresh,
+    type RefreshContext,
+} from "./refresh-scheduler";
+import {
+    applyReplicationRoleGuarded,
+    createFileShareReplicationRole,
+    DEFAULT_REPLICATION_ROLE,
+    formatFileShareStorageMegabytes,
+    getInitialReplicationRole,
+    parseFileShareStorageMegabytes,
+    parseStoredRole,
+} from "./role-state";
+import {
+    coalesceRootListRefreshSource,
+    getRootListRefreshSource,
+    listRemoteRootFilesForReconciliation,
+    listRootFilesForRole,
+    REMOTE_ROOT_RECONCILIATION_INTERVAL_MS,
+    shouldReconcileRemoteRootFiles,
+} from "./file-list-loader";
+import {
+    createPendingReadyResolver,
+    resolveRemoteReadyRoot,
+    type PendingReadyResolver,
+} from "./pending-ready-resolver";
+import { confirmRemoteRoot } from "./remote-root-confirmation";
+import {
+    applyRemoteRootConfirmation,
+    createRemoteRootConfirmationScheduler,
+    createRemoteRootReconciliationState,
+    invalidateRemoteRootAbsenceForVisibleRoots,
+    isRemoteRootObservationCurrent,
+    observeLocalRootSnapshot,
+    observeRemoteRootSnapshot,
+    recordExplicitRootChange,
+    type RemoteRootConfirmationScheduler,
+    type RemoteRootObservation,
+} from "./remote-root-reconciliation";
+import { settleUploadBatch } from "./upload-lifecycle";
 
 const saveRoleLocalStorage = (files: Files, role: string) => {
     localStorage.setItem(files.address + "-role", role); // Save role in localstorage for next time
@@ -31,15 +77,6 @@ const saveRoleLocalStorage = (files: Files, role: string) => {
 const getRoleFromLocalStorage = (files: Files) => {
     return localStorage.getItem(files.address + "-role"); // Save role in localstorage for next time
 };
-
-const DEFAULT_REPLICATION_ROLE: ReplicationOptions = {
-    limits: { cpu: { max: 1, monitor: undefined } },
-};
-
-const parseStoredRole = (
-    serializedRole: string | null
-): ReplicationOptions | undefined =>
-    serializedRole == null ? undefined : JSON.parse(serializedRole);
 
 const STREAMING_DOWNLOAD_THRESHOLD_BYTES = 250_000_000n;
 
@@ -57,6 +94,7 @@ type ListingDiagnostics = {
     firstProgramHookReadyAt: number | null;
     programHookStatus: string | null;
     programHookLoading: boolean;
+    programHookError: string | null;
     onOpenStartedAt: number | null;
     trustCheckStartedAt: number | null;
     trustCheckFinishedAt: number | null;
@@ -70,6 +108,10 @@ type ListingDiagnostics = {
     lastUpdateRoleFinishedAt: number | null;
     lastAppliedRole: "replicator" | "observer" | null;
     listCallCount: number;
+    coalescedListRefreshCount: number;
+    listRefreshInFlight: boolean;
+    lastCoalescedListSource: string | null;
+    staleListResultIgnoredCount: number;
     adaptiveRefreshCount: number;
     adaptiveRefreshInFlight: boolean;
     lastAdaptiveRefreshReason: string | null;
@@ -80,7 +122,14 @@ type ListingDiagnostics = {
     rootFileChangeEventCount: number;
     rootChangeDirectAddCount: number;
     rootChangeDirectRemoveCount: number;
+    rootChangeAvoidedListRefreshCount: number;
     skippedChildFileChangeEventCount: number;
+    pendingReadyResolverStartCount: number;
+    pendingReadyResolverResolvedCount: number;
+    pendingReadyResolverExpiredCount: number;
+    pendingReadyResolverErrorCount: number;
+    pendingReadyResolverActiveCount: number;
+    lastPendingReadyResolverError: string | null;
     activeTransferCount: number;
     skippedActiveTransferRefreshCount: number;
     sharePeerAddressCount: number;
@@ -97,6 +146,23 @@ type SaveFilePickerWindow = Window & {
 const isUserCancelledDownload = (error: unknown) =>
     error instanceof DOMException &&
     (error.name === "AbortError" || error.name === "NotAllowedError");
+
+const getProgramHookErrorMessage = (error: unknown) => {
+    if (error == null) {
+        return null;
+    }
+    if (error instanceof Error) {
+        return error.message;
+    }
+    if (
+        typeof error === "object" &&
+        "message" in error &&
+        typeof error.message === "string"
+    ) {
+        return error.message;
+    }
+    return String(error);
+};
 
 const getStreamingDownloadThresholdBytes = () => {
     const override = (window as SaveFilePickerWindow)
@@ -139,6 +205,7 @@ const createListingDiagnostics = (
     firstProgramHookReadyAt: null,
     programHookStatus: null,
     programHookLoading: false,
+    programHookError: null,
     onOpenStartedAt: null,
     trustCheckStartedAt: null,
     trustCheckFinishedAt: null,
@@ -152,6 +219,10 @@ const createListingDiagnostics = (
     lastUpdateRoleFinishedAt: null,
     lastAppliedRole: null,
     listCallCount: 0,
+    coalescedListRefreshCount: 0,
+    listRefreshInFlight: false,
+    lastCoalescedListSource: null,
+    staleListResultIgnoredCount: 0,
     adaptiveRefreshCount: 0,
     adaptiveRefreshInFlight: false,
     lastAdaptiveRefreshReason: null,
@@ -162,7 +233,14 @@ const createListingDiagnostics = (
     rootFileChangeEventCount: 0,
     rootChangeDirectAddCount: 0,
     rootChangeDirectRemoveCount: 0,
+    rootChangeAvoidedListRefreshCount: 0,
     skippedChildFileChangeEventCount: 0,
+    pendingReadyResolverStartCount: 0,
+    pendingReadyResolverResolvedCount: 0,
+    pendingReadyResolverExpiredCount: 0,
+    pendingReadyResolverErrorCount: 0,
+    pendingReadyResolverActiveCount: 0,
+    lastPendingReadyResolverError: null,
     activeTransferCount: 0,
     skippedActiveTransferRefreshCount: 0,
     sharePeerAddressCount: 0,
@@ -177,22 +255,6 @@ export const useDebouncedEffect = (effect, deps, delay) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [...(deps || []), delay]);
 };
-
-function callEvenInterval(func, delay) {
-    var timer: ReturnType<typeof setTimeout> = undefined;
-    let promise: any = undefined;
-    return function debouncedFn(args?: any) {
-        if (timer || promise) {
-            return;
-        }
-        timer = setTimeout(async () => {
-            promise = func(args);
-            await promise;
-            promise = undefined;
-            timer = undefined;
-        }, delay);
-    };
-}
 
 export const Drop = () => {
     const navigate = useNavigate();
@@ -212,6 +274,8 @@ export const Drop = () => {
         new Set()
     );
     const [isHost, setIsHost] = useState<boolean>();
+    const isHostRef = useRef<boolean | undefined>(isHost);
+    isHostRef.current = isHost;
     const [replicatorCount, setReplicatorCount] = useState(0);
     const [left, setLeft] = useState(false);
     const shareAddress = params.address && decodeURIComponent(params.address);
@@ -223,20 +287,61 @@ export const Drop = () => {
     const [currentRole, setCurrentRole] = useState<ReplicationOptions>(
         storedRole ?? DEFAULT_REPLICATION_ROLE
     );
+    const currentRoleRef = useRef<ReplicationOptions>(currentRole);
+    const roleRevisionRef = useRef(0);
     const diagnosticsRef = useRef<ListingDiagnostics>(
         createListingDiagnostics(shareAddress, storedRole)
     );
-    const adaptiveRefreshRef = useRef<Promise<void> | null>(null);
-    const adaptiveRefreshSignatureRef = useRef<string | null>(null);
-
+    const adaptiveRefreshRef = useRef<
+        (RefreshContext<Files> & { promise: Promise<void> }) | null
+    >(null);
+    const adaptiveRefreshSignatureRef = useRef<
+        (RefreshContext<Files> & { signature: string }) | null
+    >(null);
+    const listRefreshRef = useRef<Promise<void> | null>(null);
+    const queuedListRefreshSourceRef = useRef<string | null>(null);
+    const listRefreshGenerationRef = useRef(0);
+    const rootListRevisionRef = useRef(0);
+    const remoteRootReconciliationStartedAtRef = useRef<number | null>(null);
+    const remoteRootConfirmationRunStartedAtRef = useRef<number | null>(null);
+    const remoteRootReconciliationStateRef = useRef(
+        createRemoteRootReconciliationState()
+    );
+    const remoteRootConfirmationSchedulerRef = useRef<{
+        generation: number;
+        program: Files;
+        scheduler: RemoteRootConfirmationScheduler<
+            RemoteRootObservation<Files>
+        >;
+    } | null>(null);
+    const listRefreshProgramRef = useRef<Files | null>(null);
+    const pendingReadyResolverRef = useRef<{
+        program: Files;
+        resolver: PendingReadyResolver<Files>;
+    } | null>(null);
     useEffect(() => {
         diagnosticsRef.current = createListingDiagnostics(
             shareAddress,
             storedRole
         );
         setRootList([]);
+        setReplicationSet(new Set());
+        const nextRole = storedRole ?? DEFAULT_REPLICATION_ROLE;
+        currentRoleRef.current = nextRole;
+        roleRevisionRef.current += 1;
+        setCurrentRole(nextRole);
         adaptiveRefreshRef.current = null;
         adaptiveRefreshSignatureRef.current = null;
+        listRefreshGenerationRef.current += 1;
+        listRefreshRef.current = null;
+        queuedListRefreshSourceRef.current = null;
+        rootListRevisionRef.current += 1;
+        remoteRootReconciliationStartedAtRef.current = null;
+        remoteRootConfirmationRunStartedAtRef.current = null;
+        remoteRootConfirmationSchedulerRef.current?.scheduler.reset();
+        remoteRootConfirmationSchedulerRef.current = null;
+        remoteRootReconciliationStateRef.current =
+            createRemoteRootReconciliationState();
         // Reset diagnostics only when we enter a different share. Role changes
         // inside the same share are part of the same session we want to measure.
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -248,6 +353,7 @@ export const Drop = () => {
             replicate: storedRole ?? DEFAULT_REPLICATION_ROLE,
         },
     });
+    listRefreshProgramRef.current = files.program ?? null;
 
     useEffect(() => {
         if (peer && diagnosticsRef.current.firstPeerReadyAt == null) {
@@ -258,13 +364,16 @@ export const Drop = () => {
     useEffect(() => {
         diagnosticsRef.current.programHookStatus = files.status;
         diagnosticsRef.current.programHookLoading = files.loading;
+        diagnosticsRef.current.programHookError = getProgramHookErrorMessage(
+            files.error
+        );
         if (
             files.program &&
             diagnosticsRef.current.firstProgramHookReadyAt == null
         ) {
             diagnosticsRef.current.firstProgramHookReadyAt = Date.now();
         }
-    }, [files.loading, files.program, files.status]);
+    }, [files.error, files.loading, files.program, files.status]);
 
     const { memory } = useStorageUsage(files.program?.files.log);
     const { up, down } = useNetworkUsage();
@@ -277,6 +386,19 @@ export const Drop = () => {
     const [limitCPU, setLimitCPU] = useState<number | undefined>(1);
     const [uploadProgress, setUploadProgress] = useState<number | null>(null);
     const activeTransferCountRef = useRef(0);
+
+    const selectRole = (nextRole: "replicator" | "observer") => {
+        setRole(nextRole);
+        if (nextRole === "observer" && currentRoleRef.current !== false) {
+            currentRoleRef.current = false;
+            roleRevisionRef.current += 1;
+            pendingReadyResolverRef.current?.resolver.cancelAll();
+            if (listRefreshProgramRef.current) {
+                listRefreshProgramRef.current.persistChunkReads = false;
+            }
+            void updateList("role-change");
+        }
+    };
 
     const startActiveTransfer = () => {
         activeTransferCountRef.current += 1;
@@ -293,10 +415,91 @@ export const Drop = () => {
             activeTransferCountRef.current;
     };
 
-    // we exclude the string type 'replicator' | 'observer' from the roleOptions so that we can easily serialize it with JSON
-    const updateRole = async (roleOptions?: ReplicationOptions) => {
-        if (roleOptions == null || !files.program) {
+    const getCurrentRefreshContext = (): RefreshContext<Files | null> => ({
+        generation: listRefreshGenerationRef.current,
+        program: listRefreshProgramRef.current,
+    });
+
+    const reconcilePendingReadyRoots = (
+        program: Files,
+        context: RefreshContext<Files>,
+        rootFiles: AbstractFile[]
+    ) => {
+        const activeResolver = pendingReadyResolverRef.current;
+        if (
+            !activeResolver ||
+            activeResolver.program !== program ||
+            !isRefreshContextActive(getCurrentRefreshContext(), context)
+        ) {
             return;
+        }
+        const reconciliation = getPendingReadyRootReconciliation(rootFiles);
+        for (const id of reconciliation.readyIds) {
+            activeResolver.resolver.cancel(id, program);
+        }
+        if (currentRoleRef.current === false || isHostRef.current === true) {
+            diagnosticsRef.current.pendingReadyResolverActiveCount =
+                activeResolver.resolver.size;
+            return;
+        }
+        for (const file of reconciliation.pending) {
+            const start = activeResolver.resolver.start(file.id, program);
+            if (start.status !== "started") {
+                continue;
+            }
+            diagnosticsRef.current.pendingReadyResolverStartCount += 1;
+            diagnosticsRef.current.lastPendingReadyResolverError = null;
+            void start.promise.finally(() => {
+                if (
+                    pendingReadyResolverRef.current === activeResolver &&
+                    isRefreshContextActive(getCurrentRefreshContext(), context)
+                ) {
+                    diagnosticsRef.current.pendingReadyResolverActiveCount =
+                        activeResolver.resolver.size;
+                }
+            });
+        }
+        diagnosticsRef.current.pendingReadyResolverActiveCount =
+            activeResolver.resolver.size;
+    };
+
+    const applyReplicationRole = async (
+        program: Files,
+        roleOptions: ReplicationOptions,
+        revision: number,
+        context: RefreshContext<Files>
+    ) =>
+        applyReplicationRoleGuarded(program, roleOptions, {
+            expectedRevision: revision,
+            getCurrentRevision: () => roleRevisionRef.current,
+            getCurrentRole: () => currentRoleRef.current,
+            isContextActive: () =>
+                isRefreshContextActive(getCurrentRefreshContext(), context),
+        });
+
+    // we exclude the string type 'replicator' | 'observer' from the roleOptions so that we can easily serialize it with JSON
+    const updateRole = async (
+        roleOptions?: ReplicationOptions,
+        targetProgram = files.program
+    ) => {
+        if (roleOptions == null || !targetProgram || targetProgram.closed) {
+            return;
+        }
+
+        const roleModeChanged =
+            (currentRoleRef.current === false) !== (roleOptions === false);
+
+        const context: RefreshContext<Files> = {
+            generation: listRefreshGenerationRef.current,
+            program: targetProgram,
+        };
+        if (!isRefreshContextActive(getCurrentRefreshContext(), context)) {
+            return;
+        }
+        let appliedRoleRevision = ++roleRevisionRef.current;
+        currentRoleRef.current = roleOptions;
+        if (roleOptions === false) {
+            pendingReadyResolverRef.current?.resolver.cancelAll();
         }
 
         diagnosticsRef.current.updateRoleCount += 1;
@@ -305,27 +508,67 @@ export const Drop = () => {
         diagnosticsRef.current.lastUpdateRoleStartedAt = Date.now();
 
         setCurrentRole(roleOptions);
-        files.program.persistChunkReads = roleOptions !== false;
 
         // console.log("X", files.program.files.log["_roleOptions"]?.["limits"]?.["cpu"]?.max)
-        saveRoleLocalStorage(files.program, JSON.stringify(roleOptions)); // Save role in localstorage for next time
-        await files.program.files.log.replicate(false);
-        if (roleOptions !== false) {
-            await files.program.files.log.replicate(roleOptions);
+        saveRoleLocalStorage(targetProgram, JSON.stringify(roleOptions)); // Save role in localstorage for next time
+        await applyReplicationRole(
+            targetProgram,
+            roleOptions,
+            appliedRoleRevision,
+            context
+        );
+        while (
+            isRefreshContextActive(getCurrentRefreshContext(), context) &&
+            appliedRoleRevision !== roleRevisionRef.current
+        ) {
+            appliedRoleRevision = roleRevisionRef.current;
+            await applyReplicationRole(
+                targetProgram,
+                currentRoleRef.current,
+                appliedRoleRevision,
+                context
+            );
         }
-        diagnosticsRef.current.lastUpdateRoleFinishedAt = Date.now();
+        if (
+            appliedRoleRevision === roleRevisionRef.current &&
+            isRefreshContextActive(getCurrentRefreshContext(), context)
+        ) {
+            diagnosticsRef.current.lastUpdateRoleFinishedAt = Date.now();
+            if (roleModeChanged) {
+                await updateList("role-change", context);
+            }
+        }
     };
 
-    const refreshAdaptiveReplication = async (reason: string) => {
-        if (!files.program || files.program.closed || currentRole === false) {
+    const refreshAdaptiveReplication = async (
+        reason: string,
+        context: RefreshContext<Files>
+    ) => {
+        if (
+            !isRefreshContextActive(
+                getCurrentRefreshContext(),
+                context,
+                currentRoleRef.current !== false
+            ) ||
+            context.program.closed
+        ) {
             return;
         }
-        if (adaptiveRefreshRef.current) {
-            return adaptiveRefreshRef.current;
+        const existing = adaptiveRefreshRef.current;
+        if (
+            existing &&
+            existing.generation === context.generation &&
+            existing.program === context.program
+        ) {
+            return existing.promise;
         }
 
-        const program = files.program;
-        const roleOptions = currentRole;
+        const program = context.program;
+        const roleOptions = currentRoleRef.current;
+        if (roleOptions === false) {
+            return;
+        }
+        let appliedRoleRevision = roleRevisionRef.current;
         diagnosticsRef.current.adaptiveRefreshCount += 1;
         diagnosticsRef.current.adaptiveRefreshInFlight = true;
         diagnosticsRef.current.lastAdaptiveRefreshReason = reason;
@@ -338,41 +581,90 @@ export const Drop = () => {
             await program.files.log.replicate(roleOptions, {
                 rebalance: true,
             });
+            while (
+                isRefreshContextActive(getCurrentRefreshContext(), context) &&
+                appliedRoleRevision !== roleRevisionRef.current
+            ) {
+                appliedRoleRevision = roleRevisionRef.current;
+                await applyReplicationRole(
+                    program,
+                    currentRoleRef.current,
+                    appliedRoleRevision,
+                    context
+                );
+            }
         })();
 
-        adaptiveRefreshRef.current = refresh;
+        const operation = { ...context, promise: refresh };
+        adaptiveRefreshRef.current = operation;
         try {
             await refresh;
         } catch (error) {
-            diagnosticsRef.current.lastAdaptiveRefreshError =
-                error instanceof Error ? error.message : String(error);
+            if (isRefreshContextActive(getCurrentRefreshContext(), context)) {
+                diagnosticsRef.current.lastAdaptiveRefreshError =
+                    error instanceof Error ? error.message : String(error);
+            }
             throw error;
         } finally {
-            if (adaptiveRefreshRef.current === refresh) {
+            if (adaptiveRefreshRef.current === operation) {
                 adaptiveRefreshRef.current = null;
             }
-            diagnosticsRef.current.adaptiveRefreshInFlight = false;
-            diagnosticsRef.current.lastAdaptiveRefreshFinishedAt = Date.now();
+            if (isRefreshContextActive(getCurrentRefreshContext(), context)) {
+                diagnosticsRef.current.adaptiveRefreshInFlight = false;
+                diagnosticsRef.current.lastAdaptiveRefreshFinishedAt =
+                    Date.now();
+            }
         }
     };
 
     const scheduleAdaptiveRefresh = (
         reason: string,
-        signature?: string | null
+        signature?: string | null,
+        requestedContext?: RefreshContext<Files>
     ) => {
-        if (!files.program || files.program.closed || currentRole === false) {
+        const currentContext = getCurrentRefreshContext();
+        const context =
+            requestedContext ??
+            (currentContext.program
+                ? {
+                      generation: currentContext.generation,
+                      program: currentContext.program,
+                  }
+                : undefined);
+        if (
+            !context ||
+            context.program.closed ||
+            !isRefreshContextActive(
+                currentContext,
+                context,
+                currentRoleRef.current !== false
+            )
+        ) {
             return;
         }
+        if (activeTransferCountRef.current > 0) {
+            diagnosticsRef.current.skippedActiveTransferRefreshCount += 1;
+            return;
+        }
+        let signatureToken:
+            | (RefreshContext<Files> & { signature: string })
+            | undefined;
         if (signature) {
-            if (adaptiveRefreshSignatureRef.current === signature) {
+            const existing = adaptiveRefreshSignatureRef.current;
+            if (
+                existing?.signature === signature &&
+                existing.generation === context.generation &&
+                existing.program === context.program
+            ) {
                 return;
             }
-            adaptiveRefreshSignatureRef.current = signature;
+            signatureToken = { ...context, signature };
+            adaptiveRefreshSignatureRef.current = signatureToken;
         }
-        void refreshAdaptiveReplication(reason).catch((error) => {
+        void refreshAdaptiveReplication(reason, context).catch((error) => {
             if (
-                signature &&
-                adaptiveRefreshSignatureRef.current === signature
+                signatureToken &&
+                adaptiveRefreshSignatureRef.current === signatureToken
             ) {
                 adaptiveRefreshSignatureRef.current = null;
             }
@@ -389,6 +681,9 @@ export const Drop = () => {
                 setReplicationRole: (
                     roleOptions: ReplicationOptions
                 ) => Promise<void>;
+                setPersistChunkReads: (persist: boolean) => boolean;
+                getLightweightSnapshot: () => Record<string, unknown>;
+                getTopologySnapshot: () => Promise<Record<string, unknown>>;
                 getDiagnostics: () => Promise<Record<string, unknown>>;
             };
             __peerbitFileShareBenchmarkStats?: {
@@ -396,7 +691,7 @@ export const Drop = () => {
             };
         };
         const program = files.program;
-        testWindow.__peerbitFileShareTestHooks = {
+        const testHooks = {
             setReplicationRole: async (roleOptions) => {
                 if (!program || program.closed) {
                     throw new Error("Program is not ready");
@@ -404,6 +699,91 @@ export const Drop = () => {
                 saveRoleLocalStorage(program, JSON.stringify(roleOptions));
                 setRole(roleOptions ? "replicator" : "observer");
                 await updateRole(roleOptions);
+            },
+            setPersistChunkReads: (persist) => {
+                if (!program || program.closed) {
+                    throw new Error("Program is not ready");
+                }
+                program.persistChunkReads = persist;
+                return program.persistChunkReads;
+            },
+            getLightweightSnapshot: () => ({
+                capturedAt: Date.now(),
+                programAddress: program?.address ?? null,
+                programClosed: program?.closed ?? null,
+                programHookStatus: files.status,
+                programHookError: getProgramHookErrorMessage(files.error),
+                persistChunkReads: program?.persistChunkReads ?? null,
+                listCount: listRef.current.length,
+                listedFiles: listRef.current.map((file) => ({
+                    id: file.id,
+                    name: file.name,
+                    type: isLargeFileLike(file) ? "large" : "tiny",
+                    size: file.size.toString(),
+                    ready: isLargeFileLike(file) ? file.ready : undefined,
+                    finalHash: isLargeFileLike(file)
+                        ? file.finalHash
+                        : undefined,
+                })),
+            }),
+            getTopologySnapshot: async () => {
+                const activeProgram =
+                    program && !program.closed ? program : undefined;
+                const replicators = activeProgram
+                    ? await activeProgram.files.log
+                          .getReplicators()
+                          .catch(() => undefined)
+                    : undefined;
+                const peerHash =
+                    peer?.identity?.publicKey?.hashcode?.() ?? null;
+                const replicatorHashes = replicators
+                    ? [...replicators]
+                          .map(
+                              (
+                                  replicator:
+                                      | string
+                                      | { hashcode?: () => string }
+                              ) =>
+                                  typeof replicator === "string"
+                                      ? replicator
+                                      : replicator.hashcode?.()
+                          )
+                          .filter((hash): hash is string => hash != null)
+                    : undefined;
+                const appDiagnostics = (
+                    window as Window & {
+                        __peerbitFileShareAppDiagnostics?: () => {
+                            peersProvided?: boolean;
+                            peerHintSource?: string | null;
+                            peerAddressCount?: number;
+                            connectionState?: string;
+                            dialStartedAt?: number | null;
+                            dialFinishedAt?: number | null;
+                        };
+                    }
+                ).__peerbitFileShareAppDiagnostics?.();
+                const connections =
+                    (peer as any)?.libp2p?.getConnections?.() ?? [];
+
+                return {
+                    capturedAt: Date.now(),
+                    peersProvided: appDiagnostics?.peersProvided ?? null,
+                    peerHintSource: appDiagnostics?.peerHintSource ?? null,
+                    peerAddressCount: appDiagnostics?.peerAddressCount ?? null,
+                    appConnectionState: appDiagnostics?.connectionState ?? null,
+                    appDialStartedAt: appDiagnostics?.dialStartedAt ?? null,
+                    appDialFinishedAt: appDiagnostics?.dialFinishedAt ?? null,
+                    connectionCount: connections.length,
+                    peerHash,
+                    replicatorCount:
+                        replicators && typeof replicators.size === "number"
+                            ? replicators.size
+                            : null,
+                    selfInReplicatorSet:
+                        peerHash && replicatorHashes
+                            ? replicatorHashes.includes(peerHash)
+                            : null,
+                };
             },
             getDiagnostics: async () => {
                 const activeProgram =
@@ -427,6 +807,9 @@ export const Drop = () => {
                         type: isLargeFileLike(file) ? "large" : "tiny",
                         size: file.size.toString(),
                         ready: isLargeFileLike(file) ? file.ready : undefined,
+                        finalHash: isLargeFileLike(file)
+                            ? file.finalHash
+                            : undefined,
                         chunkCount: isLargeFileLike(file)
                             ? file.chunkCount
                             : undefined,
@@ -434,6 +817,12 @@ export const Drop = () => {
                             activeProgram && isLargeFileLike(file)
                                 ? await activeProgram
                                       .countLocalChunks(file)
+                                      .catch(() => null)
+                                : undefined,
+                        localChunkBlockCount:
+                            activeProgram && isLargeFileLike(file)
+                                ? await activeProgram
+                                      .countLocalChunkBlocks(file)
                                       .catch(() => null)
                                 : undefined,
                     }))
@@ -456,14 +845,13 @@ export const Drop = () => {
                     peerAddresses,
                     peerStatus,
                     peerLoading,
+                    programHookError: getProgramHookErrorMessage(files.error),
                     connectionCount: connections.length,
                     connectionPeers: connections,
-                    programOpenDiagnostics:
-                        program?.openDiagnostics ?? null,
+                    programOpenDiagnostics: program?.openDiagnostics ?? null,
                     lastUploadDiagnostics:
                         program?.lastUploadDiagnostics ?? null,
-                    lastReadDiagnostics:
-                        program?.lastReadDiagnostics ?? null,
+                    lastReadDiagnostics: program?.lastReadDiagnostics ?? null,
                     replicatorCount:
                         replicators && typeof replicators.size === "number"
                             ? replicators.size
@@ -479,13 +867,17 @@ export const Drop = () => {
                 };
             },
         };
+        testWindow.__peerbitFileShareTestHooks = testHooks;
         return () => {
-            delete testWindow.__peerbitFileShareTestHooks;
+            if (testWindow.__peerbitFileShareTestHooks === testHooks) {
+                delete testWindow.__peerbitFileShareTestHooks;
+            }
         };
     }, [
         files.program,
         files.program?.address,
         files.program?.closed,
+        files.error,
         files.loading,
         files.status,
         isHost,
@@ -544,20 +936,15 @@ export const Drop = () => {
 
     useDebouncedEffect(
         () => {
-            const limitSizeMB = Number(limitStorageString);
-            const sizeBytes = limitSizeMB * 1e6;
+            const sizeBytes =
+                parseFileShareStorageMegabytes(limitStorageString);
 
             updateRole(
                 role === "replicator"
-                    ? {
-                          limits: {
-                              cpu:
-                                  limitCPU != null
-                                      ? { max: limitCPU }
-                                      : undefined,
-                              storage: limitStorage ? sizeBytes : undefined,
-                          },
-                      }
+                    ? createFileShareReplicationRole({
+                          cpuMax: limitCPU,
+                          storage: limitStorage ? sizeBytes : undefined,
+                      })
                     : false
             );
         },
@@ -571,7 +958,220 @@ export const Drop = () => {
             return;
         }
 
-        const updateListDebounced = callEvenInterval(updateList, 500);
+        listRefreshGenerationRef.current += 1;
+        listRefreshRef.current = null;
+        queuedListRefreshSourceRef.current = null;
+        adaptiveRefreshRef.current = null;
+        adaptiveRefreshSignatureRef.current = null;
+        remoteRootReconciliationStartedAtRef.current = null;
+        remoteRootConfirmationRunStartedAtRef.current = null;
+        remoteRootConfirmationSchedulerRef.current?.scheduler.reset();
+        remoteRootConfirmationSchedulerRef.current = null;
+        const remoteRootReconciliationState =
+            createRemoteRootReconciliationState();
+        remoteRootReconciliationStateRef.current =
+            remoteRootReconciliationState;
+        diagnosticsRef.current.adaptiveRefreshInFlight = false;
+
+        const program = files.program;
+        const refreshContext: RefreshContext<Files> = {
+            generation: listRefreshGenerationRef.current,
+            program,
+        };
+        let disposed = false;
+        const hasCurrentContext = createRefreshContextGuard(
+            getCurrentRefreshContext,
+            refreshContext
+        );
+        const isContextCurrent = () => !disposed && hasCurrentContext();
+        const pendingReadyResolver = createPendingReadyResolver<
+            Files,
+            AbstractFile
+        >({
+            attemptTimeoutMs: 1_500,
+            retryDelayMs: 350,
+            maxEntries: 64,
+            maxLifetimeMs: 5 * 60_000,
+            resolve: (id, targetProgram, signal, attemptTimeoutMs) =>
+                resolveRemoteReadyRoot(
+                    targetProgram,
+                    id,
+                    signal,
+                    attemptTimeoutMs
+                ),
+            isActive: (id, targetProgram) => {
+                if (
+                    targetProgram !== program ||
+                    targetProgram.closed ||
+                    currentRoleRef.current === false ||
+                    isHostRef.current === true ||
+                    !isContextCurrent()
+                ) {
+                    return false;
+                }
+                const listed = listRef.current.find((file) => file.id === id);
+                return Boolean(
+                    listed && isLargeFileLike(listed) && !listed.ready
+                );
+            },
+            onReady: (id, targetProgram, readyFile) => {
+                if (
+                    targetProgram !== program ||
+                    readyFile.id !== id ||
+                    targetProgram.closed ||
+                    currentRoleRef.current === false ||
+                    !isContextCurrent()
+                ) {
+                    return;
+                }
+                const listed = listRef.current.find((file) => file.id === id);
+                if (!listed || !isLargeFileLike(listed) || listed.ready) {
+                    return;
+                }
+
+                diagnosticsRef.current.pendingReadyResolverResolvedCount += 1;
+                rootListRevisionRef.current += 1;
+                const nextList = applyRootFileChangeToList(listRef.current, {
+                    added: [readyFile],
+                    removed: [],
+                });
+                setRootList(nextList);
+                forceUpdate();
+            },
+            onError: (_id, _targetProgram, error) => {
+                if (!isContextCurrent()) {
+                    return;
+                }
+                diagnosticsRef.current.pendingReadyResolverErrorCount += 1;
+                diagnosticsRef.current.lastPendingReadyResolverError =
+                    error instanceof Error ? error.message : String(error);
+            },
+            onExpired: () => {
+                if (isContextCurrent()) {
+                    diagnosticsRef.current.pendingReadyResolverExpiredCount += 1;
+                }
+            },
+        });
+        pendingReadyResolverRef.current = {
+            program,
+            resolver: pendingReadyResolver,
+        };
+        const remoteRootConfirmationScheduler =
+            createRemoteRootConfirmationScheduler<
+                RemoteRootObservation<Files>,
+                Awaited<ReturnType<typeof confirmRemoteRoot>>
+            >({
+                maxCandidatesPerRun: 8,
+                concurrency: 2,
+                confirm: (id, signal) => confirmRemoteRoot(program, id, signal),
+                onResult: (id, result, observation) => {
+                    if (
+                        !isContextCurrent() ||
+                        !isRemoteRootObservationCurrent(
+                            {
+                                generation: listRefreshGenerationRef.current,
+                                program: listRefreshProgramRef.current,
+                                rootRevision: rootListRevisionRef.current,
+                            },
+                            observation
+                        )
+                    ) {
+                        return "retry";
+                    }
+                    const action = applyRemoteRootConfirmation(
+                        remoteRootReconciliationState,
+                        id,
+                        result
+                    );
+                    if (action.type === "merge") {
+                        const nextList = applyRootFileChangeToList(
+                            listRef.current,
+                            { added: [action.root], removed: [] }
+                        );
+                        setRootList(nextList);
+                        reconcilePendingReadyRoots(
+                            program,
+                            refreshContext,
+                            nextList
+                        );
+                        const readyLargeFileSignature =
+                            getReadyLargeFileSignature(nextList);
+                        if (readyLargeFileSignature) {
+                            scheduleAdaptiveRefresh(
+                                "ready-exact-remote-root",
+                                readyLargeFileSignature,
+                                refreshContext
+                            );
+                        }
+                        forceUpdate();
+                    } else if (action.type === "remove") {
+                        const nextList = applyRootFileChangeToList(
+                            listRef.current,
+                            {
+                                added: [],
+                                removed: [{ id, parentId: undefined }],
+                            }
+                        );
+                        setRootList(nextList);
+                        pendingReadyResolver.cancel(id, program);
+                        diagnosticsRef.current.pendingReadyResolverActiveCount =
+                            pendingReadyResolver.size;
+                        setReplicationSet((current) => {
+                            const next = new Set(current);
+                            next.delete(id);
+                            return next;
+                        });
+                        forceUpdate();
+                    }
+                    return action.retry ? "retry" : "complete";
+                },
+            });
+        remoteRootConfirmationSchedulerRef.current = {
+            ...refreshContext,
+            scheduler: remoteRootConfirmationScheduler,
+        };
+        const cancelPendingReadyResolver = (id: string) => {
+            if (pendingReadyResolver.cancel(id, program)) {
+                diagnosticsRef.current.pendingReadyResolverActiveCount =
+                    pendingReadyResolver.size;
+            }
+        };
+        const startPendingReadyResolver = (file: AbstractFile) => {
+            if (
+                !isLargeFileLike(file) ||
+                file.ready ||
+                currentRoleRef.current === false ||
+                isHostRef.current === true ||
+                !isContextCurrent()
+            ) {
+                return;
+            }
+            const start = pendingReadyResolver.start(file.id, program);
+            if (start.status !== "started") {
+                diagnosticsRef.current.pendingReadyResolverActiveCount =
+                    pendingReadyResolver.size;
+                return;
+            }
+            diagnosticsRef.current.pendingReadyResolverStartCount += 1;
+            diagnosticsRef.current.lastPendingReadyResolverError = null;
+            diagnosticsRef.current.pendingReadyResolverActiveCount =
+                pendingReadyResolver.size;
+            void start.promise.finally(() => {
+                if (isContextCurrent()) {
+                    diagnosticsRef.current.pendingReadyResolverActiveCount =
+                        pendingReadyResolver.size;
+                }
+            });
+        };
+        const updateListForProgram = bindRefreshContext<Files, string | Event>(
+            () => ({
+                generation: listRefreshGenerationRef.current,
+                program: listRefreshProgramRef.current,
+            }),
+            refreshContext,
+            (sourceOrEvent, context) => updateList(sourceOrEvent, context)
+        );
+        const updateListDebounced = callEvenInterval(updateListForProgram, 500);
         const refresh = setInterval(() => {
             if (activeTransferCountRef.current > 0) {
                 diagnosticsRef.current.skippedActiveTransferRefreshCount += 1;
@@ -579,12 +1179,12 @@ export const Drop = () => {
             }
             updateListDebounced();
         }, 5000);
-        files.program.files.log.events.addEventListener("join", updateList);
-        files.program.files.log.events.addEventListener(
-            "leave",
-            updateListDebounced
-        );
+        program.files.log.events.addEventListener("join", updateListForProgram);
+        program.files.log.events.addEventListener("leave", updateListDebounced);
         const filesChangeListener = (event: Event) => {
+            if (!isContextCurrent()) {
+                return;
+            }
             diagnosticsRef.current.fileChangeEventCount += 1;
             if (!shouldRefreshRootListForFileChange(event)) {
                 diagnosticsRef.current.skippedChildFileChangeEventCount += 1;
@@ -598,131 +1198,223 @@ export const Drop = () => {
                     rootChange.added.length;
                 diagnosticsRef.current.rootChangeDirectRemoveCount +=
                     rootChange.removed.length;
+                rootListRevisionRef.current += 1;
+                const changedRemoteRootIds = recordExplicitRootChange(
+                    remoteRootReconciliationState,
+                    {
+                        removed: rootChange.removed,
+                        added: rootChange.added,
+                    }
+                );
+                for (const id of changedRemoteRootIds) {
+                    remoteRootConfirmationScheduler.forget(id);
+                }
                 const nextList = applyRootFileChangeToList(
                     listRef.current,
                     rootChange
                 );
                 setRootList(nextList);
+                for (const removed of rootChange.removed) {
+                    cancelPendingReadyResolver(removed.id);
+                }
+                for (const added of rootChange.added) {
+                    if (isLargeFileLike(added) && added.ready) {
+                        cancelPendingReadyResolver(added.id);
+                    } else {
+                        startPendingReadyResolver(added);
+                    }
+                }
+                setReplicationSet((current) => {
+                    const next = new Set(current);
+                    for (const removed of rootChange.removed) {
+                        next.delete(removed.id);
+                    }
+                    for (const added of rootChange.added) {
+                        next.add(added.id);
+                    }
+                    return next;
+                });
                 const readyLargeFileSignature =
                     getReadyLargeFileSignature(nextList);
                 if (readyLargeFileSignature) {
                     scheduleAdaptiveRefresh(
                         "ready-change:event",
-                        readyLargeFileSignature
+                        readyLargeFileSignature,
+                        refreshContext
                     );
                 }
                 forceUpdate();
+                diagnosticsRef.current.rootChangeAvoidedListRefreshCount += 1;
+                return;
             }
             updateListDebounced(event);
         };
 
-        files.program.files.events.addEventListener(
-            "change",
-            filesChangeListener
-        );
+        program.files.events.addEventListener("change", filesChangeListener);
 
         const replicatorsChangeListener = async () => {
             try {
-                setReplicatorCount(
-                    (await files.program.files.log.getReplicators()).size
-                );
+                const replicators = await program.files.log.getReplicators();
+                if (isContextCurrent()) {
+                    setReplicatorCount(replicators.size);
+                }
             } catch (error) {
-                console.warn(
-                    "Failed to refresh replicator count: " +
-                        (error instanceof Error ? error.message : String(error))
-                );
+                if (isContextCurrent()) {
+                    console.warn(
+                        "Failed to refresh replicator count: " +
+                            (error instanceof Error
+                                ? error.message
+                                : String(error))
+                    );
+                }
             }
 
             //  setCurrentRole(ev.detail.replicate); TODO this should be somewhere else
         };
 
-        files.program.files.log.events.addEventListener(
+        program.files.log.events.addEventListener(
             "replication:change",
             replicatorsChangeListener
         );
 
-        let onOpen = async () => {
+        const onOpen = async () => {
+            if (!isContextCurrent()) {
+                return;
+            }
             diagnosticsRef.current.onOpenStartedAt = Date.now();
 
-            const serializedRoleFromStorage = getRoleFromLocalStorage(
-                files.program
-            );
+            const serializedRoleFromStorage = getRoleFromLocalStorage(program);
             const hasStoredRole = serializedRoleFromStorage != null;
-            const roleFromLocalstore = parseStoredRole(
+            const desiredRole = getInitialReplicationRole(
                 serializedRoleFromStorage
             );
-            const desiredRole = hasStoredRole
-                ? roleFromLocalstore
-                : role === "replicator"
-                  ? DEFAULT_REPLICATION_ROLE
-                  : false;
 
-            files.program.persistChunkReads = desiredRole !== false;
+            program.persistChunkReads = desiredRole !== false;
+            currentRoleRef.current = desiredRole;
+            roleRevisionRef.current += 1;
+            if (desiredRole === false) {
+                pendingReadyResolver.cancelAll();
+            }
             setCurrentRole(desiredRole);
             setRole(desiredRole === false ? "observer" : "replicator");
-            void updateList("initial-open");
+            void updateListForProgram("initial-open");
 
             diagnosticsRef.current.trustCheckStartedAt = Date.now();
             const isTrusted =
-                !files.program.trustGraph ||
-                (await files.program.trustGraph.isTrusted(
-                    peer.identity.publicKey
-                ));
+                !program.trustGraph ||
+                (await program.trustGraph.isTrusted(peer.identity.publicKey));
+            if (!isContextCurrent()) {
+                return;
+            }
             diagnosticsRef.current.trustCheckFinishedAt = Date.now();
             setIsHost(isTrusted);
 
-            files.program = files.program;
             if (isTrusted && hasStoredRole) {
                 setLimitCPU(
-                    files.program.files.log["_roleOptions"]?.["limits"]?.["cpu"]
-                        ?.max
+                    program.files.log["_roleOptions"]?.["limits"]?.["cpu"]?.max
                 ); // TODO export types
                 const limitStorageLoaded =
-                    files.program.files.log["_roleOptions"]?.["limits"]?.memory;
+                    program.files.log["_roleOptions"]?.["limits"]?.storage;
                 setLimitStorage(limitStorageLoaded != null); // TODO export types
                 setLimitStorageString(
                     limitStorageLoaded != null
-                        ? String(limitStorageLoaded)
+                        ? formatFileShareStorageMegabytes(limitStorageLoaded)
                         : "0"
                 ); // TODO export types
             }
 
-            const replicators = await files.program.files.log.getReplicators();
-            setReplicatorCount(replicators.size);
+            const replicators = await program.files.log.getReplicators();
+            if (isContextCurrent()) {
+                setReplicatorCount(replicators.size);
+            }
         };
 
-        onOpen();
+        void onOpen().catch((error) => {
+            if (isContextCurrent()) {
+                console.warn(
+                    "Failed to initialize file-share view: " +
+                        (error instanceof Error ? error.message : String(error))
+                );
+            }
+        });
 
         return () => {
+            disposed = true;
+            pendingReadyResolver.cancelAll();
+            if (
+                pendingReadyResolverRef.current?.program === program &&
+                pendingReadyResolverRef.current.resolver ===
+                    pendingReadyResolver
+            ) {
+                pendingReadyResolverRef.current = null;
+            }
             clearInterval(refresh);
+            updateListDebounced.cancel();
+            remoteRootConfirmationScheduler.reset();
+            if (
+                remoteRootConfirmationSchedulerRef.current?.scheduler ===
+                remoteRootConfirmationScheduler
+            ) {
+                remoteRootConfirmationSchedulerRef.current = null;
+            }
+            if (
+                remoteRootReconciliationStateRef.current ===
+                remoteRootReconciliationState
+            ) {
+                remoteRootReconciliationStateRef.current =
+                    createRemoteRootReconciliationState();
+            }
+            listRefreshGenerationRef.current += 1;
+            listRefreshRef.current = null;
+            queuedListRefreshSourceRef.current = null;
+            if (
+                adaptiveRefreshRef.current?.generation ===
+                    refreshContext.generation &&
+                adaptiveRefreshRef.current.program === program
+            ) {
+                adaptiveRefreshRef.current = null;
+            }
+            if (
+                adaptiveRefreshSignatureRef.current?.generation ===
+                    refreshContext.generation &&
+                adaptiveRefreshSignatureRef.current.program === program
+            ) {
+                adaptiveRefreshSignatureRef.current = null;
+            }
 
-            files.program.files.log.events.removeEventListener(
+            program.files.log.events.removeEventListener(
                 "join",
-                updateList
+                updateListForProgram
             );
-            files.program.files.log.events.removeEventListener(
+            program.files.log.events.removeEventListener(
                 "leave",
                 updateListDebounced
             );
-            files.program.files.events.removeEventListener(
+            program.files.events.removeEventListener(
                 "change",
                 filesChangeListener
             );
-            files.program.files.log.events.removeEventListener(
+            program.files.log.events.removeEventListener(
                 "replication:change",
                 replicatorsChangeListener
             );
-            files.program.events.removeEventListener("open", onOpen);
         };
-    }, [files.program?.address, files.program?.closed]);
+    }, [files.program, files.program?.closed]);
 
-    const updateList = async (sourceOrEvent: string | Event = "refresh") => {
-        if (files.program.files.log.closed) {
+    const refreshList = async (
+        source: string,
+        generation: number,
+        program: Files
+    ) => {
+        const refreshContext = { generation, program };
+        const isContextCurrent = createRefreshContextGuard(
+            getCurrentRefreshContext,
+            refreshContext
+        );
+        if (program.files.log.closed || !isContextCurrent()) {
             return;
         }
 
-        const source =
-            typeof sourceOrEvent === "string" ? sourceOrEvent : "event";
         const benchmarkWindow = window as Window & {
             __peerbitFileShareBenchmarkStats?: {
                 updateListCalls?: Array<Record<string, unknown>>;
@@ -732,6 +1424,77 @@ export const Drop = () => {
         const updateListStats: Record<string, unknown> = {
             source,
             startedAt: Date.now(),
+        };
+        const remoteRootReconciliationState =
+            remoteRootReconciliationStateRef.current;
+        const scheduleRemoteRootConfirmations = (
+            ids: Iterable<string>,
+            rateLimited: boolean
+        ) => {
+            const confirmationScheduler =
+                remoteRootConfirmationSchedulerRef.current;
+            if (
+                confirmationScheduler?.generation !== generation ||
+                confirmationScheduler.program !== program
+            ) {
+                return;
+            }
+            let run = activeTransferCountRef.current === 0;
+            if (run && rateLimited) {
+                const now = Date.now();
+                const lastStartedAt =
+                    remoteRootConfirmationRunStartedAtRef.current;
+                run =
+                    lastStartedAt == null ||
+                    now - lastStartedAt >=
+                        REMOTE_ROOT_RECONCILIATION_INTERVAL_MS;
+                if (run) {
+                    remoteRootConfirmationRunStartedAtRef.current = now;
+                }
+            }
+            void confirmationScheduler.scheduler
+                .schedule(
+                    ids,
+                    {
+                        generation,
+                        program,
+                        rootRevision: rootListRevisionRef.current,
+                    },
+                    run
+                )
+                .catch((error) => {
+                    if (isContextCurrent()) {
+                        console.warn(
+                            "Failed to confirm remote roots: " +
+                                (error instanceof Error
+                                    ? error.message
+                                    : String(error))
+                        );
+                    }
+                });
+        };
+        const listLocalRootMetadata = () =>
+            program.files.index.search(
+                new SearchRequest({
+                    query: new IsNull({ key: "parentId" }),
+                    fetch: 0xffffffff,
+                }),
+                {
+                    local: true,
+                    remote: false,
+                }
+            );
+        const queueRefreshAfterStaleRootRevision = () => {
+            diagnosticsRef.current.staleListResultIgnoredCount += 1;
+            updateListStats.staleListResultIgnored = true;
+            updateListStats.displayListCount = listRef.current.length;
+            queueCoalescedRefresh(
+                queuedListRefreshSourceRef,
+                coalesceRootListRefreshSource(
+                    queuedListRefreshSourceRef.current,
+                    "stale-root-revision"
+                )
+            );
         };
 
         // TODO don't reload the whole list, just add the new elements..
@@ -743,9 +1506,31 @@ export const Drop = () => {
                 diagnosticsRef.current.firstListSource = source;
             }
             const listStartedAt = performance.now();
-            const list = await files.program.list();
+            const rootListRevision = rootListRevisionRef.current;
+            const listRole = currentRoleRef.current;
+            const [list, observerLocalRootFiles] = await Promise.all([
+                listRootFilesForRole(program, listRole),
+                listRole === false
+                    ? listLocalRootMetadata().catch((error) => {
+                          if (isContextCurrent()) {
+                              console.warn(
+                                  "Failed to distinguish local observer roots: " +
+                                      (error instanceof Error
+                                          ? error.message
+                                          : String(error))
+                              );
+                          }
+                          return undefined;
+                      })
+                    : Promise.resolve(undefined),
+            ]);
             updateListStats.listMs = performance.now() - listStartedAt;
             updateListStats.listCount = list.length;
+            updateListStats.listMode =
+                listRole === false ? "observer-remote" : "replicator-local";
+            if (!isContextCurrent()) {
+                return;
+            }
             const finishedAt = Date.now();
             if (diagnosticsRef.current.firstListFinishedAt == null) {
                 diagnosticsRef.current.firstListFinishedAt = finishedAt;
@@ -755,79 +1540,296 @@ export const Drop = () => {
             const rootFiles = sortRootFilesForDisplay(
                 list.filter((x) => !x.parentId)
             );
-            const displayRootFiles = applyRootFileChangeToList(
-                listRef.current,
-                { added: rootFiles, removed: [] }
-            );
-            updateListStats.displayListCount = displayRootFiles.length;
-            setRootList(displayRootFiles);
-            const readyLargeFileSignature =
-                getReadyLargeFileSignature(displayRootFiles);
-            if (readyLargeFileSignature) {
-                scheduleAdaptiveRefresh(
-                    `ready-list:${source}`,
-                    readyLargeFileSignature
-                );
-            }
-            forceUpdate();
-            void (async () => {
-                try {
-                    const metadataStartedAt = performance.now();
-                    const [allFiles, replicators] = await Promise.all([
-                        files.program.files.index.search(
-                            new SearchRequest({}),
-                            { local: true, remote: false }
-                        ),
-                        files.program.files.log.getReplicators(),
-                    ]);
-                    updateListStats.metadataMs =
-                        performance.now() - metadataStartedAt;
-                    updateListStats.replicationSetSize = allFiles.length;
-                    updateListStats.replicatorCount = replicators.size;
-                    updateListStats.totalMs =
-                        performance.now() - updateListStartedAt;
-                    const updateListCalls =
-                        benchmarkWindow.__peerbitFileShareBenchmarkStats
-                            ?.updateListCalls ?? [];
-                    updateListCalls.push(updateListStats);
-                    benchmarkWindow.__peerbitFileShareBenchmarkStats = {
-                        updateListCalls,
-                    };
-                    setReplicationSet(new Set(allFiles.map((x) => x.id)));
-                    setReplicatorCount(replicators.size);
-                    if (
-                        diagnosticsRef.current.firstMetadataRefreshFinishedAt ==
-                        null
-                    ) {
-                        diagnosticsRef.current.firstMetadataRefreshFinishedAt =
-                            Date.now();
+            if (rootListRevision === rootListRevisionRef.current) {
+                let observerRemoteRootObservation:
+                    | ReturnType<typeof observeRemoteRootSnapshot>
+                    | undefined;
+                const visibleRootFiles = (() => {
+                    if (listRole !== false) {
+                        return observeLocalRootSnapshot(
+                            remoteRootReconciliationState,
+                            rootFiles
+                        );
                     }
-                    forceUpdate();
-                } catch (error) {
-                    console.warn(
-                        "Failed to refresh replication metadata: " +
-                            error?.message
+                    if (observerLocalRootFiles == null) {
+                        return rootFiles.filter(
+                            (file) =>
+                                !remoteRootReconciliationState.suppressedIds.has(
+                                    file.id
+                                )
+                        );
+                    }
+                    observeLocalRootSnapshot(
+                        remoteRootReconciliationState,
+                        observerLocalRootFiles ?? []
+                    );
+                    observerRemoteRootObservation = observeRemoteRootSnapshot(
+                        remoteRootReconciliationState,
+                        rootFiles
+                    );
+                    const confirmationScheduler =
+                        remoteRootConfirmationSchedulerRef.current;
+                    if (
+                        confirmationScheduler?.generation === generation &&
+                        confirmationScheduler.program === program
+                    ) {
+                        invalidateRemoteRootAbsenceForVisibleRoots(
+                            confirmationScheduler.scheduler,
+                            observerRemoteRootObservation.visibleRoots
+                        );
+                    }
+                    return observerRemoteRootObservation.visibleRoots;
+                })();
+                const displayRootFiles = applyRootFileChangeToList(
+                    listRef.current,
+                    { added: visibleRootFiles, removed: [] }
+                );
+                updateListStats.displayListCount = displayRootFiles.length;
+                setRootList(displayRootFiles);
+                reconcilePendingReadyRoots(
+                    program,
+                    refreshContext,
+                    displayRootFiles
+                );
+                const readyLargeFileSignature =
+                    getReadyLargeFileSignature(displayRootFiles);
+                if (readyLargeFileSignature) {
+                    scheduleAdaptiveRefresh(
+                        `ready-list:${source}`,
+                        readyLargeFileSignature,
+                        refreshContext
                     );
                 }
-            })();
+                forceUpdate();
+                if (observerRemoteRootObservation) {
+                    scheduleRemoteRootConfirmations(
+                        observerRemoteRootObservation.confirmationIds,
+                        true
+                    );
+                }
+            } else {
+                queueRefreshAfterStaleRootRevision();
+                return;
+            }
+            const remoteReconciliationStartedAt = Date.now();
+            if (
+                shouldReconcileRemoteRootFiles({
+                    role: listRole,
+                    source,
+                    now: remoteReconciliationStartedAt,
+                    lastStartedAt: remoteRootReconciliationStartedAtRef.current,
+                })
+            ) {
+                remoteRootReconciliationStartedAtRef.current =
+                    remoteReconciliationStartedAt;
+                const remoteRootListRevision = rootListRevisionRef.current;
+                const remoteListStartedAt = performance.now();
+                try {
+                    const remoteList =
+                        await listRemoteRootFilesForReconciliation(program);
+                    updateListStats.remoteReconciliationMs =
+                        performance.now() - remoteListStartedAt;
+                    updateListStats.remoteReconciliationCount =
+                        remoteList.length;
+                    updateListStats.remoteReconciliationMode =
+                        "partial-remote-merge";
+                    if (!isContextCurrent()) {
+                        return;
+                    }
+                    if (
+                        remoteRootListRevision !== rootListRevisionRef.current
+                    ) {
+                        queueRefreshAfterStaleRootRevision();
+                        return;
+                    }
+                    const remoteRootFiles = sortRootFilesForDisplay(
+                        remoteList.filter((file) => !file.parentId)
+                    );
+                    const remoteRootObservation = observeRemoteRootSnapshot(
+                        remoteRootReconciliationState,
+                        remoteRootFiles
+                    );
+                    const confirmationScheduler =
+                        remoteRootConfirmationSchedulerRef.current;
+                    if (
+                        confirmationScheduler?.generation === generation &&
+                        confirmationScheduler.program === program
+                    ) {
+                        invalidateRemoteRootAbsenceForVisibleRoots(
+                            confirmationScheduler.scheduler,
+                            remoteRootObservation.visibleRoots
+                        );
+                    }
+                    const displayRootFiles = applyRootFileChangeToList(
+                        listRef.current,
+                        {
+                            added: remoteRootObservation.visibleRoots,
+                            removed: [],
+                        }
+                    );
+                    updateListStats.displayListCount = displayRootFiles.length;
+                    setRootList(displayRootFiles);
+                    reconcilePendingReadyRoots(
+                        program,
+                        refreshContext,
+                        displayRootFiles
+                    );
+                    const readyLargeFileSignature =
+                        getReadyLargeFileSignature(displayRootFiles);
+                    if (readyLargeFileSignature) {
+                        scheduleAdaptiveRefresh(
+                            `ready-remote-list:${source}`,
+                            readyLargeFileSignature,
+                            refreshContext
+                        );
+                    }
+                    forceUpdate();
+                    scheduleRemoteRootConfirmations(
+                        remoteRootObservation.confirmationIds,
+                        false
+                    );
+                } catch (error) {
+                    if (isContextCurrent()) {
+                        updateListStats.remoteReconciliationError =
+                            error instanceof Error
+                                ? error.message
+                                : String(error);
+                        console.warn(
+                            "Failed to reconcile remote root list: " +
+                                (error instanceof Error
+                                    ? error.message
+                                    : String(error))
+                        );
+                    }
+                }
+            }
+            try {
+                const metadataStartedAt = performance.now();
+                const [localRootFiles, replicators] = await Promise.all([
+                    observerLocalRootFiles ?? listLocalRootMetadata(),
+                    program.files.log.getReplicators(),
+                ]);
+                if (!isContextCurrent()) {
+                    return;
+                }
+                updateListStats.metadataMs =
+                    performance.now() - metadataStartedAt;
+                updateListStats.replicationSetSize = localRootFiles.length;
+                updateListStats.replicatorCount = replicators.size;
+                updateListStats.totalMs =
+                    performance.now() - updateListStartedAt;
+                const updateListCalls =
+                    benchmarkWindow.__peerbitFileShareBenchmarkStats
+                        ?.updateListCalls ?? [];
+                updateListCalls.push(updateListStats);
+                benchmarkWindow.__peerbitFileShareBenchmarkStats = {
+                    updateListCalls,
+                };
+                setReplicationSet(
+                    new Set(localRootFiles.map((file) => file.id))
+                );
+                setReplicatorCount(replicators.size);
+                if (
+                    diagnosticsRef.current.firstMetadataRefreshFinishedAt ==
+                    null
+                ) {
+                    diagnosticsRef.current.firstMetadataRefreshFinishedAt =
+                        Date.now();
+                }
+                forceUpdate();
+            } catch (error) {
+                if (isContextCurrent()) {
+                    console.warn(
+                        "Failed to refresh replication metadata: " +
+                            (error instanceof Error
+                                ? error.message
+                                : String(error))
+                    );
+                }
+            }
         } catch (error) {
-            console.warn(
-                "Failed to resolve complete file list: " + error?.message
-            );
+            if (isContextCurrent()) {
+                console.warn(
+                    "Failed to resolve complete file list: " +
+                        (error instanceof Error ? error.message : String(error))
+                );
+            }
         }
+    };
+
+    const updateList = (
+        sourceOrEvent: string | Event = "refresh",
+        context?: RefreshContext<Files>
+    ) => {
+        const program = context?.program ?? files.program;
+        const generation =
+            context?.generation ?? listRefreshGenerationRef.current;
+        const refreshContext = program ? { generation, program } : undefined;
+        const isContextCurrent = refreshContext
+            ? createRefreshContextGuard(
+                  getCurrentRefreshContext,
+                  refreshContext
+              )
+            : () => false;
+        if (!program || program.files.log.closed || !isContextCurrent()) {
+            return Promise.resolve();
+        }
+
+        const source = getRootListRefreshSource(sourceOrEvent);
+        queueCoalescedRefresh(
+            queuedListRefreshSourceRef,
+            coalesceRootListRefreshSource(
+                queuedListRefreshSourceRef.current,
+                source
+            )
+        );
+        if (listRefreshRef.current) {
+            diagnosticsRef.current.coalescedListRefreshCount += 1;
+            diagnosticsRef.current.lastCoalescedListSource = source;
+            return listRefreshRef.current;
+        }
+
+        const refresh = (async () => {
+            diagnosticsRef.current.listRefreshInFlight = true;
+            try {
+                await drainCoalescedRefreshQueue(
+                    queuedListRefreshSourceRef,
+                    isContextCurrent,
+                    (queuedSource) =>
+                        refreshList(queuedSource, generation, program)
+                );
+            } finally {
+                if (listRefreshRef.current === refresh) {
+                    listRefreshRef.current = null;
+                }
+                if (isContextCurrent()) {
+                    diagnosticsRef.current.listRefreshInFlight = false;
+                }
+            }
+        })();
+        listRefreshRef.current = refresh;
+        return refresh;
     };
 
     const download = async (
         file: AbstractFile,
         progress: (progress: number | null) => void
     ) => {
+        const program = files.program;
+        if (!program || program.closed) {
+            progress(null);
+            return;
+        }
         const timeout = getDownloadTimeout(file);
         startActiveTransfer();
         try {
             if (isLargeFileLike(file)) {
-                files.program?.retainFileRead(file);
+                program.retainFileRead(file);
             }
-            scheduleAdaptiveRefresh("download-start");
+
+            // Do not change the replication role around a download. Switching a
+            // live reader to observer mode can detach the fanout route that a
+            // partially-local file still needs for its missing chunk queries.
 
             const saveFilePicker = (window as SaveFilePickerWindow)
                 .showSaveFilePicker;
@@ -846,7 +1848,7 @@ export const Drop = () => {
                 });
                 if (handle) {
                     const writable = await handle.createWritable();
-                    await file.writeFile(files.program, writable, {
+                    await file.writeFile(program, writable, {
                         timeout,
                         progress: (value) => {
                             progress(value);
@@ -857,7 +1859,7 @@ export const Drop = () => {
                 return;
             }
 
-            const bytes = await file.getFile(files.program, {
+            const bytes = await file.getFile(program, {
                 as: "chunks",
                 timeout,
                 progress,
@@ -873,8 +1875,14 @@ export const Drop = () => {
             }, 60_000);
         } finally {
             finishActiveTransfer();
+            scheduleAdaptiveRefresh("download-finished");
             progress(null);
         }
+    };
+
+    const reportUploadFailure = (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        alert("Failed to upload: " + message);
     };
 
     function dropHandler(ev) {
@@ -906,22 +1914,28 @@ export const Drop = () => {
                 promises.push(addFile([file], false));
             });
         }
-        Promise.all(promises).finally(() => {
-            setUploadProgress(null);
-        });
+        void settleUploadBatch(promises, reportUploadFailure)
+            .finally(() => {
+                setUploadProgress(null);
+            })
+            .catch((error) => {
+                console.warn("Failed to finish upload batch", error);
+            });
     }
 
-    const addFile = (filesToAdd: FileList | File[], endProgress = true) => {
-        return new Promise<void>((resolve, reject) => {
-            let promises: Promise<any>[] = [];
-            const transferStarted = filesToAdd.length > 0;
-            if (transferStarted) {
-                startActiveTransfer();
-            }
+    const addFile = async (
+        filesToAdd: FileList | File[] | null | undefined,
+        endProgress = true
+    ) => {
+        const uploadFiles = filesToAdd ? [...filesToAdd] : [];
+        const transferStarted = uploadFiles.length > 0;
+        if (transferStarted) {
+            startActiveTransfer();
+        }
 
-            // there will just by one file here in practice
-            for (const file of filesToAdd) {
-                promises.push(
+        try {
+            await Promise.all(
+                uploadFiles.map((file) =>
                     files.program.addBlob(
                         file.name,
                         file,
@@ -934,29 +1948,18 @@ export const Drop = () => {
                             );
                         }
                     )
-                );
+                )
+            );
+            scheduleAdaptiveRefresh("upload-complete");
+            void updateList();
+        } finally {
+            if (endProgress) {
+                setUploadProgress(null);
             }
-
-            if (promises.length === filesToAdd.length) {
-                Promise.all(promises)
-                    .then(async () => {
-                        scheduleAdaptiveRefresh("upload-complete");
-                        if (endProgress) {
-                            setUploadProgress(null);
-                        }
-                        updateList();
-                        resolve();
-                    })
-                    .catch((e) => {
-                        reject(e);
-                    })
-                    .finally(() => {
-                        if (transferStarted) {
-                            finishActiveTransfer();
-                        }
-                    });
+            if (transferStarted) {
+                finishActiveTransfer();
             }
-        });
+        }
     };
 
     const goBack = () => (
@@ -1030,7 +2033,9 @@ export const Drop = () => {
                                             data-testid="upload-input"
                                             className="hidden"
                                             onChange={(e) => {
-                                                addFile(e.target?.files);
+                                                void addFile(
+                                                    e.target?.files
+                                                ).catch(reportUploadFailure);
                                             }}
                                         />
                                         <button
@@ -1053,7 +2058,7 @@ export const Drop = () => {
                             <Toggle.Root
                                 data-testid="seed-toggle"
                                 onPressedChange={(e) => {
-                                    setRole(e ? "replicator" : "observer");
+                                    selectRole(e ? "replicator" : "observer");
                                 }}
                                 disabled={!files.program}
                                 pressed={role === "replicator"}
@@ -1093,7 +2098,7 @@ export const Drop = () => {
                                                     className="SwitchRoot"
                                                     id="seed"
                                                     onCheckedChange={(e) => {
-                                                        setRole(
+                                                        selectRole(
                                                             e
                                                                 ? "replicator"
                                                                 : "observer"
@@ -1312,9 +2317,9 @@ export const Drop = () => {
                                     Files ({list.length}):
                                 </h1>
                                 <ul data-testid="file-list">
-                                    {list.map((x, ix) => {
+                                    {list.map((x) => {
                                         return (
-                                            <li key={ix}>
+                                            <li key={x.id}>
                                                 <File
                                                     isHost={isHost}
                                                     delete={() => {

--- a/packages/file-share/frontend/src/File.tsx
+++ b/packages/file-share/frontend/src/File.tsx
@@ -1,11 +1,6 @@
-import {
-    IndexableFile,
-    LargeFile,
-    TinyFile,
-    isLargeFileLike,
-} from "@peerbit/please-lib";
+import { IndexableFile, TinyFile, isLargeFileLike } from "@peerbit/please-lib";
 import { Files, AbstractFile } from "@peerbit/please-lib";
-import { useEffect, useReducer, useState } from "react";
+import { useEffect, useState } from "react";
 import { FaSeedling } from "react-icons/fa";
 import { MdDeleteForever, MdDownload } from "react-icons/md";
 import { DocumentsChange } from "@peerbit/document";
@@ -13,9 +8,24 @@ import { DocumentsChange } from "@peerbit/document";
 const formatFileSize = (size: number | bigint) =>
     `${Math.round(Number(size) / 1000)} kb`;
 
+export const formatIndexedChunkRatio = (ratio: number) => `${ratio}% indexed`;
+
+const LOCAL_CHUNK_COUNT_REFRESH_DELAY_MS = 250;
+
 export const shouldDisableFileDownload = (properties: {
     progress: number | null;
 }) => properties.progress != null;
+
+export const hasFileChunkChange = (
+    detail: {
+        added?: AbstractFile[];
+        removed?: Pick<IndexableFile, "parentId">[];
+    },
+    fileId: string
+) =>
+    (detail.added ?? []).some(
+        (added) => added instanceof TinyFile && added.parentId === fileId
+    ) || (detail.removed ?? []).some((removed) => removed.parentId === fileId);
 
 export const File = (properties: {
     files: Files;
@@ -37,47 +47,89 @@ export const File = (properties: {
     });
 
     useEffect(() => {
-        if (!properties.files) {
+        if (!properties.files || !largeFile || !properties.replicated) {
+            setReplicatedChunksRatio(0);
             return;
         }
 
-        let fetchLocalChunks = () =>
-            properties.files
-                .countLocalChunks(properties.file as LargeFile)
-                .then((count) => {
-                    largeFile &&
-                        setReplicatedChunksRatio(
-                            Math.round((count * 100) / Math.max(chunkCount, 1))
-                        );
-                });
-        let changeListener = largeFile
-            ? (
-                  e: CustomEvent<DocumentsChange<AbstractFile, IndexableFile>>
-              ) => {
-                  for (const added of e.detail.added) {
-                      if (
-                          added instanceof TinyFile &&
-                          added.parentId === properties.file.id
-                      ) {
-                          fetchLocalChunks();
-                      }
-                  }
-              }
-            : undefined;
+        let disposed = false;
+        let refreshTimer: ReturnType<typeof setTimeout> | undefined;
+        let refreshInFlight = false;
+        let refreshQueued = false;
 
-        changeListener &&
-            properties.files.files.events.addEventListener(
-                "change",
-                changeListener
-            );
-        fetchLocalChunks();
-        return () =>
-            changeListener &&
+        const fetchLocalChunks = async () => {
+            refreshTimer = undefined;
+            if (disposed || refreshInFlight) {
+                return;
+            }
+            refreshInFlight = true;
+            refreshQueued = false;
+            try {
+                const count =
+                    await properties.files.countLocalChunks(largeFile);
+                if (!disposed) {
+                    setReplicatedChunksRatio(
+                        Math.round((count * 100) / Math.max(chunkCount, 1))
+                    );
+                }
+            } catch (error) {
+                if (!disposed) {
+                    console.warn(
+                        "Failed to count local chunks for " +
+                            properties.file.name +
+                            ": " +
+                            (error instanceof Error
+                                ? error.message
+                                : String(error))
+                    );
+                }
+            } finally {
+                refreshInFlight = false;
+                if (refreshQueued && !disposed) {
+                    scheduleLocalChunkCountRefresh();
+                }
+            }
+        };
+
+        const scheduleLocalChunkCountRefresh = () => {
+            refreshQueued = true;
+            if (disposed || refreshInFlight || refreshTimer) {
+                return;
+            }
+            refreshTimer = setTimeout(() => {
+                void fetchLocalChunks();
+            }, LOCAL_CHUNK_COUNT_REFRESH_DELAY_MS);
+        };
+
+        const changeListener = (
+            event: CustomEvent<DocumentsChange<AbstractFile, IndexableFile>>
+        ) => {
+            if (hasFileChunkChange(event.detail, properties.file.id)) {
+                scheduleLocalChunkCountRefresh();
+            }
+        };
+
+        properties.files.files.events.addEventListener(
+            "change",
+            changeListener
+        );
+        void fetchLocalChunks();
+        return () => {
+            disposed = true;
+            if (refreshTimer) {
+                clearTimeout(refreshTimer);
+            }
             properties.files.files.events.removeEventListener(
                 "change",
                 changeListener
             );
-    }, [properties.files.address, properties.file.id]);
+        };
+    }, [
+        properties.files,
+        properties.file.id,
+        properties.replicated,
+        chunkCount,
+    ]);
 
     return (
         <div className="flex flex-row items-center gap-3 mb-3">
@@ -100,8 +152,11 @@ export const File = (properties: {
 
                     {replicatedChunksRatio > 0 && (
                         <div className="ml-[-5px] mt-[-15px]">
-                            <span className="text-xs bg-green-400 rounded-full p-[2px] leading-[5px] !text-black">
-                                {replicatedChunksRatio}%
+                            <span
+                                title="Indexed locally; payload availability is verified when the file is read"
+                                className="text-xs bg-green-400 rounded-full p-[2px] leading-[5px] !text-black"
+                            >
+                                {formatIndexedChunkRatio(replicatedChunksRatio)}
                             </span>
                         </div>
                     )}
@@ -138,7 +193,6 @@ export const File = (properties: {
                                     ". " +
                                     error.message?.toString()
                             );
-                            throw error;
                         });
                 }}
                 className={`flex flex-row border border-1 items-center p-2 btn btn-elevated`}

--- a/packages/file-share/frontend/src/app-connection.ts
+++ b/packages/file-share/frontend/src/app-connection.ts
@@ -1,0 +1,72 @@
+export type PeerOverrideAction =
+    | "wait-for-peer"
+    | "ready-without-explicit-dial"
+    | "dial-explicit-peers";
+
+export type PeerDialStatus = "pending" | "fulfilled" | "rejected";
+export type PeerDialOutcome = "pending" | "ready" | "failed";
+
+export type PeerHintSource = "peer" | "bootstrap" | null;
+
+export type PeerAddressConfiguration = {
+    source: PeerHintSource;
+    peers: string[] | undefined;
+};
+
+const getHashSearchParams = (url: URL) => {
+    const queryIndex = url.hash.indexOf("?");
+    return queryIndex === -1
+        ? new URLSearchParams()
+        : new URLSearchParams(url.hash.slice(queryIndex + 1));
+};
+
+export const getPeerAddressConfiguration = (
+    href: string
+): PeerAddressConfiguration => {
+    const url = new URL(href);
+    const hashParams = getHashSearchParams(url);
+    const peer = url.searchParams.get("peer") ?? hashParams.get("peer");
+    const bootstrap =
+        url.searchParams.get("bootstrap") ?? hashParams.get("bootstrap");
+    const value = peer ?? bootstrap;
+    const source: PeerHintSource =
+        peer != null ? "peer" : bootstrap != null ? "bootstrap" : null;
+    if (value == null) {
+        return { source, peers: undefined };
+    }
+
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "" || normalized === "offline") {
+        return { source, peers: [] };
+    }
+    return {
+        source,
+        peers: value
+            .split(",")
+            .map((address) => address.trim())
+            .filter(Boolean),
+    };
+};
+
+export const getPeerOverrideAction = (
+    peerAvailable: boolean,
+    peers: readonly string[] | undefined
+): PeerOverrideAction => {
+    if (!peerAvailable) {
+        return "wait-for-peer";
+    }
+    return peers != null && peers.length > 0
+        ? "dial-explicit-peers"
+        : "ready-without-explicit-dial";
+};
+
+export const getPeerDialOutcome = (
+    results: readonly { status: PeerDialStatus }[]
+): PeerDialOutcome => {
+    if (results.some((result) => result.status === "pending")) {
+        return "pending";
+    }
+    return results.some((result) => result.status === "fulfilled")
+        ? "ready"
+        : "failed";
+};

--- a/packages/file-share/frontend/src/file-list-loader.ts
+++ b/packages/file-share/frontend/src/file-list-loader.ts
@@ -1,0 +1,88 @@
+import { IsNull, SearchRequest } from "@peerbit/document";
+import type { Files } from "@peerbit/please-lib";
+import type { ReplicationOptions } from "@peerbit/shared-log";
+
+export const REMOTE_ROOT_RECONCILIATION_INTERVAL_MS = 30_000;
+
+const createRootSearchRequest = () =>
+    new SearchRequest({
+        query: new IsNull({ key: "parentId" }),
+        fetch: 0xffffffff,
+    });
+
+export const getRootListRefreshSource = (
+    sourceOrEvent?: string | Pick<Event, "type">
+) => {
+    if (typeof sourceOrEvent === "string") {
+        return sourceOrEvent;
+    }
+    if (sourceOrEvent == null) {
+        return "refresh";
+    }
+    return sourceOrEvent.type || "event";
+};
+
+const isImmediateRemoteReconciliationSource = (source: string) =>
+    source === "initial-open" || source === "join" || source === "role-change";
+
+export const coalesceRootListRefreshSource = (
+    current: string | null,
+    next: string
+) => {
+    if (
+        current != null &&
+        isImmediateRemoteReconciliationSource(current) &&
+        !isImmediateRemoteReconciliationSource(next)
+    ) {
+        return current;
+    }
+    return next;
+};
+
+export const listRootFilesForRole = (
+    program: Files,
+    role: ReplicationOptions
+) => {
+    if (role === false) {
+        return program.list();
+    }
+    return program.files.index.search(createRootSearchRequest(), {
+        local: true,
+        remote: false,
+    });
+};
+
+export const listRemoteRootFilesForReconciliation = async (program: Files) => {
+    const from = await program.getReadPeerHints();
+    return program.files.index.search(createRootSearchRequest(), {
+        local: false,
+        remote: {
+            throwOnMissing: false,
+            replicate: false,
+            from,
+        },
+    } as any);
+};
+
+export const shouldReconcileRemoteRootFiles = (properties: {
+    role: ReplicationOptions;
+    source: string;
+    now: number;
+    lastStartedAt: number | null;
+    intervalMs?: number;
+}) => {
+    if (properties.role === false) {
+        return false;
+    }
+    if (isImmediateRemoteReconciliationSource(properties.source)) {
+        return true;
+    }
+    if (properties.source !== "refresh") {
+        return false;
+    }
+    return (
+        properties.lastStartedAt == null ||
+        properties.now - properties.lastStartedAt >=
+            (properties.intervalMs ?? REMOTE_ROOT_RECONCILIATION_INTERVAL_MS)
+    );
+};

--- a/packages/file-share/frontend/src/pending-ready-resolver.ts
+++ b/packages/file-share/frontend/src/pending-ready-resolver.ts
@@ -1,0 +1,298 @@
+import {
+    type AbstractFile,
+    type Files,
+    isLargeFileLike,
+} from "@peerbit/please-lib";
+
+type PendingReadyResolverOptions<TProgram, TValue> = {
+    attemptTimeoutMs?: number;
+    expiryCooldownMs?: number;
+    maxEntries?: number;
+    maxLifetimeMs?: number;
+    retryDelayMs?: number;
+    resolve: (
+        key: string,
+        program: TProgram,
+        signal: AbortSignal,
+        attemptTimeoutMs: number
+    ) => Promise<TValue | undefined>;
+    isActive: (key: string, program: TProgram) => boolean;
+    onReady: (key: string, program: TProgram, value: TValue) => void;
+    onError?: (key: string, program: TProgram, error: unknown) => void;
+    onExpired?: (key: string, program: TProgram) => void;
+};
+
+type PendingTask<TProgram> = {
+    program: TProgram;
+    controller: AbortController;
+    promise: Promise<void>;
+};
+
+export type PendingReadyStartResult =
+    | { status: "started"; promise: Promise<void> }
+    | { status: "existing"; promise: Promise<void> }
+    | { status: "cooldown"; reason: "expired"; retryAt: number }
+    | { status: "capacity"; activeCount: number; maxEntries: number };
+
+export type PendingReadyResolver<TProgram> = {
+    readonly size: number;
+    readonly cooldownSize: number;
+    start(key: string, program: TProgram): PendingReadyStartResult;
+    cancel(key: string, program?: TProgram): boolean;
+    cancelProgram(program: TProgram): number;
+    cancelAll(): number;
+};
+
+const waitForRetry = (delayMs: number, signal: AbortSignal) =>
+    new Promise<void>((resolve) => {
+        if (signal.aborted || delayMs <= 0) {
+            resolve();
+            return;
+        }
+        const finish = () => {
+            clearTimeout(timer);
+            signal.removeEventListener("abort", finish);
+            resolve();
+        };
+        const timer = setTimeout(finish, delayMs);
+        signal.addEventListener("abort", finish, { once: true });
+    });
+
+export const createPendingReadyResolver = <TProgram, TValue>(
+    options: PendingReadyResolverOptions<TProgram, TValue>
+): PendingReadyResolver<TProgram> => {
+    const attemptTimeoutMs = options.attemptTimeoutMs ?? 1_500;
+    const maxEntries = Math.max(1, options.maxEntries ?? 64);
+    const maxLifetimeMs = Math.max(1, options.maxLifetimeMs ?? 5 * 60_000);
+    const retryDelayMs = Math.max(0, options.retryDelayMs ?? 350);
+    const expiryCooldownMs = Math.max(
+        0,
+        options.expiryCooldownMs ?? maxLifetimeMs
+    );
+    const tasks = new Map<TProgram, Map<string, PendingTask<TProgram>>>();
+    const cooldowns = new Map<TProgram, Map<string, number>>();
+    let taskCount = 0;
+
+    const deleteTask = (
+        key: string,
+        program: TProgram,
+        expected?: PendingTask<TProgram>
+    ) => {
+        const programTasks = tasks.get(program);
+        const task = programTasks?.get(key);
+        if (!task || (expected && task !== expected)) {
+            return undefined;
+        }
+        programTasks!.delete(key);
+        taskCount -= 1;
+        if (programTasks!.size === 0) {
+            tasks.delete(program);
+        }
+        return task;
+    };
+
+    const clearCooldown = (key: string, program: TProgram) => {
+        const programCooldowns = cooldowns.get(program);
+        const cleared = programCooldowns?.delete(key) ?? false;
+        if (programCooldowns?.size === 0) {
+            cooldowns.delete(program);
+        }
+        return cleared;
+    };
+
+    const pruneExpiredCooldowns = (now = Date.now()) => {
+        for (const [program, programCooldowns] of cooldowns) {
+            for (const [key, retryAt] of programCooldowns) {
+                if (now >= retryAt) {
+                    programCooldowns.delete(key);
+                }
+            }
+            if (programCooldowns.size === 0) {
+                cooldowns.delete(program);
+            }
+        }
+    };
+
+    const cancel = (key: string, program?: TProgram) => {
+        let cleared = false;
+        if (program != null) {
+            const task = deleteTask(key, program);
+            if (task) {
+                task.controller.abort();
+                cleared = true;
+            }
+            return clearCooldown(key, program) || cleared;
+        }
+        for (const targetProgram of new Set([
+            ...tasks.keys(),
+            ...cooldowns.keys(),
+        ])) {
+            const task = deleteTask(key, targetProgram);
+            if (task) {
+                task.controller.abort();
+                cleared = true;
+            }
+            cleared = clearCooldown(key, targetProgram) || cleared;
+        }
+        return cleared;
+    };
+
+    const start = (key: string, program: TProgram) => {
+        const now = Date.now();
+        pruneExpiredCooldowns(now);
+        const existing = tasks.get(program)?.get(key);
+        if (existing) {
+            return { status: "existing", promise: existing.promise } as const;
+        }
+        const retryAt = cooldowns.get(program)?.get(key);
+        if (retryAt != null) {
+            return {
+                status: "cooldown",
+                reason: "expired",
+                retryAt,
+            } as const;
+        }
+        if (taskCount >= maxEntries) {
+            return {
+                status: "capacity",
+                activeCount: taskCount,
+                maxEntries,
+            } as const;
+        }
+
+        const controller = new AbortController();
+        const task: PendingTask<TProgram> = {
+            program,
+            controller,
+            promise: Promise.resolve(),
+        };
+        let programTasks = tasks.get(program);
+        if (!programTasks) {
+            programTasks = new Map();
+            tasks.set(program, programTasks);
+        }
+        programTasks.set(key, task);
+        taskCount += 1;
+        const startedAt = now;
+        task.promise = (async () => {
+            try {
+                while (
+                    !controller.signal.aborted &&
+                    options.isActive(key, program)
+                ) {
+                    if (Date.now() - startedAt >= maxLifetimeMs) {
+                        if (expiryCooldownMs > 0) {
+                            let programCooldowns = cooldowns.get(program);
+                            if (!programCooldowns) {
+                                programCooldowns = new Map();
+                                cooldowns.set(program, programCooldowns);
+                            }
+                            programCooldowns.set(
+                                key,
+                                Date.now() + expiryCooldownMs
+                            );
+                        }
+                        options.onExpired?.(key, program);
+                        return;
+                    }
+                    try {
+                        const ready = await options.resolve(
+                            key,
+                            program,
+                            controller.signal,
+                            attemptTimeoutMs
+                        );
+                        if (
+                            controller.signal.aborted ||
+                            !options.isActive(key, program)
+                        ) {
+                            return;
+                        }
+                        if (ready != null) {
+                            clearCooldown(key, program);
+                            options.onReady(key, program, ready);
+                            return;
+                        }
+                    } catch (error) {
+                        if (controller.signal.aborted) {
+                            return;
+                        }
+                        options.onError?.(key, program, error);
+                    }
+                    await waitForRetry(retryDelayMs, controller.signal);
+                }
+            } finally {
+                deleteTask(key, program, task);
+            }
+        })();
+        return { status: "started", promise: task.promise } as const;
+    };
+
+    return {
+        get size() {
+            return taskCount;
+        },
+        get cooldownSize() {
+            pruneExpiredCooldowns();
+            let size = 0;
+            for (const programCooldowns of cooldowns.values()) {
+                size += programCooldowns.size;
+            }
+            return size;
+        },
+        start,
+        cancel,
+        cancelProgram(program) {
+            const programTasks = tasks.get(program);
+            const cancelled = programTasks?.size ?? 0;
+            if (programTasks) {
+                tasks.delete(program);
+                taskCount -= cancelled;
+                for (const task of programTasks.values()) {
+                    task.controller.abort();
+                }
+            }
+            cooldowns.delete(program);
+            return cancelled;
+        },
+        cancelAll() {
+            const count = taskCount;
+            const activeTasks = [...tasks.values()].flatMap((programTasks) => [
+                ...programTasks.values(),
+            ]);
+            tasks.clear();
+            cooldowns.clear();
+            taskCount = 0;
+            for (const task of activeTasks) {
+                task.controller.abort();
+            }
+            return count;
+        },
+    };
+};
+
+export const resolveRemoteReadyRoot = async (
+    program: Files,
+    id: string,
+    signal: AbortSignal,
+    attemptTimeoutMs: number
+): Promise<AbstractFile | undefined> => {
+    const from = await program.getReadPeerHints();
+    signal.throwIfAborted();
+    const candidate = (await program.files.index.get(id, {
+        local: false,
+        signal,
+        remote: {
+            timeout: attemptTimeoutMs,
+            strategy: "always" as any,
+            throwOnMissing: false,
+            retryMissingResponses: true,
+            replicate: false,
+            from,
+        },
+    })) as AbstractFile | undefined;
+    signal.throwIfAborted();
+    return candidate && isLargeFileLike(candidate) && candidate.ready
+        ? candidate
+        : undefined;
+};

--- a/packages/file-share/frontend/src/refresh-scheduler.ts
+++ b/packages/file-share/frontend/src/refresh-scheduler.ts
@@ -1,0 +1,123 @@
+export type RefreshContext<TProgram> = {
+    generation: number;
+    program: TProgram;
+};
+
+export type CancellableScheduledCall<TArgs> = ((args?: TArgs) => void) & {
+    cancel(): void;
+};
+
+export type CoalescedRefreshQueue<TSource> = {
+    current: TSource | null;
+};
+
+export const queueCoalescedRefresh = <TSource>(
+    queue: CoalescedRefreshQueue<TSource>,
+    source: TSource
+) => {
+    queue.current = source;
+};
+
+export const drainCoalescedRefreshQueue = async <TSource>(
+    queue: CoalescedRefreshQueue<TSource>,
+    isActive: () => boolean,
+    refresh: (source: TSource) => Promise<void> | void
+) => {
+    while (isActive() && queue.current != null) {
+        const source = queue.current;
+        queue.current = null;
+        await refresh(source);
+    }
+};
+
+export const isRefreshContextActive = <TProgram>(
+    current: RefreshContext<TProgram | null>,
+    expected: RefreshContext<TProgram>,
+    enabled = true
+) =>
+    enabled &&
+    current.generation === expected.generation &&
+    current.program === expected.program;
+
+export const createRefreshContextGuard =
+    <TProgram>(
+        getCurrentContext: () => RefreshContext<TProgram | null>,
+        expected: RefreshContext<TProgram>
+    ) =>
+    () =>
+        isRefreshContextActive(getCurrentContext(), expected);
+
+export const bindRefreshContext =
+    <TProgram, TArgs>(
+        getCurrentContext: () => RefreshContext<TProgram | null>,
+        context: RefreshContext<TProgram>,
+        refresh: (
+            args: TArgs | undefined,
+            context: RefreshContext<TProgram>
+        ) => Promise<void> | void
+    ) =>
+    async (args?: TArgs) => {
+        const current = getCurrentContext();
+        if (!isRefreshContextActive(current, context)) {
+            return;
+        }
+        await refresh(args, context);
+    };
+
+export const callEvenInterval = <TArgs>(
+    func: (args?: TArgs) => Promise<void> | void,
+    delay: number,
+    onError: (error: unknown) => void = (error) => {
+        console.warn("Scheduled refresh failed", error);
+    }
+): CancellableScheduledCall<TArgs> => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let promise: Promise<void> | undefined;
+    let queued = false;
+    let cancelled = false;
+    let latestArgs: TArgs | undefined;
+
+    const schedule = () => {
+        if (cancelled || timer || promise || !queued) {
+            return;
+        }
+        timer = setTimeout(async () => {
+            timer = undefined;
+            if (cancelled) {
+                return;
+            }
+            queued = false;
+            const args = latestArgs;
+            promise = Promise.resolve().then(() => func(args));
+            try {
+                await promise;
+            } catch (error) {
+                if (!cancelled) {
+                    onError(error);
+                }
+            } finally {
+                promise = undefined;
+                schedule();
+            }
+        }, delay);
+    };
+
+    const scheduled = ((args?: TArgs) => {
+        if (cancelled) {
+            return;
+        }
+        latestArgs = args;
+        queued = true;
+        schedule();
+    }) as CancellableScheduledCall<TArgs>;
+    scheduled.cancel = () => {
+        cancelled = true;
+        queued = false;
+        latestArgs = undefined;
+        if (timer) {
+            clearTimeout(timer);
+            timer = undefined;
+        }
+    };
+    return scheduled;
+};

--- a/packages/file-share/frontend/src/remote-root-confirmation.ts
+++ b/packages/file-share/frontend/src/remote-root-confirmation.ts
@@ -1,0 +1,128 @@
+import {
+    SearchRequest,
+    StringMatch,
+    StringMatchMethod,
+} from "@peerbit/document";
+import type { AbstractFile, Files } from "@peerbit/please-lib";
+
+export const DEFAULT_REMOTE_ROOT_CONFIRMATION_TIMEOUT_MS = 3_000;
+
+export type RemoteRootConfirmation =
+    | {
+          status: "present";
+          root: AbstractFile;
+      }
+    | {
+          status: "missing";
+      }
+    | {
+          status: "unknown";
+          diagnostic?: string;
+      };
+
+const getDiagnostic = (error: unknown) => {
+    if (error instanceof Error) {
+        return error.message || error.name;
+    }
+    if (typeof error === "string") {
+        return error;
+    }
+    return undefined;
+};
+
+const getModified = (root: AbstractFile) => {
+    const modified = (
+        root as AbstractFile & {
+            __context?: { modified?: unknown };
+        }
+    ).__context?.modified;
+    return typeof modified === "bigint" ? modified : undefined;
+};
+
+const preferNewerRoot = (current: AbstractFile, candidate: AbstractFile) => {
+    const currentModified = getModified(current);
+    const candidateModified = getModified(candidate);
+    if (candidateModified == null) {
+        return current;
+    }
+    if (currentModified == null || candidateModified > currentModified) {
+        return candidate;
+    }
+    return current;
+};
+
+/**
+ * Confirms an exact remote root against every currently known remote
+ * replicator. A missing response is deliberately kept distinct from a
+ * successful lookup that found no document.
+ */
+export const confirmRemoteRoot = async (
+    program: Files,
+    id: string,
+    signal: AbortSignal,
+    timeoutMs = DEFAULT_REMOTE_ROOT_CONFIRMATION_TIMEOUT_MS
+): Promise<RemoteRootConfirmation> => {
+    if (signal.aborted) {
+        return {
+            status: "unknown",
+            diagnostic: "Remote root confirmation was aborted",
+        };
+    }
+
+    try {
+        const hints = await program.getReadPeerHints();
+        if (!hints?.length) {
+            return {
+                status: "unknown",
+                diagnostic: "No remote read peers are available",
+            };
+        }
+
+        signal.throwIfAborted();
+        const from = [...hints];
+        const candidates = (await program.files.index.search(
+            new SearchRequest({
+                query: new StringMatch({
+                    key: "id",
+                    value: id,
+                    caseInsensitive: false,
+                    method: StringMatchMethod.exact,
+                }),
+                fetch: 0xffffffff,
+            }),
+            {
+                local: false,
+                signal,
+                remote: {
+                    from,
+                    replicate: false,
+                    timeout: timeoutMs,
+                    throwOnMissing: true,
+                    retryMissingResponses: false,
+                    strategy: "fallback",
+                },
+            }
+        )) as AbstractFile[];
+        signal.throwIfAborted();
+
+        if (candidates.length === 0) {
+            return { status: "missing" };
+        }
+        const roots = candidates.filter(
+            (candidate) => candidate.id === id && !candidate.parentId
+        );
+        if (roots.length === 0) {
+            return {
+                status: "unknown",
+                diagnostic: "Exact root search returned no valid root document",
+            };
+        }
+        const candidate = roots.slice(1).reduce(preferNewerRoot, roots[0]);
+        return { status: "present", root: candidate };
+    } catch (error) {
+        return {
+            status: "unknown",
+            diagnostic: getDiagnostic(error),
+        };
+    }
+};

--- a/packages/file-share/frontend/src/remote-root-reconciliation.ts
+++ b/packages/file-share/frontend/src/remote-root-reconciliation.ts
@@ -1,0 +1,439 @@
+import type { AbstractFile } from "@peerbit/please-lib";
+import type { RemoteRootConfirmation } from "./remote-root-confirmation";
+
+export type RemoteRootVersion = {
+    head: string;
+    modified: bigint;
+};
+
+type VersionedRootReference = Pick<AbstractFile, "id"> & {
+    __context?: {
+        head?: unknown;
+        modified?: unknown;
+    };
+};
+
+type RemoteRootSuppression = {
+    version?: RemoteRootVersion;
+};
+
+export type RemoteRootReconciliationState = {
+    localRootIds: Set<string>;
+    remoteOnlyIds: Set<string>;
+    suppressedIds: Map<string, RemoteRootSuppression>;
+    observedVersions: Map<string, RemoteRootVersion>;
+};
+
+export const createRemoteRootReconciliationState =
+    (): RemoteRootReconciliationState => ({
+        localRootIds: new Set(),
+        remoteOnlyIds: new Set(),
+        suppressedIds: new Map(),
+        observedVersions: new Map(),
+    });
+
+const getRootVersion = (
+    root: VersionedRootReference
+): RemoteRootVersion | undefined => {
+    const head = root.__context?.head;
+    const modified = root.__context?.modified;
+    if (typeof head !== "string" || typeof modified !== "bigint") {
+        return undefined;
+    }
+    return { head, modified };
+};
+
+const rememberRootVersion = (
+    state: RemoteRootReconciliationState,
+    root: VersionedRootReference
+) => {
+    const candidate = getRootVersion(root);
+    if (!candidate) {
+        return;
+    }
+    const current = state.observedVersions.get(root.id);
+    if (!current || candidate.modified > current.modified) {
+        state.observedVersions.set(root.id, candidate);
+    }
+};
+
+const setObservedRootVersion = (
+    state: RemoteRootReconciliationState,
+    root: VersionedRootReference
+) => {
+    const version = getRootVersion(root);
+    if (version) {
+        state.observedVersions.set(root.id, version);
+    } else {
+        state.observedVersions.delete(root.id);
+    }
+};
+
+const isCausallyNewer = (
+    candidate: RemoteRootVersion | undefined,
+    previous: RemoteRootVersion | undefined
+) =>
+    candidate != null &&
+    previous != null &&
+    candidate.head !== previous.head &&
+    candidate.modified > previous.modified;
+
+export const recordExplicitRootChange = (
+    state: RemoteRootReconciliationState,
+    change: {
+        removed: Iterable<VersionedRootReference>;
+        added: Iterable<VersionedRootReference>;
+    }
+) => {
+    const changedIds = new Set<string>();
+    for (const root of change.removed) {
+        const id = root.id;
+        changedIds.add(id);
+        state.localRootIds.delete(id);
+        state.remoteOnlyIds.delete(id);
+        const version = getRootVersion(root) ?? state.observedVersions.get(id);
+        state.suppressedIds.set(id, { version });
+        if (version) {
+            state.observedVersions.set(id, version);
+        }
+    }
+    // Additions are processed second so remove+add recreation wins.
+    for (const root of change.added) {
+        const id = root.id;
+        changedIds.add(id);
+        state.suppressedIds.delete(id);
+        state.remoteOnlyIds.delete(id);
+        state.localRootIds.add(id);
+        setObservedRootVersion(state, root);
+    }
+    return changedIds;
+};
+
+export const observeLocalRootSnapshot = <
+    TRoot extends Pick<AbstractFile, "id">,
+>(
+    state: RemoteRootReconciliationState,
+    roots: TRoot[]
+) => {
+    const visibleRoots = roots.filter(
+        (root) => !state.suppressedIds.has(root.id)
+    );
+    const nextLocalIds = new Set(visibleRoots.map((root) => root.id));
+    for (const id of state.localRootIds) {
+        if (!nextLocalIds.has(id) && !state.suppressedIds.has(id)) {
+            state.remoteOnlyIds.add(id);
+        }
+    }
+    state.localRootIds.clear();
+    for (const root of visibleRoots) {
+        state.localRootIds.add(root.id);
+        state.remoteOnlyIds.delete(root.id);
+        setObservedRootVersion(state, root);
+    }
+    return visibleRoots;
+};
+
+export const observeRemoteRootSnapshot = (
+    state: RemoteRootReconciliationState,
+    roots: AbstractFile[]
+) => {
+    const seenIds = new Set(roots.map((root) => root.id));
+    const confirmationIds = new Set<string>();
+    for (const id of state.remoteOnlyIds) {
+        if (!seenIds.has(id)) {
+            confirmationIds.add(id);
+        }
+    }
+    for (const id of state.suppressedIds.keys()) {
+        if (seenIds.has(id)) {
+            confirmationIds.add(id);
+        }
+    }
+
+    const visibleRoots = roots.filter(
+        (root) => !state.suppressedIds.has(root.id)
+    );
+    for (const root of visibleRoots) {
+        if (state.localRootIds.has(root.id)) {
+            state.remoteOnlyIds.delete(root.id);
+        } else {
+            state.remoteOnlyIds.add(root.id);
+        }
+        rememberRootVersion(state, root);
+    }
+    return { visibleRoots, confirmationIds: [...confirmationIds] };
+};
+
+export type RemoteRootConfirmationAction =
+    | { type: "merge"; root: AbstractFile; retry: false }
+    | { type: "remove"; retry: false }
+    | { type: "retain"; retry: boolean };
+
+export const applyRemoteRootConfirmation = (
+    state: RemoteRootReconciliationState,
+    id: string,
+    confirmation: RemoteRootConfirmation
+): RemoteRootConfirmationAction => {
+    if (confirmation.status === "unknown") {
+        return { type: "retain", retry: true };
+    }
+    if (confirmation.status === "present") {
+        const suppression = state.suppressedIds.get(id);
+        if (
+            suppression &&
+            !isCausallyNewer(
+                getRootVersion(confirmation.root),
+                suppression.version
+            )
+        ) {
+            return { type: "retain", retry: true };
+        }
+        state.suppressedIds.delete(id);
+        setObservedRootVersion(state, confirmation.root);
+        if (state.localRootIds.has(id)) {
+            state.remoteOnlyIds.delete(id);
+        } else {
+            state.remoteOnlyIds.add(id);
+        }
+        return { type: "merge", root: confirmation.root, retry: false };
+    }
+
+    const wasTrackedRemoteOnly = state.remoteOnlyIds.delete(id);
+    if (wasTrackedRemoteOnly) {
+        state.suppressedIds.set(id, {
+            version: state.observedVersions.get(id),
+        });
+        return { type: "remove", retry: false };
+    }
+    return { type: "retain", retry: false };
+};
+
+export type RemoteRootObservation<TProgram> = {
+    generation: number;
+    program: TProgram;
+    rootRevision: number;
+};
+
+export const isRemoteRootObservationCurrent = <TProgram>(
+    current: RemoteRootObservation<TProgram | null>,
+    expected: RemoteRootObservation<TProgram>
+) =>
+    current.generation === expected.generation &&
+    current.program === expected.program &&
+    current.rootRevision === expected.rootRevision;
+
+type ConfirmationDisposition = "complete" | "retry";
+
+export type RemoteRootConfirmationScheduler<TContext> = {
+    readonly inFlightSize: number;
+    readonly queuedSize: number;
+    isPending(id: string): boolean;
+    schedule(
+        ids: Iterable<string>,
+        context: TContext,
+        run?: boolean
+    ): Promise<void>;
+    forget(id: string): void;
+    reset(): void;
+};
+
+export const invalidateRemoteRootAbsenceForVisibleRoots = (
+    scheduler: Pick<RemoteRootConfirmationScheduler<unknown>, "forget">,
+    roots: Iterable<Pick<AbstractFile, "id">>
+) => {
+    for (const root of roots) {
+        scheduler.forget(root.id);
+    }
+};
+
+export const createRemoteRootConfirmationScheduler = <
+    TContext,
+    TResult,
+>(options: {
+    confirm: (id: string, signal: AbortSignal) => Promise<TResult>;
+    onResult: (
+        id: string,
+        result: TResult,
+        context: TContext
+    ) => ConfirmationDisposition | Promise<ConfirmationDisposition>;
+    maxCandidatesPerRun?: number;
+    concurrency?: number;
+}): RemoteRootConfirmationScheduler<TContext> => {
+    const maxCandidatesPerRun = Math.max(1, options.maxCandidatesPerRun ?? 8);
+    const concurrency = Math.max(1, options.concurrency ?? 2);
+    const queue: string[] = [];
+    const queued = new Set<string>();
+    const deferred = new Set<string>();
+    const inFlight = new Map<string, { epoch: number; version: number }>();
+    const contexts = new Map<string, TContext>();
+    const versions = new Map<string, number>();
+    let controller = new AbortController();
+    let epoch = 0;
+    let requestedRuns = 0;
+    let drainPromise: Promise<void> | null = null;
+
+    const enqueue = (id: string) => {
+        if (queued.has(id)) {
+            return;
+        }
+        const active = inFlight.get(id);
+        if (active) {
+            if (
+                active.epoch !== epoch ||
+                active.version !== (versions.get(id) ?? 0)
+            ) {
+                deferred.add(id);
+            }
+            return;
+        }
+        queued.add(id);
+        queue.push(id);
+    };
+
+    const runBatch = async (runEpoch: number) => {
+        const signal = controller.signal;
+        const batch: Array<{
+            id: string;
+            context: TContext;
+            version: number;
+        }> = [];
+        while (queue.length > 0 && batch.length < maxCandidatesPerRun) {
+            const id = queue.shift()!;
+            queued.delete(id);
+            const context = contexts.get(id);
+            if (context == null || inFlight.has(id)) {
+                continue;
+            }
+            const version = versions.get(id) ?? 0;
+            inFlight.set(id, { epoch: runEpoch, version });
+            batch.push({ id, context, version });
+        }
+
+        let cursor = 0;
+        const worker = async () => {
+            while (cursor < batch.length) {
+                if (runEpoch !== epoch || signal.aborted) {
+                    return;
+                }
+                const entry = batch[cursor++];
+                let retry = false;
+                try {
+                    const result = await options.confirm(entry.id, signal);
+                    if (
+                        runEpoch !== epoch ||
+                        signal.aborted ||
+                        entry.version !== (versions.get(entry.id) ?? 0)
+                    ) {
+                        continue;
+                    }
+                    retry =
+                        (await options.onResult(
+                            entry.id,
+                            result,
+                            entry.context
+                        )) === "retry";
+                } catch {
+                    retry = true;
+                } finally {
+                    const active = inFlight.get(entry.id);
+                    const ownsFlight =
+                        active?.epoch === runEpoch &&
+                        active.version === entry.version;
+                    if (ownsFlight) {
+                        inFlight.delete(entry.id);
+                    }
+                    const isCurrent =
+                        runEpoch === epoch &&
+                        entry.version === (versions.get(entry.id) ?? 0);
+                    const hasDeferredReplacement =
+                        ownsFlight && deferred.delete(entry.id);
+                    if (isCurrent || hasDeferredReplacement) {
+                        if (retry || hasDeferredReplacement) {
+                            enqueue(entry.id);
+                        } else {
+                            contexts.delete(entry.id);
+                        }
+                    }
+                }
+            }
+        };
+        await Promise.all(
+            Array.from({ length: Math.min(concurrency, batch.length) }, () =>
+                worker()
+            )
+        );
+    };
+
+    const ensureDrain = () => {
+        if (!drainPromise) {
+            const runEpoch = epoch;
+            const nextDrain = Promise.resolve()
+                .then(async () => {
+                    while (requestedRuns > 0 && runEpoch === epoch) {
+                        requestedRuns -= 1;
+                        await runBatch(runEpoch);
+                    }
+                })
+                .finally(() => {
+                    if (drainPromise === nextDrain) {
+                        drainPromise = null;
+                        if (requestedRuns > 0) {
+                            void ensureDrain();
+                        }
+                    }
+                });
+            drainPromise = nextDrain;
+        }
+        return drainPromise;
+    };
+
+    return {
+        get inFlightSize() {
+            return inFlight.size;
+        },
+        get queuedSize() {
+            return queue.length + deferred.size;
+        },
+        isPending(id) {
+            return queued.has(id) || deferred.has(id) || inFlight.has(id);
+        },
+        schedule(ids, context, run = true) {
+            for (const id of queue) {
+                contexts.set(id, context);
+            }
+            for (const id of ids) {
+                contexts.set(id, context);
+                enqueue(id);
+            }
+            if (!run) {
+                return drainPromise ?? Promise.resolve();
+            }
+            requestedRuns += 1;
+            return ensureDrain();
+        },
+        forget(id) {
+            versions.set(id, (versions.get(id) ?? 0) + 1);
+            contexts.delete(id);
+            deferred.delete(id);
+            if (queued.delete(id)) {
+                const index = queue.indexOf(id);
+                if (index >= 0) {
+                    queue.splice(index, 1);
+                }
+            }
+        },
+        reset() {
+            epoch += 1;
+            controller.abort();
+            controller = new AbortController();
+            requestedRuns = 0;
+            drainPromise = null;
+            queue.length = 0;
+            queued.clear();
+            deferred.clear();
+            inFlight.clear();
+            contexts.clear();
+            versions.clear();
+        },
+    };
+};

--- a/packages/file-share/frontend/src/role-state.ts
+++ b/packages/file-share/frontend/src/role-state.ts
@@ -1,0 +1,153 @@
+import type { ReplicationOptions } from "@peerbit/shared-log";
+import type { Files } from "@peerbit/please-lib";
+
+export const FILE_SHARE_QUIET_REBALANCE_INTERVAL_MS = 5 * 60 * 1000;
+export const FILE_SHARE_STORAGE_BYTES_PER_MB = 1_000_000;
+
+export const parseFileShareStorageMegabytes = (megabytes: string) =>
+    Number(megabytes) * FILE_SHARE_STORAGE_BYTES_PER_MB;
+
+export const formatFileShareStorageMegabytes = (bytes: number) =>
+    String(bytes / FILE_SHARE_STORAGE_BYTES_PER_MB);
+
+export const DEFAULT_REPLICATION_ROLE: ReplicationOptions = {
+    limits: {
+        interval: FILE_SHARE_QUIET_REBALANCE_INTERVAL_MS,
+        cpu: { max: 1, monitor: undefined },
+    },
+};
+
+type AdaptiveRole = {
+    limits?: {
+        interval?: number;
+        storage?: number;
+        cpu?: number | { max: number; monitor?: unknown };
+    };
+};
+
+type AdaptiveCpuLimit = number | { max: number; monitor?: unknown };
+
+const getAdaptiveRole = (role: ReplicationOptions) =>
+    role != null &&
+    role !== false &&
+    typeof role === "object" &&
+    !Array.isArray(role) &&
+    !("factor" in role)
+        ? (role as AdaptiveRole)
+        : undefined;
+
+const getCpuMax = (cpu: AdaptiveCpuLimit | undefined) =>
+    typeof cpu === "number" ? cpu : cpu?.max;
+
+export const shouldUseQuietFileShareRebalancing = (
+    role: ReplicationOptions
+) => {
+    const adaptiveRole = getAdaptiveRole(role);
+    if (!adaptiveRole) {
+        return false;
+    }
+    const limits = adaptiveRole.limits;
+    const cpuMax = getCpuMax(limits?.cpu);
+    return limits?.storage == null && (cpuMax == null || cpuMax === 1);
+};
+
+export const normalizeFileShareReplicationRole = (
+    role: ReplicationOptions
+): ReplicationOptions => {
+    const adaptiveRole = getAdaptiveRole(role);
+    if (
+        !shouldUseQuietFileShareRebalancing(role) ||
+        !adaptiveRole ||
+        adaptiveRole.limits?.interval != null
+    ) {
+        return role;
+    }
+    return {
+        ...adaptiveRole,
+        limits: {
+            ...adaptiveRole.limits,
+            interval: FILE_SHARE_QUIET_REBALANCE_INTERVAL_MS,
+        },
+    } as ReplicationOptions;
+};
+
+export const createFileShareReplicationRole = (properties: {
+    cpuMax?: number;
+    storage?: number;
+}): ReplicationOptions =>
+    normalizeFileShareReplicationRole({
+        limits: {
+            cpu:
+                properties.cpuMax == null
+                    ? undefined
+                    : { max: properties.cpuMax },
+            storage: properties.storage,
+        },
+    });
+
+export const parseStoredRole = (
+    serializedRole: string | null
+): ReplicationOptions | undefined =>
+    serializedRole == null
+        ? undefined
+        : normalizeFileShareReplicationRole(JSON.parse(serializedRole));
+
+export const getInitialReplicationRole = (serializedRole: string | null) =>
+    parseStoredRole(serializedRole) ?? DEFAULT_REPLICATION_ROLE;
+
+type ReplicationRoleGuard = {
+    expectedRevision: number;
+    getCurrentRevision: () => number;
+    getCurrentRole: () => ReplicationOptions;
+    isContextActive: () => boolean;
+};
+
+type ReplicationRoleState = Omit<ReplicationRoleGuard, "expectedRevision">;
+
+export const applyReplicationRoleGuarded = async (
+    program: Files,
+    role: ReplicationOptions,
+    guard: ReplicationRoleGuard
+) => {
+    program.persistChunkReads = role !== false;
+    await program.files.log.replicate(false);
+
+    if (role === false) {
+        return true;
+    }
+    if (
+        program.closed ||
+        !guard.isContextActive() ||
+        guard.getCurrentRevision() !== guard.expectedRevision ||
+        guard.getCurrentRole() !== role
+    ) {
+        return false;
+    }
+
+    await program.files.log.replicate(role);
+    return true;
+};
+
+export const applyReplicationRoleUntilStable = async (
+    program: Files,
+    initialRevision: number,
+    state: ReplicationRoleState
+) => {
+    let revision = initialRevision;
+    while (!program.closed && state.isContextActive()) {
+        const role = state.getCurrentRole();
+        await applyReplicationRoleGuarded(program, role, {
+            ...state,
+            expectedRevision: revision,
+        });
+        if (program.closed || !state.isContextActive()) {
+            return revision;
+        }
+        const currentRevision = state.getCurrentRevision();
+        if (currentRevision === revision && state.getCurrentRole() === role) {
+            return revision;
+        }
+        revision = currentRevision;
+    }
+    return revision;
+};

--- a/packages/file-share/frontend/src/root-list.ts
+++ b/packages/file-share/frontend/src/root-list.ts
@@ -58,6 +58,22 @@ export const getReadyLargeFileSignature = (files: AbstractFile[]) => {
     return readyFiles.length > 0 ? readyFiles.join("|") : null;
 };
 
+export const getPendingReadyRootReconciliation = (files: AbstractFile[]) => {
+    const pending: LargeFile[] = [];
+    const readyIds: string[] = [];
+    for (const file of files) {
+        if (!isLargeFileLike(file)) {
+            continue;
+        }
+        if (file.ready) {
+            readyIds.push(file.id);
+        } else {
+            pending.push(file);
+        }
+    }
+    return { pending, readyIds };
+};
+
 export const getRootFileChange = (event: Event): RootFileChange => {
     const detail = (event as CustomEvent<FileChangeDetail>).detail;
     if (!detail) {
@@ -101,9 +117,6 @@ export const applyRootFileChangeToList = (
     }
 
     for (const file of change.added) {
-        if (removedIds.has(file.id)) {
-            continue;
-        }
         const existing = byId.get(file.id);
         if (!existing || shouldPreferRootCandidate(file, existing)) {
             byId.set(file.id, file);

--- a/packages/file-share/frontend/src/routes.tsx
+++ b/packages/file-share/frontend/src/routes.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from "react-router";
+import { Route, Routes, useLocation, useParams } from "react-router";
 import { PublicSignKey } from "@peerbit/crypto";
 import { serialize, deserialize } from "@dao-xyz/borsh";
 import { CreateDrop } from "./CreateDrop";
@@ -7,7 +7,6 @@ import { Drop } from "./Drop";
 import { Files } from "@peerbit/please-lib";
 
 import { useEffect } from "react";
-import { useLocation } from "react-router";
 
 export default function ScrollToTop() {
     const { pathname } = useLocation();
@@ -26,12 +25,17 @@ export const getDropAreaPath = (files: Files) => "s/" + files.address;
 export const getKeyFromDropAreaKey = (key: string) =>
     deserialize(base64url.decode(key), PublicSignKey);
 
+export const AddressKeyedDrop = () => {
+    const { address } = useParams();
+    return <Drop key={address} />;
+};
+
 export function BaseRoutes() {
     return (
         <>
             <ScrollToTop /> {/* For mobile  */}
             <Routes>
-                <Route path={SPACE} element={<Drop />} />
+                <Route path={SPACE} element={<AddressKeyedDrop />} />
                 <Route path={"/#"} element={<CreateDrop />} />
                 <Route path={"/"} element={<CreateDrop />} />
             </Routes>

--- a/packages/file-share/frontend/src/upload-lifecycle.ts
+++ b/packages/file-share/frontend/src/upload-lifecycle.ts
@@ -1,0 +1,18 @@
+/**
+ * Reports the first failed upload but waits for the rest of the batch before
+ * allowing shared UI state to be cleared.
+ */
+export const settleUploadBatch = async (
+    uploads: Promise<unknown>[],
+    onError: (error: unknown) => void
+) => {
+    try {
+        await Promise.all(uploads);
+    } catch (error) {
+        try {
+            onError(error);
+        } finally {
+            await Promise.allSettled(uploads);
+        }
+    }
+};

--- a/packages/file-share/frontend/tests/app-connection.unit.test.ts
+++ b/packages/file-share/frontend/tests/app-connection.unit.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+    getPeerAddressConfiguration,
+    getPeerDialOutcome,
+    getPeerOverrideAction,
+} from "../src/app-connection";
+
+describe("App peer override readiness", () => {
+    it("reports direct peer hints separately from bootstrap overrides", () => {
+        expect(
+            getPeerAddressConfiguration(
+                "https://files.test/?peer=peer-a,peer-b&bootstrap=relay#/s/share"
+            )
+        ).toEqual({ source: "peer", peers: ["peer-a", "peer-b"] });
+        expect(
+            getPeerAddressConfiguration(
+                "https://files.test/?bootstrap=relay#/s/share"
+            )
+        ).toEqual({ source: "bootstrap", peers: ["relay"] });
+    });
+
+    it("reads peer hints from the hash query without losing their source", () => {
+        expect(
+            getPeerAddressConfiguration(
+                "https://files.test/#/s/share?peer=peer-a%2Cpeer-b"
+            )
+        ).toEqual({ source: "peer", peers: ["peer-a", "peer-b"] });
+    });
+
+    it("waits for the peer before declaring supplied hints ready", () => {
+        expect(
+            getPeerOverrideAction(false, ["/ip4/127.0.0.1/tcp/9000/ws"])
+        ).toBe("wait-for-peer");
+    });
+
+    it("dials every supplied hint once the peer exists", () => {
+        expect(getPeerOverrideAction(true, ["peer-a", "peer-b"])).toBe(
+            "dial-explicit-peers"
+        );
+    });
+
+    it("needs no explicit dial when no hints were supplied", () => {
+        expect(getPeerOverrideAction(true, undefined)).toBe(
+            "ready-without-explicit-dial"
+        );
+        expect(getPeerOverrideAction(true, [])).toBe(
+            "ready-without-explicit-dial"
+        );
+    });
+
+    it("waits for every explicit dial before choosing an outcome", () => {
+        expect(
+            getPeerDialOutcome([{ status: "fulfilled" }, { status: "pending" }])
+        ).toBe("pending");
+    });
+
+    it("becomes ready after all dials settle when at least one succeeded", () => {
+        expect(
+            getPeerDialOutcome([
+                { status: "rejected" },
+                { status: "fulfilled" },
+                { status: "rejected" },
+            ])
+        ).toBe("ready");
+    });
+
+    it("fails only after every supplied dial was rejected", () => {
+        expect(
+            getPeerDialOutcome([{ status: "rejected" }, { status: "rejected" }])
+        ).toBe("failed");
+    });
+});

--- a/packages/file-share/frontend/tests/app-provider-config.unit.test.ts
+++ b/packages/file-share/frontend/tests/app-provider-config.unit.test.ts
@@ -1,0 +1,70 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const appHarness = vi.hoisted(() => {
+    const dial = vi.fn();
+    return {
+        providerConfigs: [] as unknown[],
+        dial,
+        peer: { dial },
+    };
+});
+
+vi.mock("@peerbit/react", () => ({
+    PeerProvider: ({
+        config,
+        children,
+    }: {
+        config: unknown;
+        children: unknown;
+    }) => {
+        appHarness.providerConfigs.push(config);
+        return children;
+    },
+    usePeer: () => ({
+        peer: appHarness.peer,
+    }),
+}));
+
+vi.mock("../src/routes", () => ({ BaseRoutes: () => null }));
+vi.mock("../src/Footer", () => ({ Footer: () => null }));
+vi.mock("../src/Spinner", () => ({ Spinner: () => null }));
+
+describe("App PeerProvider lifecycle", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+        window.history.replaceState(null, "", "/");
+        appHarness.providerConfigs = [];
+        appHarness.dial.mockReset();
+    });
+
+    it("keeps the provider config identity stable when explicit dialing becomes ready", async () => {
+        window.history.replaceState(
+            null,
+            "",
+            "/?peer=%2Fip4%2F127.0.0.1%2Ftcp%2F9000%2Fws%2Fp2p%2Fwriter#/s/share"
+        );
+        appHarness.dial.mockResolvedValue(undefined);
+        const { App } = await import("../src/App");
+        const container = document.createElement("div");
+        document.body.append(container);
+        const root = createRoot(container);
+        (
+            globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+        ).IS_REACT_ACT_ENVIRONMENT = true;
+
+        await act(async () => {
+            root.render(createElement(App));
+        });
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        expect(appHarness.dial).toHaveBeenCalledTimes(1);
+        expect(appHarness.providerConfigs.length).toBeGreaterThanOrEqual(2);
+        expect(new Set(appHarness.providerConfigs).size).toBe(1);
+
+        await act(async () => root.unmount());
+    });
+});

--- a/packages/file-share/frontend/tests/download-streamed.local.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/download-streamed.local.e2e.spec.ts
@@ -3,7 +3,7 @@ import { startBootstrapPeer } from "./bootstrapPeer";
 import {
     createSpace,
     expectSavedViaPicker,
-    installMockSaveFilePicker,
+    installNodeBackedMockSaveFilePicker,
     rootUrl,
     setSeedMode,
     uploadSyntheticFile,
@@ -34,9 +34,18 @@ test.describe("file-share streamed download via local bootstrap", () => {
         const writer = await writerContext.newPage();
         const reader = await readerContext.newPage();
         const fileName = `local-streamed-download-${Date.now()}.bin`;
+        let nodeSinkController:
+            | Awaited<ReturnType<typeof installNodeBackedMockSaveFilePicker>>
+            | undefined;
 
         try {
-            await installMockSaveFilePicker(reader);
+            nodeSinkController = await installNodeBackedMockSaveFilePicker(
+                reader,
+                {
+                    expectedName: fileName,
+                    expectedSizeBytes: FILE_SIZE_MB * 1024 * 1024,
+                }
+            );
             const entryUrl = withPeer(rootUrl(baseURL), bootstrap.addrs);
             const shareUrl = await createSpace(
                 writer,
@@ -52,18 +61,15 @@ test.describe("file-share streamed download via local bootstrap", () => {
             await setSeedMode(reader, false);
             await waitForFileListed(reader, fileName, 600_000);
 
-            await reader
-                .locator("li", { hasText: fileName })
-                .getByTestId("download-file")
-                .click();
-
-            await expectSavedViaPicker(
+            const saved = await expectSavedViaPicker(
                 reader,
                 fileName,
                 FILE_SIZE_MB,
                 10 * 60 * 1000
             );
+            await saved.cleanup();
         } finally {
+            await nodeSinkController?.cleanup().catch(() => {});
             await writerContext.close().catch(() => {});
             await readerContext.close().catch(() => {});
             await bootstrap.stop().catch(() => {});

--- a/packages/file-share/frontend/tests/file-list-loader.unit.test.ts
+++ b/packages/file-share/frontend/tests/file-list-loader.unit.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Files } from "@peerbit/please-lib";
+import {
+    coalesceRootListRefreshSource,
+    getRootListRefreshSource,
+    listRemoteRootFilesForReconciliation,
+    listRootFilesForRole,
+    shouldReconcileRemoteRootFiles,
+} from "../src/file-list-loader";
+
+describe("file-share root list loading", () => {
+    it("preserves join events and maps argument-less periodic ticks to refresh", () => {
+        expect(getRootListRefreshSource({ type: "join" })).toBe("join");
+        expect(getRootListRefreshSource()).toBe("refresh");
+        expect(getRootListRefreshSource("role-change")).toBe("role-change");
+    });
+
+    it("does not let periodic or stale work overwrite a queued lifecycle reconciliation", () => {
+        expect(coalesceRootListRefreshSource("join", "refresh")).toBe("join");
+        expect(
+            coalesceRootListRefreshSource("role-change", "stale-root-revision")
+        ).toBe("role-change");
+        expect(coalesceRootListRefreshSource("refresh", "join")).toBe("join");
+        expect(coalesceRootListRefreshSource("event", "refresh")).toBe(
+            "refresh"
+        );
+    });
+
+    it("uses a local-only root query for replicators", async () => {
+        const roots = [{ id: "root" }];
+        const search = vi.fn().mockResolvedValue(roots);
+        const list = vi.fn();
+        const program = {
+            list,
+            files: { index: { search } },
+        } as unknown as Files;
+
+        await expect(
+            listRootFilesForRole(program, { limits: {} })
+        ).resolves.toBe(roots);
+        expect(list).not.toHaveBeenCalled();
+        expect(search).toHaveBeenCalledOnce();
+        expect(search.mock.calls[0][1]).toEqual({
+            local: true,
+            remote: false,
+        });
+    });
+
+    it("keeps remote listing for observers", async () => {
+        const roots = [{ id: "remote-root" }];
+        const search = vi.fn();
+        const list = vi.fn().mockResolvedValue(roots);
+        const program = {
+            list,
+            files: { index: { search } },
+        } as unknown as Files;
+
+        await expect(listRootFilesForRole(program, false)).resolves.toBe(roots);
+        expect(list).toHaveBeenCalledOnce();
+        expect(search).not.toHaveBeenCalled();
+    });
+
+    it("uses a non-replicating root-only remote query for reconciliation", async () => {
+        const roots = [{ id: "remote-root" }];
+        const search = vi.fn().mockResolvedValue(roots);
+        const from = ["peer-hint"];
+        const getReadPeerHints = vi.fn().mockResolvedValue(from);
+        const program = {
+            getReadPeerHints,
+            files: { index: { search } },
+        } as unknown as Files;
+
+        await expect(
+            listRemoteRootFilesForReconciliation(program)
+        ).resolves.toBe(roots);
+        expect(getReadPeerHints).toHaveBeenCalledOnce();
+        expect(search).toHaveBeenCalledOnce();
+        expect(search.mock.calls[0][1]).toEqual({
+            local: false,
+            remote: {
+                throwOnMissing: false,
+                replicate: false,
+                from,
+            },
+        });
+    });
+
+    it("reconciles replicators on lifecycle triggers and a slow cadence", () => {
+        const role = { limits: {} };
+        const policy = (
+            source: string,
+            now: number,
+            lastStartedAt: number | null
+        ) =>
+            shouldReconcileRemoteRootFiles({
+                role,
+                source,
+                now,
+                lastStartedAt,
+            });
+
+        expect(policy("initial-open", 1_000, null)).toBe(true);
+        expect(policy("join", 2_000, 1_000)).toBe(true);
+        expect(policy("role-change", 3_000, 2_000)).toBe(true);
+        expect(policy("refresh", 29_999, 0)).toBe(false);
+        expect(policy("refresh", 30_000, 0)).toBe(true);
+        expect(policy("event", 30_000, 0)).toBe(false);
+        expect(policy("stale-root-revision", 30_000, 0)).toBe(false);
+    });
+
+    it("never adds a second remote reconciliation for observers", () => {
+        for (const source of [
+            "initial-open",
+            "join",
+            "role-change",
+            "refresh",
+        ]) {
+            expect(
+                shouldReconcileRemoteRootFiles({
+                    role: false,
+                    source,
+                    now: 60_000,
+                    lastStartedAt: null,
+                })
+            ).toBe(false);
+        }
+    });
+});

--- a/packages/file-share/frontend/tests/file.unit.test.ts
+++ b/packages/file-share/frontend/tests/file.unit.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { shouldDisableFileDownload } from "../src/File";
+import {
+    formatIndexedChunkRatio,
+    hasFileChunkChange,
+    shouldDisableFileDownload,
+} from "../src/File";
 
 describe("file download controls", () => {
     it("disables while a download is in progress", () => {
@@ -16,5 +20,21 @@ describe("file download controls", () => {
                 progress: null,
             })
         ).to.equal(false);
+    });
+
+    it("refreshes local progress when a child chunk is removed", () => {
+        expect(
+            hasFileChunkChange(
+                {
+                    added: [],
+                    removed: [{ parentId: "file-id" }],
+                },
+                "file-id"
+            )
+        ).toBe(true);
+    });
+
+    it("labels local chunk counts as indexed rather than fully replicated", () => {
+        expect(formatIndexedChunkRatio(100)).toBe("100% indexed");
     });
 });

--- a/packages/file-share/frontend/tests/helpers.ts
+++ b/packages/file-share/frontend/tests/helpers.ts
@@ -1,20 +1,134 @@
 import fs from "node:fs";
+import { createCipheriv, createHash, randomUUID } from "node:crypto";
+import { createServer } from "node:http";
 import { expect, type Page } from "@playwright/test";
-import { mkdtemp, open, rm, stat } from "node:fs/promises";
+import { mkdtemp, open, rm, stat, type FileHandle } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-const uploadTempDirectories = new Set<string>();
-let uploadTempCleanupRegistered = false;
+export type SyntheticFixtureMode = "sparse" | "deterministic";
 
-const registerUploadTempDirectory = (directory: string) => {
-    uploadTempDirectories.add(directory);
-    if (uploadTempCleanupRegistered) {
+export type SyntheticFixtureMetadata = {
+    mode: "sparse-zero" | "aes-256-ctr-v1";
+    seed: string | null;
+    sha256Base64: string | null;
+    crc32Hex: string | null;
+};
+
+type SyntheticFixtureOptions = {
+    mode?: SyntheticFixtureMode;
+    seed?: string;
+};
+
+const DETERMINISTIC_FIXTURE_CHUNK_BYTES = 1024 * 1024;
+const DEFAULT_DETERMINISTIC_FIXTURE_SEED = "peerbit-file-share-v1";
+const CRC32_INITIAL_STATE = 0xffffffff;
+const CRC32_TABLE = (() => {
+    const table = new Uint32Array(256);
+    for (let index = 0; index < table.length; index++) {
+        let value = index;
+        for (let bit = 0; bit < 8; bit++) {
+            value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+        }
+        table[index] = value >>> 0;
+    }
+    return table;
+})();
+
+const updateCrc32State = (state: number, bytes: Uint8Array) => {
+    let next = state >>> 0;
+    for (const byte of bytes) {
+        next = CRC32_TABLE[(next ^ byte) & 0xff] ^ (next >>> 8);
+    }
+    return next >>> 0;
+};
+
+const formatCrc32State = (state: number) =>
+    ((state ^ CRC32_INITIAL_STATE) >>> 0).toString(16).padStart(8, "0");
+
+export const createCrc32 = () => {
+    let state = CRC32_INITIAL_STATE;
+    return {
+        update(bytes: Uint8Array) {
+            state = updateCrc32State(state, bytes);
+        },
+        digestHex() {
+            return formatCrc32State(state);
+        },
+    };
+};
+
+const writeFully = async (file: FileHandle, bytes: Uint8Array) => {
+    let offset = 0;
+    while (offset < bytes.byteLength) {
+        const { bytesWritten } = await file.write(
+            bytes,
+            offset,
+            bytes.byteLength - offset,
+            null
+        );
+        if (bytesWritten <= 0) {
+            throw new Error("Failed to make progress while writing fixture");
+        }
+        offset += bytesWritten;
+    }
+};
+
+const writeDeterministicFixture = async (
+    file: FileHandle,
+    sizeBytes: number,
+    seed: string
+) => {
+    const descriptor = `${seed}\0${sizeBytes}`;
+    const key = createHash("sha256")
+        .update("peerbit-file-share-fixture-key-v1\0")
+        .update(descriptor)
+        .digest();
+    const iv = createHash("sha256")
+        .update("peerbit-file-share-fixture-iv-v1\0")
+        .update(descriptor)
+        .digest()
+        .subarray(0, 16);
+    const cipher = createCipheriv("aes-256-ctr", key, iv);
+    const hasher = createHash("sha256");
+    const crc32 = createCrc32();
+    const input = Buffer.alloc(
+        Math.min(DETERMINISTIC_FIXTURE_CHUNK_BYTES, Math.max(sizeBytes, 1))
+    );
+
+    let remaining = sizeBytes;
+    while (remaining > 0) {
+        const length = Math.min(input.byteLength, remaining);
+        const output = cipher.update(input.subarray(0, length));
+        await writeFully(file, output);
+        hasher.update(output);
+        crc32.update(output);
+        remaining -= length;
+    }
+
+    const final = cipher.final();
+    if (final.byteLength > 0) {
+        await writeFully(file, final);
+        hasher.update(final);
+        crc32.update(final);
+    }
+    return {
+        sha256Base64: hasher.digest("base64"),
+        crc32Hex: crc32.digestHex(),
+    };
+};
+
+const temporaryDirectories = new Set<string>();
+let temporaryDirectoryCleanupRegistered = false;
+
+const registerTemporaryDirectory = (directory: string) => {
+    temporaryDirectories.add(directory);
+    if (temporaryDirectoryCleanupRegistered) {
         return;
     }
-    uploadTempCleanupRegistered = true;
+    temporaryDirectoryCleanupRegistered = true;
     process.on("exit", () => {
-        for (const dir of uploadTempDirectories) {
+        for (const dir of temporaryDirectories) {
             try {
                 fs.rmSync(dir, { recursive: true, force: true });
             } catch {
@@ -22,6 +136,11 @@ const registerUploadTempDirectory = (directory: string) => {
             }
         }
     });
+};
+
+const cleanupTemporaryDirectory = async (directory: string) => {
+    await rm(directory, { recursive: true, force: true });
+    temporaryDirectories.delete(directory);
 };
 
 export function rootUrl(baseURL: string): string {
@@ -44,22 +163,77 @@ export function withPeer(baseURL: string, addrs: string[]): string {
 
 export async function createSyntheticFileOnDisk(
     fileName: string,
-    sizeMb: number
+    sizeMb: number,
+    options: SyntheticFixtureOptions = {}
 ) {
+    const sizeBytes = sizeMb * 1024 * 1024;
+    if (!Number.isSafeInteger(sizeBytes) || sizeBytes < 0) {
+        throw new Error(`Invalid synthetic fixture size: ${sizeMb} MiB`);
+    }
+    const mode = options.mode ?? "sparse";
     const dir = await mkdtemp(path.join(tmpdir(), "peerbit-file-share-"));
     const filePath = path.join(dir, fileName);
-    const file = await open(filePath, "w");
     try {
-        await file.truncate(sizeMb * 1024 * 1024);
-    } finally {
-        await file.close();
+        const file = await open(filePath, "w");
+        let fixture: SyntheticFixtureMetadata;
+        try {
+            if (mode === "deterministic") {
+                const seed =
+                    options.seed?.trim() || DEFAULT_DETERMINISTIC_FIXTURE_SEED;
+                const digests = await writeDeterministicFixture(
+                    file,
+                    sizeBytes,
+                    seed
+                );
+                fixture = {
+                    mode: "aes-256-ctr-v1",
+                    seed,
+                    ...digests,
+                };
+            } else {
+                await file.truncate(sizeBytes);
+                fixture = {
+                    mode: "sparse-zero",
+                    seed: null,
+                    sha256Base64: null,
+                    crc32Hex: null,
+                };
+            }
+        } finally {
+            await file.close();
+        }
+        return {
+            dir,
+            filePath,
+            fileName,
+            fixture,
+        };
+    } catch (error) {
+        await rm(dir, { recursive: true, force: true }).catch(() => {});
+        throw error;
+    }
+}
+
+export const sha256FileBase64 = async (filePath: string) => {
+    const hasher = createHash("sha256");
+    for await (const chunk of fs.createReadStream(filePath)) {
+        hasher.update(chunk);
+    }
+    return hasher.digest("base64");
+};
+
+export const sha256AndCrc32File = async (filePath: string) => {
+    const hasher = createHash("sha256");
+    const crc32 = createCrc32();
+    for await (const chunk of fs.createReadStream(filePath)) {
+        hasher.update(chunk);
+        crc32.update(chunk);
     }
     return {
-        dir,
-        filePath,
-        fileName,
+        sha256Base64: hasher.digest("base64"),
+        crc32Hex: crc32.digestHex(),
     };
-}
+};
 
 export async function createSpace(
     page: Page,
@@ -133,7 +307,7 @@ export async function uploadSyntheticFile(
     }
 
     const tempFile = await createSyntheticFileOnDisk(fileName, sizeMb);
-    registerUploadTempDirectory(tempFile.dir);
+    registerTemporaryDirectory(tempFile.dir);
     await page.locator("#imgupload").setInputFiles(tempFile.filePath);
 }
 
@@ -146,6 +320,42 @@ export async function waitForFileListed(
         .locator("li", { hasText: fileName })
         .first()
         .waitFor({ timeout });
+}
+
+export async function waitForReadyFileListed(
+    page: Page,
+    fileName: string,
+    expectedProgramAddress: string,
+    timeout = 180_000
+) {
+    const snapshotHandle = await page.waitForFunction(
+        ({ expectedName, expectedAddress }) => {
+            const hooks = (window as any).__peerbitFileShareTestHooks;
+            if (!hooks?.getLightweightSnapshot) {
+                return null;
+            }
+            const snapshot = hooks.getLightweightSnapshot();
+            const isReady = Boolean(
+                snapshot?.programAddress === expectedAddress &&
+                snapshot?.programClosed === false &&
+                snapshot?.listedFiles?.some(
+                    (file: Record<string, unknown>) =>
+                        file.name === expectedName &&
+                        file.ready === true &&
+                        typeof file.finalHash === "string" &&
+                        file.finalHash.length > 0
+                )
+            );
+            return isReady ? snapshot : null;
+        },
+        { expectedName: fileName, expectedAddress: expectedProgramAddress },
+        { polling: 50, timeout }
+    );
+    try {
+        return (await snapshotHandle.jsonValue()) as Record<string, unknown>;
+    } finally {
+        await snapshotHandle.dispose();
+    }
 }
 
 export async function waitForUploadComplete(page: Page, timeout = 600_000) {
@@ -172,14 +382,53 @@ export async function setSeedMode(page: Page, seeded: boolean) {
     await expect(toggle).toHaveAttribute("data-state", expected);
 }
 
-export async function expectDownloadedFile(
+export type DownloadSinkResult = {
+    sink: "browser-download" | "opfs" | "node-file";
+    size: number;
+    sinkCompletedAt: number;
+    downloadPath?: string;
+    serverWriteCalls?: number;
+    serverWriteDurationMs?: number;
+    cleanup: () => Promise<void>;
+};
+
+type MockSavedFileSink = "opfs" | "node-file";
+
+type NodeBackedSinkSession = {
+    id: string;
+    name: string;
+    filePath: string;
+    file: FileHandle | null;
+    state: "open" | "closed";
+    size: number;
+    completedAt: number | null;
+    serverWriteCalls: number;
+    serverWriteDurationMs: number;
+    busy: boolean;
+};
+
+type NodeBackedMockSaveFilePickerOptions = {
+    expectedName: string;
+    expectedSizeBytes: number;
+};
+
+type NodeBackedSinkController = {
+    cleanup: () => Promise<void>;
+    directory: string;
+    getClosedFile: (
+        storageName: string,
+        expectedName: string
+    ) => { filePath: string };
+};
+
+const nodeBackedSinkControllers = new WeakMap<Page, NodeBackedSinkController>();
+
+export function armDownloadedFile(
     page: Page,
     fileName: string,
     expectedSizeMb: number,
     timeout = 8 * 60 * 1000
-) {
-    const { button } = await getDownloadButton(page, fileName, timeout);
-
+): Promise<DownloadSinkResult> {
     const downloadPromise = page.waitForEvent("download", { timeout });
     const dialogFailure = ignoreTimeout(
         page.waitForEvent("dialog", { timeout }).then(async (dialog) => {
@@ -194,25 +443,47 @@ export async function expectDownloadedFile(
         })
     );
 
+    const completion = (async (): Promise<DownloadSinkResult> => {
+        const download = await Promise.race([
+            downloadPromise,
+            dialogFailure,
+            pageErrorFailure,
+        ]);
+        expect(download.suggestedFilename()).toBe(fileName);
+
+        // `path()` resolves when Chromium has completed its own download sink.
+        // Avoid `saveAs()` here: that would add a second filesystem copy to the
+        // click-to-sink benchmark interval.
+        const downloadPath = await download.path();
+        const details = await stat(downloadPath);
+        expect(details.size).toBe(expectedSizeMb * 1024 * 1024);
+        return {
+            sink: "browser-download",
+            downloadPath,
+            size: details.size,
+            sinkCompletedAt: Date.now(),
+            cleanup: () => download.delete(),
+        };
+    })();
+    void completion.catch(() => {});
+    return completion;
+}
+
+export async function expectDownloadedFile(
+    page: Page,
+    fileName: string,
+    expectedSizeMb: number,
+    timeout = 8 * 60 * 1000
+) {
+    const completion = armDownloadedFile(
+        page,
+        fileName,
+        expectedSizeMb,
+        timeout
+    );
+    const { button } = await getDownloadButton(page, fileName, timeout);
     await button.click();
-    const download = await Promise.race([
-        downloadPromise,
-        dialogFailure,
-        pageErrorFailure,
-    ]);
-
-    expect(download.suggestedFilename()).toBe(fileName);
-
-    const dir = await mkdtemp(path.join(tmpdir(), "peerbit-file-download-"));
-    const downloadPath = path.join(dir, fileName);
-    await download.saveAs(downloadPath);
-    const details = await stat(downloadPath);
-    expect(details.size).toBe(expectedSizeMb * 1024 * 1024);
-
-    return {
-        downloadPath,
-        size: details.size,
-    };
+    return completion;
 }
 
 const ignoreTimeout = <T>(promise: Promise<T>) =>
@@ -240,9 +511,595 @@ const getDownloadButton = async (
     return { row, button };
 };
 
+/**
+ * Installs a save-file picker whose bytes are streamed to a temporary Node
+ * file over loopback HTTP. Keeping the benchmark output outside browser
+ * storage prevents a large download from competing with Peerbit for the same
+ * origin quota while preserving backpressure at every write.
+ */
+export async function installNodeBackedMockSaveFilePicker(
+    page: Page,
+    options: NodeBackedMockSaveFilePickerOptions
+) {
+    if (
+        !Number.isSafeInteger(options.expectedSizeBytes) ||
+        options.expectedSizeBytes < 0
+    ) {
+        throw new Error(
+            `Invalid Node benchmark sink size: ${options.expectedSizeBytes}`
+        );
+    }
+    if (!options.expectedName || options.expectedName.length > 4096) {
+        throw new Error("Invalid Node benchmark sink file name");
+    }
+    if (nodeBackedSinkControllers.has(page)) {
+        throw new Error("A Node benchmark sink is already installed");
+    }
+    const directory = await mkdtemp(
+        path.join(tmpdir(), "peerbit-file-share-download-")
+    );
+    registerTemporaryDirectory(directory);
+    const routeSecret = randomUUID();
+    const sessions = new Map<string, NodeBackedSinkSession>();
+    let stopped = false;
+    let controller: NodeBackedSinkController | undefined;
+
+    const corsHeaders = {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET, POST, DELETE, OPTIONS",
+        "access-control-allow-headers": "content-type",
+        "access-control-allow-private-network": "true",
+        "cache-control": "no-store",
+    };
+    const server = createServer((request, response) => {
+        const respondJson = (status: number, body: unknown) => {
+            response.writeHead(status, {
+                ...corsHeaders,
+                "content-type": "application/json",
+            });
+            response.end(JSON.stringify(body));
+        };
+        const handleRequest = async () => {
+            if (request.method === "OPTIONS") {
+                response.writeHead(204, corsHeaders);
+                response.end();
+                return;
+            }
+
+            const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+            const route = requestUrl.pathname.split("/").filter(Boolean);
+            if (route.shift() !== routeSecret) {
+                respondJson(404, { error: "Unknown benchmark sink route" });
+                return;
+            }
+
+            const action = route.shift();
+            if (action === "open" && request.method === "POST") {
+                let bodyBytes = 0;
+                const chunks: Buffer[] = [];
+                for await (const chunk of request) {
+                    const bytes = Buffer.isBuffer(chunk)
+                        ? chunk
+                        : Buffer.from(chunk);
+                    bodyBytes += bytes.byteLength;
+                    if (bodyBytes > 64 * 1024) {
+                        throw new Error("Save-file picker name is too large");
+                    }
+                    chunks.push(bytes);
+                }
+                const body = JSON.parse(
+                    Buffer.concat(chunks).toString("utf8") || "{}"
+                ) as { name?: unknown };
+                const name =
+                    typeof body.name === "string" && body.name.length > 0
+                        ? body.name
+                        : "download.bin";
+                if (name !== options.expectedName) {
+                    throw new Error(
+                        `Unexpected benchmark sink name: expected "${options.expectedName}", received "${name}"`
+                    );
+                }
+                const id = randomUUID();
+                const filePath = path.join(directory, id);
+                const file = await open(filePath, "wx");
+                sessions.set(id, {
+                    id,
+                    name,
+                    filePath,
+                    file,
+                    state: "open",
+                    size: 0,
+                    completedAt: null,
+                    serverWriteCalls: 0,
+                    serverWriteDurationMs: 0,
+                    busy: false,
+                });
+                respondJson(200, { storageName: id });
+                return;
+            }
+
+            const id = route.shift();
+            const session = id ? sessions.get(id) : undefined;
+            if (!session) {
+                respondJson(404, { error: "Unknown benchmark sink file" });
+                return;
+            }
+
+            if (action === "write" && request.method === "POST") {
+                if (session.state !== "open" || !session.file) {
+                    throw new Error("Cannot write to a closed benchmark sink");
+                }
+                if (session.busy) {
+                    throw new Error(
+                        "Concurrent benchmark sink operations are not allowed"
+                    );
+                }
+                session.busy = true;
+                try {
+                    const contentLengthValue =
+                        request.headers["content-length"];
+                    const contentLength = Number(contentLengthValue);
+                    if (
+                        !Number.isSafeInteger(contentLength) ||
+                        contentLength < 0
+                    ) {
+                        throw new Error(
+                            "Benchmark sink write is missing a valid content length"
+                        );
+                    }
+                    if (
+                        session.size + contentLength >
+                        options.expectedSizeBytes
+                    ) {
+                        throw new Error(
+                            `Benchmark sink write exceeds expected size ${options.expectedSizeBytes}`
+                        );
+                    }
+                    const writeStartedAt = process.hrtime.bigint();
+                    let written = 0;
+                    for await (const chunk of request) {
+                        const bytes = Buffer.isBuffer(chunk)
+                            ? chunk
+                            : Buffer.from(chunk);
+                        if (
+                            session.size + written + bytes.byteLength >
+                            options.expectedSizeBytes
+                        ) {
+                            throw new Error(
+                                `Benchmark sink write exceeds expected size ${options.expectedSizeBytes}`
+                            );
+                        }
+                        await writeFully(session.file, bytes);
+                        written += bytes.byteLength;
+                    }
+                    if (written !== contentLength) {
+                        throw new Error(
+                            `Benchmark sink request length mismatch: expected ${contentLength}, received ${written}`
+                        );
+                    }
+                    session.size += written;
+                    session.serverWriteCalls += 1;
+                    session.serverWriteDurationMs +=
+                        Number(process.hrtime.bigint() - writeStartedAt) / 1e6;
+                    respondJson(200, { size: session.size });
+                } finally {
+                    session.busy = false;
+                }
+                return;
+            }
+
+            if (action === "close" && request.method === "POST") {
+                if (session.state !== "open" || !session.file) {
+                    throw new Error("Benchmark sink is already closed");
+                }
+                if (session.busy) {
+                    throw new Error(
+                        "Concurrent benchmark sink operations are not allowed"
+                    );
+                }
+                session.busy = true;
+                try {
+                    if (session.size !== options.expectedSizeBytes) {
+                        throw new Error(
+                            `Benchmark sink size mismatch: expected ${options.expectedSizeBytes}, received ${session.size}`
+                        );
+                    }
+                    await session.file.close();
+                    session.file = null;
+                    session.state = "closed";
+                    const details = await stat(session.filePath);
+                    if (details.size !== session.size) {
+                        throw new Error(
+                            `Benchmark sink size mismatch: wrote ${session.size}, stored ${details.size}`
+                        );
+                    }
+                    session.completedAt = Date.now();
+                    respondJson(200, {
+                        name: session.name,
+                        storageName: session.id,
+                        size: details.size,
+                        completedAt: session.completedAt,
+                        sink: "node-file",
+                        serverWriteCalls: session.serverWriteCalls,
+                        serverWriteDurationMs: session.serverWriteDurationMs,
+                    });
+                } finally {
+                    session.busy = false;
+                }
+                return;
+            }
+
+            if (action === "crc32" && request.method === "GET") {
+                if (session.state !== "closed") {
+                    throw new Error(
+                        "Cannot verify CRC32 before the benchmark sink closes"
+                    );
+                }
+                const crc32 = createCrc32();
+                for await (const chunk of fs.createReadStream(
+                    session.filePath
+                )) {
+                    crc32.update(chunk);
+                }
+                respondJson(200, { crc32Hex: crc32.digestHex() });
+                return;
+            }
+
+            if (
+                (action === "abort" && request.method === "POST") ||
+                (action === "cleanup" && request.method === "DELETE")
+            ) {
+                if (session.file) {
+                    await session.file.close().catch(() => {});
+                    session.file = null;
+                }
+                sessions.delete(session.id);
+                await rm(session.filePath, { force: true });
+                respondJson(200, { removed: true });
+                return;
+            }
+
+            respondJson(404, { error: "Unknown benchmark sink action" });
+        };
+
+        void handleRequest().catch((error) => {
+            if (!response.headersSent) {
+                respondJson(500, {
+                    error:
+                        error instanceof Error ? error.message : String(error),
+                });
+            } else {
+                response.destroy(error instanceof Error ? error : undefined);
+            }
+        });
+    });
+
+    const stop = async () => {
+        if (stopped) {
+            return;
+        }
+        stopped = true;
+        await Promise.all(
+            [...sessions.values()].map(async (session) => {
+                if (session.file) {
+                    await session.file.close().catch(() => {});
+                    session.file = null;
+                }
+            })
+        );
+        sessions.clear();
+        if (server.listening) {
+            await new Promise<void>((resolve) => {
+                server.close(() => resolve());
+                server.closeAllConnections?.();
+            });
+        }
+        if (controller && nodeBackedSinkControllers.get(page) === controller) {
+            nodeBackedSinkControllers.delete(page);
+        }
+        await cleanupTemporaryDirectory(directory);
+    };
+
+    try {
+        await new Promise<void>((resolve, reject) => {
+            const onError = (error: Error) => {
+                server.off("listening", onListening);
+                reject(error);
+            };
+            const onListening = () => {
+                server.off("error", onError);
+                resolve();
+            };
+            server.once("error", onError);
+            server.once("listening", onListening);
+            server.listen(0, "127.0.0.1");
+        });
+        const address = server.address();
+        if (!address || typeof address === "string") {
+            throw new Error("Benchmark sink did not bind a TCP port");
+        }
+        const endpoint = `http://127.0.0.1:${address.port}/${routeSecret}`;
+
+        await page.addInitScript(
+            ({ endpoint }) => {
+                type SavedFile = {
+                    name: string;
+                    size: number;
+                    completedAt: number;
+                    storageName: string;
+                    sink: "node-file";
+                    serverWriteCalls: number;
+                    serverWriteDurationMs: number;
+                };
+                const savedFiles: SavedFile[] = [];
+                const activeStorageNames = new Map<string, string>();
+                const request = async <T>(
+                    route: string,
+                    init?: RequestInit
+                ): Promise<T> => {
+                    const response = await fetch(`${endpoint}/${route}`, init);
+                    const body = (await response.json()) as T & {
+                        error?: string;
+                    };
+                    if (!response.ok) {
+                        throw new Error(
+                            body.error ??
+                                `Benchmark sink request failed (${response.status})`
+                        );
+                    }
+                    return body;
+                };
+                const cleanupStorageName = async (storageName: string) => {
+                    await request(
+                        `cleanup/${encodeURIComponent(storageName)}`,
+                        {
+                            method: "DELETE",
+                        }
+                    ).catch((error) => {
+                        if (
+                            !/Unknown benchmark sink file/.test(String(error))
+                        ) {
+                            throw error;
+                        }
+                    });
+                };
+
+                Object.defineProperty(
+                    window,
+                    "__peerbitStreamingDownloadThresholdBytes",
+                    {
+                        value: 1,
+                        configurable: true,
+                        enumerable: false,
+                        writable: true,
+                    }
+                );
+                Object.defineProperty(window, "__mockSavedFiles", {
+                    value: savedFiles,
+                    configurable: true,
+                    enumerable: false,
+                    writable: false,
+                });
+                Object.defineProperty(window, "__cleanupMockSavedFile", {
+                    configurable: true,
+                    enumerable: false,
+                    writable: false,
+                    value: async (name: string) => {
+                        const storageNames = new Set(
+                            savedFiles
+                                .filter((file) => file.name === name)
+                                .map((file) => file.storageName)
+                        );
+                        const activeStorageName = activeStorageNames.get(name);
+                        if (activeStorageName) {
+                            storageNames.add(activeStorageName);
+                        }
+                        await Promise.all(
+                            [...storageNames].map(cleanupStorageName)
+                        );
+                        activeStorageNames.delete(name);
+                        for (
+                            let index = savedFiles.length - 1;
+                            index >= 0;
+                            index--
+                        ) {
+                            if (savedFiles[index].name === name) {
+                                savedFiles.splice(index, 1);
+                            }
+                        }
+                    },
+                });
+                Object.defineProperty(window, "__crc32MockSavedFile", {
+                    configurable: true,
+                    enumerable: false,
+                    writable: false,
+                    value: async (name: string) => {
+                        let saved: SavedFile | undefined;
+                        for (
+                            let index = savedFiles.length - 1;
+                            index >= 0;
+                            index--
+                        ) {
+                            if (savedFiles[index].name === name) {
+                                saved = savedFiles[index];
+                                break;
+                            }
+                        }
+                        if (!saved) {
+                            throw new Error(
+                                `No saved Node filesystem file named "${name}"`
+                            );
+                        }
+                        const result = await request<{ crc32Hex: string }>(
+                            `crc32/${encodeURIComponent(saved.storageName)}`
+                        );
+                        return result.crc32Hex;
+                    },
+                });
+                Object.defineProperty(window, "showSaveFilePicker", {
+                    configurable: true,
+                    enumerable: false,
+                    writable: true,
+                    value: async (options?: { suggestedName?: string }) => {
+                        const name = options?.suggestedName ?? "download.bin";
+                        const opened = await request<{
+                            storageName: string;
+                        }>("open", {
+                            method: "POST",
+                            headers: { "content-type": "application/json" },
+                            body: JSON.stringify({ name }),
+                        });
+                        const storageName = opened.storageName;
+                        activeStorageNames.set(name, storageName);
+                        let writableCreated = false;
+                        let writableClosed = false;
+                        return {
+                            createWritable: async () => {
+                                if (writableCreated) {
+                                    throw new Error(
+                                        "Benchmark sink writable already created"
+                                    );
+                                }
+                                writableCreated = true;
+                                return {
+                                    write: async (data: Uint8Array) => {
+                                        if (writableClosed) {
+                                            throw new Error(
+                                                "Cannot write to a closed benchmark sink"
+                                            );
+                                        }
+                                        await request(
+                                            `write/${encodeURIComponent(storageName)}`,
+                                            {
+                                                method: "POST",
+                                                body: data as unknown as BodyInit,
+                                            }
+                                        );
+                                    },
+                                    close: async () => {
+                                        if (writableClosed) {
+                                            throw new Error(
+                                                "Benchmark sink is already closed"
+                                            );
+                                        }
+                                        const saved = await request<SavedFile>(
+                                            `close/${encodeURIComponent(storageName)}`,
+                                            { method: "POST" }
+                                        );
+                                        writableClosed = true;
+                                        savedFiles.push(saved);
+                                        activeStorageNames.delete(name);
+                                    },
+                                    abort: async () => {
+                                        if (writableClosed) {
+                                            return;
+                                        }
+                                        writableClosed = true;
+                                        try {
+                                            await request(
+                                                `abort/${encodeURIComponent(storageName)}`,
+                                                { method: "POST" }
+                                            ).catch((error) => {
+                                                if (
+                                                    !/Unknown benchmark sink file/.test(
+                                                        String(error)
+                                                    )
+                                                ) {
+                                                    throw error;
+                                                }
+                                            });
+                                        } finally {
+                                            activeStorageNames.delete(name);
+                                        }
+                                    },
+                                };
+                            },
+                        };
+                    },
+                });
+            },
+            { endpoint }
+        );
+        controller = {
+            cleanup: stop,
+            directory,
+            getClosedFile: (storageName, expectedName) => {
+                const session = sessions.get(storageName);
+                if (
+                    !session ||
+                    session.state !== "closed" ||
+                    session.name !== expectedName
+                ) {
+                    throw new Error(
+                        `Missing closed Node benchmark sink file "${expectedName}"`
+                    );
+                }
+                return { filePath: session.filePath };
+            },
+        };
+        nodeBackedSinkControllers.set(page, controller);
+        page.once("close", () => {
+            void stop().catch(() => {});
+        });
+        return controller;
+    } catch (error) {
+        await stop().catch(() => {});
+        throw error;
+    }
+}
+
 export async function installMockSaveFilePicker(page: Page) {
     await page.addInitScript(() => {
-        const savedFiles: Array<{ name: string; size: number }> = [];
+        type SavedFile = {
+            name: string;
+            size: number;
+            completedAt: number;
+            storageName: string;
+            sink: "opfs";
+        };
+        const savedFiles: SavedFile[] = [];
+        const activeStorageNames = new Map<string, string>();
+        let fileSequence = 0;
+        const crc32InitialState = 0xffffffff;
+        const crc32Table = (() => {
+            const table = new Uint32Array(256);
+            for (let index = 0; index < table.length; index++) {
+                let value = index;
+                for (let bit = 0; bit < 8; bit++) {
+                    value =
+                        value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+                }
+                table[index] = value >>> 0;
+            }
+            return table;
+        })();
+        const updateCrc32 = (state: number, bytes: Uint8Array) => {
+            let next = state >>> 0;
+            for (const byte of bytes) {
+                next = crc32Table[(next ^ byte) & 0xff] ^ (next >>> 8);
+            }
+            return next >>> 0;
+        };
+        const formatCrc32 = (state: number) =>
+            ((state ^ crc32InitialState) >>> 0).toString(16).padStart(8, "0");
+        const getRoot = () =>
+            (
+                navigator.storage as StorageManager & {
+                    getDirectory(): Promise<any>;
+                }
+            ).getDirectory();
+        const removeStoredEntry = async (root: any, storageName: string) => {
+            try {
+                await root.removeEntry(storageName, { recursive: false });
+            } catch (error) {
+                if (
+                    !(error instanceof DOMException) ||
+                    error.name !== "NotFoundError"
+                ) {
+                    throw error;
+                }
+            }
+        };
         Object.defineProperty(
             window,
             "__peerbitStreamingDownloadThresholdBytes",
@@ -259,39 +1116,143 @@ export async function installMockSaveFilePicker(page: Page) {
             enumerable: false,
             writable: false,
         });
+        Object.defineProperty(window, "__cleanupMockSavedFile", {
+            configurable: true,
+            enumerable: false,
+            writable: false,
+            value: async (name: string) => {
+                const storageNames = new Set(
+                    savedFiles
+                        .filter((file) => file.name === name)
+                        .map((file) => file.storageName)
+                );
+                const activeStorageName = activeStorageNames.get(name);
+                if (activeStorageName) {
+                    storageNames.add(activeStorageName);
+                }
+                if (storageNames.size > 0) {
+                    const root = await getRoot();
+                    await Promise.all(
+                        [...storageNames].map((storageName) =>
+                            removeStoredEntry(root, storageName)
+                        )
+                    );
+                }
+                activeStorageNames.delete(name);
+                for (let index = savedFiles.length - 1; index >= 0; index--) {
+                    if (savedFiles[index].name === name) {
+                        savedFiles.splice(index, 1);
+                    }
+                }
+            },
+        });
+        Object.defineProperty(window, "__crc32MockSavedFile", {
+            configurable: true,
+            enumerable: false,
+            writable: false,
+            value: async (name: string) => {
+                let saved: SavedFile | undefined;
+                for (let index = savedFiles.length - 1; index >= 0; index--) {
+                    if (savedFiles[index].name === name) {
+                        saved = savedFiles[index];
+                        break;
+                    }
+                }
+                if (!saved) {
+                    throw new Error(`No saved OPFS file named "${name}"`);
+                }
+
+                const root = await getRoot();
+                const fileHandle = await root.getFileHandle(saved.storageName);
+                const file = await fileHandle.getFile();
+                const reader = file.stream().getReader();
+                let state = crc32InitialState;
+                try {
+                    while (true) {
+                        const { done, value } = await reader.read();
+                        if (done) {
+                            break;
+                        }
+                        if (value?.byteLength) {
+                            state = updateCrc32(state, value);
+                        }
+                    }
+                } finally {
+                    reader.releaseLock();
+                }
+                return formatCrc32(state);
+            },
+        });
         Object.defineProperty(window, "showSaveFilePicker", {
             configurable: true,
             enumerable: false,
             writable: true,
             value: async (options?: { suggestedName?: string }) => {
-                let written = 0;
+                const name = options?.suggestedName ?? "download.bin";
+                const storageName = `peerbit-file-share-${Date.now()}-${fileSequence++}`;
+                const root = await getRoot();
+                const fileHandle = await root.getFileHandle(storageName, {
+                    create: true,
+                });
+                activeStorageNames.set(name, storageName);
                 return {
-                    createWritable: async () => ({
-                        write: async (data: Uint8Array) => {
-                            written += data.byteLength ?? 0;
-                        },
-                        close: async () => {
-                            savedFiles.push({
-                                name: options?.suggestedName ?? "download.bin",
-                                size: written,
-                            });
-                        },
-                        abort: async () => {},
-                    }),
+                    createWritable: async () => {
+                        const writable = await fileHandle.createWritable();
+                        return {
+                            write: async (data: Uint8Array) => {
+                                await writable.write(data);
+                            },
+                            close: async () => {
+                                await writable.close();
+                                const saved = await fileHandle.getFile();
+                                savedFiles.push({
+                                    name,
+                                    size: saved.size,
+                                    completedAt: Date.now(),
+                                    storageName,
+                                    sink: "opfs",
+                                });
+                                activeStorageNames.delete(name);
+                            },
+                            abort: async (reason?: unknown) => {
+                                try {
+                                    await writable.abort(reason);
+                                } finally {
+                                    await removeStoredEntry(
+                                        root,
+                                        storageName
+                                    ).catch(() => {});
+                                    activeStorageNames.delete(name);
+                                }
+                            },
+                        };
+                    },
                 };
             },
         });
     });
 }
 
-export async function expectSavedViaPicker(
+export const crc32SavedViaPicker = async (page: Page, fileName: string) =>
+    page.evaluate(async (expectedName) => {
+        const crc32 = (
+            window as unknown as {
+                __crc32MockSavedFile?: (name: string) => Promise<string>;
+            }
+        ).__crc32MockSavedFile;
+        if (!crc32) {
+            throw new Error("Missing save-file picker CRC32 readback hook");
+        }
+        return crc32(expectedName);
+    }, fileName);
+
+export function armSavedViaPicker(
     page: Page,
     fileName: string,
     expectedSizeMb: number,
     timeout = 8 * 60 * 1000
-) {
+): Promise<DownloadSinkResult> {
     const expectedBytes = expectedSizeMb * 1024 * 1024;
-    const { button } = await getDownloadButton(page, fileName, timeout);
     const dialogFailure = ignoreTimeout(
         page.waitForEvent("dialog", { timeout }).then(async (dialog) => {
             const message = dialog.message();
@@ -304,31 +1265,106 @@ export async function expectSavedViaPicker(
             throw error;
         })
     );
-    const streamedSave = expect
-        .poll(
-            async () =>
-                page.evaluate((expectedName) => {
-                    const savedFiles =
-                        (
-                            window as unknown as {
-                                __mockSavedFiles?: Array<{
-                                    name: string;
-                                    size: number;
-                                }>;
-                            }
-                        ).__mockSavedFiles ?? [];
-                    return (
-                        savedFiles.find((file) => file.name === expectedName) ??
-                        null
-                    );
-                }, fileName),
-            {
-                timeout,
-                message: `Expected streamed save for ${fileName}`,
-            }
+    const pageCrashFailure = ignoreTimeout(
+        page.waitForEvent("crash", { timeout }).then(() => {
+            throw new Error("Download page crashed before sink completion");
+        })
+    );
+    const streamedSave = page
+        .waitForFunction(
+            (expectedName) => {
+                const savedFiles =
+                    (
+                        window as unknown as {
+                            __mockSavedFiles?: Array<{
+                                name: string;
+                                size: number;
+                                completedAt: number;
+                                storageName: string;
+                                sink: MockSavedFileSink;
+                                serverWriteCalls?: number;
+                                serverWriteDurationMs?: number;
+                            }>;
+                        }
+                    ).__mockSavedFiles ?? [];
+                return (
+                    savedFiles.find((file) => file.name === expectedName) ??
+                    null
+                );
+            },
+            fileName,
+            { polling: 25, timeout }
         )
-        .toEqual({ name: fileName, size: expectedBytes });
+        .then(async (handle) => {
+            try {
+                return await handle.jsonValue();
+            } finally {
+                await handle.dispose();
+            }
+        });
+    void streamedSave.catch(() => {});
 
+    const completion = Promise.race([
+        streamedSave,
+        dialogFailure,
+        pageErrorFailure,
+        pageCrashFailure,
+    ]).then((saved): DownloadSinkResult => {
+        expect(saved.size).toBe(expectedBytes);
+        const nodeSink =
+            saved.sink === "node-file"
+                ? nodeBackedSinkControllers.get(page)
+                : undefined;
+        if (saved.sink === "node-file" && !nodeSink) {
+            throw new Error("Missing Node benchmark sink controller");
+        }
+        const downloadPath = nodeSink?.getClosedFile(
+            saved.storageName,
+            fileName
+        ).filePath;
+        return {
+            sink: saved.sink,
+            downloadPath,
+            size: saved.size,
+            sinkCompletedAt: saved.completedAt,
+            serverWriteCalls: saved.serverWriteCalls,
+            serverWriteDurationMs: saved.serverWriteDurationMs,
+            cleanup: async () => {
+                await page.evaluate(async (expectedName) => {
+                    const cleanup = (
+                        window as unknown as {
+                            __cleanupMockSavedFile?: (
+                                name: string
+                            ) => Promise<void>;
+                        }
+                    ).__cleanupMockSavedFile;
+                    if (!cleanup) {
+                        throw new Error(
+                            "Missing save-file picker cleanup hook"
+                        );
+                    }
+                    await cleanup(expectedName);
+                }, fileName);
+            },
+        };
+    });
+    void completion.catch(() => {});
+    return completion;
+}
+
+export async function expectSavedViaPicker(
+    page: Page,
+    fileName: string,
+    expectedSizeMb: number,
+    timeout = 8 * 60 * 1000
+) {
+    const completion = armSavedViaPicker(
+        page,
+        fileName,
+        expectedSizeMb,
+        timeout
+    );
+    const { button } = await getDownloadButton(page, fileName, timeout);
     await button.click();
-    await Promise.race([streamedSave, dialogFailure, pageErrorFailure]);
+    return completion;
 }

--- a/packages/file-share/frontend/tests/helpers.unit.test.ts
+++ b/packages/file-share/frontend/tests/helpers.unit.test.ts
@@ -1,0 +1,441 @@
+import { gzipSync } from "node:zlib";
+import { createReadStream } from "node:fs";
+import { readFile, readdir, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { describe, expect, it, vi } from "vitest";
+import {
+    crc32SavedViaPicker,
+    createCrc32,
+    createSyntheticFileOnDisk,
+    installMockSaveFilePicker,
+    installNodeBackedMockSaveFilePicker,
+    sha256AndCrc32File,
+    sha256FileBase64,
+} from "./helpers";
+
+vi.mock("@playwright/test", () => ({ expect: vi.fn() }));
+
+const FIXTURE_SIZE_MB = 1 / 16;
+const FIXTURE_SIZE_BYTES = 64 * 1024;
+const MOCK_PICKER_WINDOW_KEYS = [
+    "__peerbitStreamingDownloadThresholdBytes",
+    "__mockSavedFiles",
+    "__cleanupMockSavedFile",
+    "__crc32MockSavedFile",
+    "showSaveFilePicker",
+] as const;
+
+const snapshotMockPickerWindow = () =>
+    new Map(
+        MOCK_PICKER_WINDOW_KEYS.map((key) => [
+            key,
+            Object.getOwnPropertyDescriptor(window, key),
+        ])
+    );
+
+const restoreMockPickerWindow = (
+    descriptors: ReturnType<typeof snapshotMockPickerWindow>
+) => {
+    for (const key of MOCK_PICKER_WINDOW_KEYS) {
+        const descriptor = descriptors.get(key);
+        if (descriptor) {
+            Object.defineProperty(window, key, descriptor);
+        } else {
+            Reflect.deleteProperty(window, key);
+        }
+    }
+};
+
+const createInitScriptPage = () => {
+    let closeListener: (() => void) | undefined;
+    const page = {
+        addInitScript: async <T>(script: (argument: T) => void, argument: T) =>
+            script(argument),
+        evaluate: async <T, A>(
+            script: (argument: A) => Promise<T>,
+            argument: A
+        ) => script(argument),
+        once: (event: string, listener: () => void) => {
+            if (event === "close") {
+                closeListener = listener;
+            }
+        },
+    } as unknown as Parameters<typeof installNodeBackedMockSaveFilePicker>[0];
+    return {
+        page,
+        close: () => closeListener?.(),
+    };
+};
+
+const crc32FileHex = async (filePath: string) => {
+    const crc32 = createCrc32();
+    for await (const chunk of createReadStream(filePath)) {
+        crc32.update(chunk);
+    }
+    return crc32.digestHex();
+};
+
+describe("synthetic on-disk fixtures", () => {
+    it("keeps the default sparse fixture behavior", async () => {
+        const fixture = await createSyntheticFileOnDisk(
+            "default-sparse.bin",
+            FIXTURE_SIZE_MB
+        );
+        try {
+            expect((await stat(fixture.filePath)).size).toBe(
+                FIXTURE_SIZE_BYTES
+            );
+            expect(fixture.fixture).toEqual({
+                mode: "sparse-zero",
+                seed: null,
+                sha256Base64: null,
+                crc32Hex: null,
+            });
+            expect(
+                (await readFile(fixture.filePath)).every((byte) => byte === 0)
+            ).toBe(true);
+        } finally {
+            await rm(fixture.dir, { recursive: true, force: true });
+        }
+    });
+
+    it("computes canonical CRC32 across chunk boundaries", () => {
+        const crc32 = createCrc32();
+        crc32.update(new TextEncoder().encode("1234"));
+        crc32.update(new TextEncoder().encode("56789"));
+
+        expect(crc32.digestHex()).toBe("cbf43926");
+        expect(crc32.digestHex()).toMatch(/^[0-9a-f]{8}$/);
+    });
+
+    it("writes deterministic, incompressible content with a streamed hash", async () => {
+        const first = await createSyntheticFileOnDisk(
+            "first.bin",
+            FIXTURE_SIZE_MB,
+            { mode: "deterministic", seed: "stable-seed" }
+        );
+        const second = await createSyntheticFileOnDisk(
+            "second.bin",
+            FIXTURE_SIZE_MB,
+            { mode: "deterministic", seed: "stable-seed" }
+        );
+        const different = await createSyntheticFileOnDisk(
+            "different.bin",
+            FIXTURE_SIZE_MB,
+            { mode: "deterministic", seed: "different-seed" }
+        );
+
+        try {
+            const firstBytes = await readFile(first.filePath);
+            const secondBytes = await readFile(second.filePath);
+            const differentBytes = await readFile(different.filePath);
+
+            expect(first.fixture).toEqual({
+                mode: "aes-256-ctr-v1",
+                seed: "stable-seed",
+                sha256Base64: second.fixture.sha256Base64,
+                crc32Hex: second.fixture.crc32Hex,
+            });
+            expect(first.fixture.sha256Base64).not.toBe(
+                different.fixture.sha256Base64
+            );
+            expect(firstBytes.equals(secondBytes)).toBe(true);
+            expect(firstBytes.equals(differentBytes)).toBe(false);
+            expect(await sha256FileBase64(first.filePath)).toBe(
+                first.fixture.sha256Base64
+            );
+            expect(await crc32FileHex(first.filePath)).toBe(
+                first.fixture.crc32Hex
+            );
+            expect(await sha256AndCrc32File(first.filePath)).toEqual({
+                sha256Base64: first.fixture.sha256Base64,
+                crc32Hex: first.fixture.crc32Hex,
+            });
+            expect(first.fixture.crc32Hex).toMatch(/^[0-9a-f]{8}$/);
+            expect(first.fixture.crc32Hex).not.toBe(different.fixture.crc32Hex);
+            expect(
+                gzipSync(firstBytes).byteLength / firstBytes.byteLength
+            ).toBeGreaterThan(0.98);
+        } finally {
+            await Promise.all(
+                [first.dir, second.dir, different.dir].map((dir) =>
+                    rm(dir, { recursive: true, force: true })
+                )
+            );
+        }
+    });
+
+    it("streams OPFS readback through the installed CRC32 hook", async () => {
+        type StoredFile = { chunks: Uint8Array[] };
+        const storedFiles = new Map<string, StoredFile>();
+        let readbackStreamCount = 0;
+        const root = {
+            async getFileHandle(
+                storageName: string,
+                options?: { create?: boolean }
+            ) {
+                let stored = storedFiles.get(storageName);
+                if (!stored && options?.create) {
+                    stored = { chunks: [] };
+                    storedFiles.set(storageName, stored);
+                }
+                if (!stored) {
+                    throw new DOMException("Missing file", "NotFoundError");
+                }
+                return {
+                    async createWritable() {
+                        stored!.chunks = [];
+                        return {
+                            async write(bytes: Uint8Array) {
+                                stored!.chunks.push(new Uint8Array(bytes));
+                            },
+                            async close() {},
+                            async abort() {
+                                stored!.chunks = [];
+                            },
+                        };
+                    },
+                    async getFile() {
+                        const chunks = stored!.chunks.map(
+                            (chunk) => new Uint8Array(chunk)
+                        );
+                        return {
+                            size: chunks.reduce(
+                                (total, chunk) => total + chunk.byteLength,
+                                0
+                            ),
+                            stream() {
+                                readbackStreamCount += 1;
+                                let index = 0;
+                                return new ReadableStream<Uint8Array>({
+                                    pull(controller) {
+                                        const chunk = chunks[index++];
+                                        if (chunk) {
+                                            controller.enqueue(chunk);
+                                        } else {
+                                            controller.close();
+                                        }
+                                    },
+                                });
+                            },
+                        };
+                    },
+                };
+            },
+            async removeEntry(storageName: string) {
+                if (!storedFiles.delete(storageName)) {
+                    throw new DOMException("Missing file", "NotFoundError");
+                }
+            },
+        };
+        const storageDescriptor = Object.getOwnPropertyDescriptor(
+            navigator,
+            "storage"
+        );
+        const windowKeys = [
+            "__peerbitStreamingDownloadThresholdBytes",
+            "__mockSavedFiles",
+            "__cleanupMockSavedFile",
+            "__crc32MockSavedFile",
+            "showSaveFilePicker",
+        ] as const;
+        const windowDescriptors = new Map(
+            windowKeys.map((key) => [
+                key,
+                Object.getOwnPropertyDescriptor(window, key),
+            ])
+        );
+        const page = {
+            addInitScript: async (script: () => void) => script(),
+            evaluate: async <T, A>(
+                script: (argument: A) => Promise<T>,
+                argument: A
+            ) => script(argument),
+        } as unknown as Parameters<typeof installMockSaveFilePicker>[0];
+
+        try {
+            Object.defineProperty(navigator, "storage", {
+                configurable: true,
+                value: { getDirectory: async () => root },
+            });
+            await installMockSaveFilePicker(page);
+            const handle = await (window as any).showSaveFilePicker({
+                suggestedName: "crc32-readback.bin",
+            });
+            const writable = await handle.createWritable();
+            await writable.write(new TextEncoder().encode("1234"));
+            await writable.write(new TextEncoder().encode("56789"));
+            await writable.close();
+
+            expect(await crc32SavedViaPicker(page, "crc32-readback.bin")).toBe(
+                "cbf43926"
+            );
+            expect(readbackStreamCount).toBe(1);
+        } finally {
+            if (storageDescriptor) {
+                Object.defineProperty(navigator, "storage", storageDescriptor);
+            } else {
+                Reflect.deleteProperty(navigator, "storage");
+            }
+            for (const key of windowKeys) {
+                const descriptor = windowDescriptors.get(key);
+                if (descriptor) {
+                    Object.defineProperty(window, key, descriptor);
+                } else {
+                    Reflect.deleteProperty(window, key);
+                }
+            }
+        }
+    });
+
+    it("streams exact bytes to a Node file and verifies them after close", async () => {
+        const descriptors = snapshotMockPickerWindow();
+        const { page } = createInitScriptPage();
+        const fileName = "node-readback.bin";
+        let controller:
+            | Awaited<ReturnType<typeof installNodeBackedMockSaveFilePicker>>
+            | undefined;
+        try {
+            controller = await installNodeBackedMockSaveFilePicker(page, {
+                expectedName: fileName,
+                expectedSizeBytes: 9,
+            });
+            const handle = await (window as any).showSaveFilePicker({
+                suggestedName: fileName,
+            });
+            const writable = await handle.createWritable();
+            await writable.write(new TextEncoder().encode("1234"));
+            await writable.write(new TextEncoder().encode("56789"));
+            await writable.close();
+
+            const saved = (window as any).__mockSavedFiles[0];
+            expect(saved).toMatchObject({
+                name: fileName,
+                size: 9,
+                sink: "node-file",
+                serverWriteCalls: 2,
+            });
+            expect(saved.serverWriteDurationMs).toBeGreaterThanOrEqual(0);
+            const storedPath = `${controller.directory}/${saved.storageName}`;
+            expect((await readFile(storedPath)).toString()).toBe("123456789");
+            expect(await crc32SavedViaPicker(page, fileName)).toBe("cbf43926");
+            await expect(writable.write(new Uint8Array([0]))).rejects.toThrow(
+                "closed"
+            );
+            await expect(writable.close()).rejects.toThrow("already closed");
+
+            await (window as any).__cleanupMockSavedFile(fileName);
+            await (window as any).__cleanupMockSavedFile(fileName);
+            await expect(stat(storedPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        } finally {
+            await controller?.cleanup();
+            restoreMockPickerWindow(descriptors);
+        }
+        await expect(stat(controller!.directory)).rejects.toMatchObject({
+            code: "ENOENT",
+        });
+    });
+
+    it("rejects wrong names, oversized writes, and undersized closes", async () => {
+        const descriptors = snapshotMockPickerWindow();
+        const { page } = createInitScriptPage();
+        const fileName = "strict-size.bin";
+        let controller:
+            | Awaited<ReturnType<typeof installNodeBackedMockSaveFilePicker>>
+            | undefined;
+        try {
+            controller = await installNodeBackedMockSaveFilePicker(page, {
+                expectedName: fileName,
+                expectedSizeBytes: 4,
+            });
+            await expect(
+                (window as any).showSaveFilePicker({
+                    suggestedName: "wrong-name.bin",
+                })
+            ).rejects.toThrow("Unexpected benchmark sink name");
+
+            const oversizedHandle = await (window as any).showSaveFilePicker({
+                suggestedName: fileName,
+            });
+            const oversized = await oversizedHandle.createWritable();
+            await expect(
+                oversized.write(new Uint8Array([1, 2, 3, 4, 5]))
+            ).rejects.toThrow("exceeds expected size");
+            await oversized.abort();
+            await oversized.abort();
+
+            const undersizedHandle = await (window as any).showSaveFilePicker({
+                suggestedName: fileName,
+            });
+            const undersized = await undersizedHandle.createWritable();
+            await undersized.write(new Uint8Array([1, 2]));
+            await expect(undersized.close()).rejects.toThrow(
+                "expected 4, received 2"
+            );
+            await undersized.abort();
+            expect(await readdir(controller.directory)).toEqual([]);
+        } finally {
+            await controller?.cleanup();
+            restoreMockPickerWindow(descriptors);
+        }
+        await expect(stat(controller!.directory)).rejects.toMatchObject({
+            code: "ENOENT",
+        });
+    });
+
+    it("can clean up an active Node sink before close without leaking", async () => {
+        const descriptors = snapshotMockPickerWindow();
+        const { page } = createInitScriptPage();
+        const fileName = "active-cleanup.bin";
+        let controller:
+            | Awaited<ReturnType<typeof installNodeBackedMockSaveFilePicker>>
+            | undefined;
+        try {
+            controller = await installNodeBackedMockSaveFilePicker(page, {
+                expectedName: fileName,
+                expectedSizeBytes: 4,
+            });
+            const handle = await (window as any).showSaveFilePicker({
+                suggestedName: fileName,
+            });
+            const writable = await handle.createWritable();
+            await writable.write(new Uint8Array([1, 2]));
+            await (window as any).__cleanupMockSavedFile(fileName);
+            await expect(
+                writable.write(new Uint8Array([3, 4]))
+            ).rejects.toThrow("Unknown benchmark sink file");
+            await writable.abort();
+            expect(await readdir(controller.directory)).toEqual([]);
+        } finally {
+            await controller?.cleanup();
+            restoreMockPickerWindow(descriptors);
+        }
+        await expect(stat(controller!.directory)).rejects.toMatchObject({
+            code: "ENOENT",
+        });
+    });
+
+    it("removes a partial fixture directory when setup fails", async () => {
+        const before = new Set(
+            (await readdir(tmpdir())).filter((name) =>
+                name.startsWith("peerbit-file-share-")
+            )
+        );
+
+        await expect(
+            createSyntheticFileOnDisk(
+                "missing-parent/fixture.bin",
+                FIXTURE_SIZE_MB,
+                { mode: "deterministic" }
+            )
+        ).rejects.toBeDefined();
+
+        const leaked = (await readdir(tmpdir())).filter(
+            (name) =>
+                name.startsWith("peerbit-file-share-") && !before.has(name)
+        );
+        expect(leaked).toEqual([]);
+    });
+});

--- a/packages/file-share/frontend/tests/pending-ready-resolver.unit.test.ts
+++ b/packages/file-share/frontend/tests/pending-ready-resolver.unit.test.ts
@@ -1,0 +1,303 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LargeFile, type Files } from "@peerbit/please-lib";
+import {
+    createPendingReadyResolver,
+    resolveRemoteReadyRoot,
+    type PendingReadyStartResult,
+} from "../src/pending-ready-resolver";
+
+const startedPromise = (result: PendingReadyStartResult) => {
+    expect(result.status).toBe("started");
+    if (result.status !== "started") {
+        throw new Error(`Expected started result, got ${result.status}`);
+    }
+    return result.promise;
+};
+
+describe("pending ready-file resolver", () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("reports existing work without duplicate diagnostics or finalizers", async () => {
+        let resolveAttempt: (value: string) => void = () => {};
+        const attempt = new Promise<string>((resolve) => {
+            resolveAttempt = resolve;
+        });
+        const resolve = vi.fn(() => attempt);
+        const onReady = vi.fn();
+        const program = {};
+        const resolver = createPendingReadyResolver({
+            resolve,
+            isActive: () => true,
+            onReady,
+        });
+
+        let startDiagnostics = 0;
+        let finalizers = 0;
+        const startFromSnapshot = () => {
+            const result = resolver.start("file", program);
+            if (result.status === "started") {
+                startDiagnostics += 1;
+                void result.promise.finally(() => {
+                    finalizers += 1;
+                });
+            }
+            return result;
+        };
+        const first = startFromSnapshot();
+        const second = startFromSnapshot();
+        expect(first.status).toBe("started");
+        expect(second.status).toBe("existing");
+        if (first.status !== "started" || second.status !== "existing") {
+            throw new Error("Unexpected admission results");
+        }
+        expect(first.promise).toBe(second.promise);
+        expect(resolve).toHaveBeenCalledOnce();
+        expect(startDiagnostics).toBe(1);
+
+        resolveAttempt("ready");
+        await first.promise;
+        expect(onReady).toHaveBeenCalledOnce();
+        expect(finalizers).toBe(1);
+        expect(resolver.size).toBe(0);
+    });
+
+    it("aborts and removes work on cancellation", async () => {
+        let attemptSignal: AbortSignal | undefined;
+        const onReady = vi.fn();
+        const program = {};
+        const resolver = createPendingReadyResolver({
+            resolve: (_key, _program, signal) => {
+                attemptSignal = signal;
+                return new Promise<undefined>((resolve) => {
+                    signal.addEventListener("abort", () => resolve(undefined), {
+                        once: true,
+                    });
+                });
+            },
+            isActive: () => true,
+            onReady,
+        });
+
+        const pending = startedPromise(resolver.start("file", program));
+        expect(resolver.cancel("file", program)).toBe(true);
+        await pending;
+
+        expect(attemptSignal?.aborted).toBe(true);
+        expect(onReady).not.toHaveBeenCalled();
+        expect(resolver.size).toBe(0);
+    });
+
+    it("refuses roots above capacity without evicting active work and retries later", async () => {
+        const signals = new Map<string, AbortSignal>();
+        const promises: Promise<void>[] = [];
+        const resolver = createPendingReadyResolver<object, string>({
+            maxEntries: 64,
+            resolve: (key, _program, signal) => {
+                signals.set(key, signal);
+                return new Promise<undefined>((resolve) => {
+                    signal.addEventListener("abort", () => resolve(undefined), {
+                        once: true,
+                    });
+                });
+            },
+            isActive: () => true,
+            onReady: vi.fn(),
+        });
+        const program = {};
+
+        for (let index = 0; index < 64; index += 1) {
+            promises.push(
+                startedPromise(resolver.start(`file-${index}`, program))
+            );
+        }
+        const excess = resolver.start("file-64", program);
+        expect(excess).toEqual({
+            status: "capacity",
+            activeCount: 64,
+            maxEntries: 64,
+        });
+        expect(resolver.size).toBe(64);
+        expect([...signals.values()].every((signal) => !signal.aborted)).toBe(
+            true
+        );
+
+        expect(resolver.cancel("file-0", program)).toBe(true);
+        const admitted = resolver.start("file-64", program);
+        promises.push(startedPromise(admitted));
+        expect(resolver.size).toBe(64);
+        expect(signals.get("file-1")?.aborted).toBe(false);
+
+        resolver.cancelAll();
+        await Promise.all(promises);
+        expect(resolver.size).toBe(0);
+    });
+
+    it("keeps expired roots in cooldown and admits them after cooldown", async () => {
+        vi.useFakeTimers();
+        const onExpired = vi.fn();
+        const resolver = createPendingReadyResolver<object, string>({
+            maxLifetimeMs: 1_000,
+            expiryCooldownMs: 5_000,
+            retryDelayMs: 100,
+            resolve: async () => undefined,
+            isActive: () => true,
+            onReady: vi.fn(),
+            onExpired,
+        });
+        const program = {};
+
+        const first = startedPromise(resolver.start("file", program));
+        await vi.advanceTimersByTimeAsync(1_100);
+        await first;
+        expect(onExpired).toHaveBeenCalledOnce();
+        expect(resolver.size).toBe(0);
+        expect(resolver.cooldownSize).toBe(1);
+
+        const cooldown = resolver.start("file", program);
+        expect(cooldown.status).toBe("cooldown");
+        if (cooldown.status !== "cooldown") {
+            throw new Error("Expected cooldown result");
+        }
+        const remainingCooldownMs = cooldown.retryAt - Date.now();
+        await vi.advanceTimersByTimeAsync(remainingCooldownMs - 1);
+        expect(resolver.start("file", program).status).toBe("cooldown");
+        await vi.advanceTimersByTimeAsync(1);
+
+        const restarted = startedPromise(resolver.start("file", program));
+        resolver.cancelAll();
+        await restarted;
+        expect(resolver.cooldownSize).toBe(0);
+    });
+
+    it("defaults expiry cooldown to the full polling lifetime", async () => {
+        vi.useFakeTimers();
+        const resolver = createPendingReadyResolver<object, string>({
+            maxLifetimeMs: 100,
+            retryDelayMs: 10,
+            resolve: async () => undefined,
+            isActive: () => true,
+            onReady: vi.fn(),
+        });
+        const program = {};
+
+        const expired = startedPromise(resolver.start("file", program));
+        await vi.advanceTimersByTimeAsync(110);
+        await expired;
+        const cooldown = resolver.start("file", program);
+        expect(cooldown.status).toBe("cooldown");
+        if (cooldown.status !== "cooldown") {
+            throw new Error("Expected cooldown result");
+        }
+
+        const retryAt = cooldown.retryAt;
+        await vi.advanceTimersByTimeAsync(40);
+        expect(resolver.start("file", program)).toMatchObject({
+            status: "cooldown",
+            retryAt,
+        });
+        await vi.advanceTimersByTimeAsync(retryAt - Date.now() - 1);
+        expect(resolver.start("file", program).status).toBe("cooldown");
+        await vi.advanceTimersByTimeAsync(1);
+
+        const restarted = startedPromise(resolver.start("file", program));
+        resolver.cancelAll();
+        await restarted;
+    });
+
+    it("clears expiry state when a root is removed", async () => {
+        vi.useFakeTimers();
+        const resolver = createPendingReadyResolver<object, string>({
+            maxLifetimeMs: 100,
+            expiryCooldownMs: 1_000,
+            retryDelayMs: 10,
+            resolve: async () => undefined,
+            isActive: () => true,
+            onReady: vi.fn(),
+        });
+        const program = {};
+
+        const expired = startedPromise(resolver.start("file", program));
+        await vi.advanceTimersByTimeAsync(110);
+        await expired;
+        expect(resolver.start("file", program).status).toBe("cooldown");
+
+        expect(resolver.cancel("file", program)).toBe(true);
+        expect(resolver.cooldownSize).toBe(0);
+        const restarted = startedPromise(resolver.start("file", program));
+        resolver.cancel("file", program);
+        await restarted;
+    });
+
+    it("clears active and cooldown state on program and resolver cleanup", async () => {
+        vi.useFakeTimers();
+        const signals = new Map<string, AbortSignal>();
+        const resolver = createPendingReadyResolver<object, string>({
+            maxEntries: 4,
+            maxLifetimeMs: 100,
+            expiryCooldownMs: 1_000,
+            retryDelayMs: 10,
+            resolve: (key, _program, signal) => {
+                signals.set(key, signal);
+                return Promise.resolve(undefined);
+            },
+            isActive: () => true,
+            onReady: vi.fn(),
+        });
+        const programA = {};
+        const programB = {};
+
+        const expired = startedPromise(resolver.start("expired", programA));
+        await vi.advanceTimersByTimeAsync(110);
+        await expired;
+        expect(resolver.cooldownSize).toBe(1);
+
+        const activeA = startedPromise(resolver.start("active-a", programA));
+        const activeB = startedPromise(resolver.start("active-b", programB));
+        expect(resolver.cancelProgram(programA)).toBe(1);
+        expect(signals.get("active-a")?.aborted).toBe(true);
+        expect(signals.get("active-b")?.aborted).toBe(false);
+        expect(resolver.cooldownSize).toBe(0);
+        expect(resolver.size).toBe(1);
+
+        expect(resolver.cancelAll()).toBe(1);
+        await Promise.all([activeA, activeB]);
+        expect(resolver.size).toBe(0);
+        expect(resolver.cooldownSize).toBe(0);
+    });
+
+    it("uses writer hints for an always-remote exact-id lookup", async () => {
+        const ready = new LargeFile({
+            id: "file",
+            name: "file.bin",
+            size: 1n,
+            chunkCount: 1,
+            ready: true,
+            finalHash: "hash",
+        });
+        const get = vi.fn().mockResolvedValue(ready);
+        const program = {
+            getReadPeerHints: vi.fn().mockResolvedValue(["writer"]),
+            files: { index: { get } },
+        } as unknown as Files;
+        const controller = new AbortController();
+
+        await expect(
+            resolveRemoteReadyRoot(program, "file", controller.signal, 1_500)
+        ).resolves.toBe(ready);
+        expect(get).toHaveBeenCalledWith(
+            "file",
+            expect.objectContaining({
+                local: false,
+                signal: controller.signal,
+                remote: expect.objectContaining({
+                    timeout: 1_500,
+                    strategy: "always",
+                    replicate: false,
+                    from: ["writer"],
+                }),
+            })
+        );
+    });
+});

--- a/packages/file-share/frontend/tests/refresh-scheduler.unit.test.ts
+++ b/packages/file-share/frontend/tests/refresh-scheduler.unit.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+    bindRefreshContext,
+    callEvenInterval,
+    createRefreshContextGuard,
+    drainCoalescedRefreshQueue,
+    isRefreshContextActive,
+    queueCoalescedRefresh,
+    type RefreshContext,
+} from "../src/refresh-scheduler";
+
+describe("refresh scheduler", () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("cancels a queued refresh during effect cleanup", async () => {
+        vi.useFakeTimers();
+        const refresh = vi.fn();
+        const scheduled = callEvenInterval(refresh, 500);
+
+        scheduled("old-share");
+        scheduled.cancel();
+        await vi.advanceTimersByTimeAsync(500);
+
+        expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it("rejects delayed work bound to an old generation or program", async () => {
+        vi.useFakeTimers();
+        const oldProgram = {};
+        const newProgram = {};
+        let current: RefreshContext<object | null> = {
+            generation: 1,
+            program: oldProgram,
+        };
+        const refresh = vi.fn();
+        const bound = bindRefreshContext(
+            () => current,
+            { generation: 1, program: oldProgram },
+            refresh
+        );
+        const scheduled = callEvenInterval(bound, 500);
+
+        scheduled("old-share");
+        current = { generation: 2, program: newProgram };
+        await vi.advanceTimersByTimeAsync(500);
+
+        expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it("rejects a deferred result after same-generation program replacement", async () => {
+        const oldProgram = {};
+        const newProgram = {};
+        let current: RefreshContext<object | null> = {
+            generation: 3,
+            program: oldProgram,
+        };
+        const isCurrent = createRefreshContextGuard(() => current, {
+            generation: 3,
+            program: oldProgram,
+        });
+        let resolveWork: () => void = () => {};
+        const applied = vi.fn();
+        const work = (async () => {
+            await new Promise<void>((resolve) => {
+                resolveWork = resolve;
+            });
+            if (isCurrent()) {
+                applied();
+            }
+        })();
+
+        current = { generation: 3, program: newProgram };
+        resolveWork();
+        await work;
+
+        expect(applied).not.toHaveBeenCalled();
+    });
+
+    it("immediately drains a replacement queued by a stale root-list result", async () => {
+        const queue = { current: "initial" as string | null };
+        const refreshes: string[] = [];
+
+        await drainCoalescedRefreshQueue(
+            queue,
+            () => true,
+            async (source) => {
+                refreshes.push(source);
+                if (source === "initial") {
+                    queueCoalescedRefresh(queue, "stale-root-revision");
+                }
+            }
+        );
+
+        expect(refreshes).toEqual(["initial", "stale-root-revision"]);
+        expect(queue.current).toBeNull();
+    });
+
+    it("reads the current role before allowing bound adaptive work", () => {
+        const program = {};
+        const context = { generation: 1, program };
+        let currentRole: false | { limits: object } = { limits: {} };
+        const canRefresh = () =>
+            isRefreshContextActive(context, context, currentRole !== false);
+
+        expect(canRefresh()).toBe(true);
+        currentRole = false;
+        expect(canRefresh()).toBe(false);
+    });
+
+    it("reports rejected scheduled work without an unhandled rejection", async () => {
+        vi.useFakeTimers();
+        const failure = new Error("refresh failed");
+        const onError = vi.fn();
+        const scheduled = callEvenInterval(
+            () => Promise.reject(failure),
+            500,
+            onError
+        );
+
+        scheduled();
+        await vi.advanceTimersByTimeAsync(500);
+
+        expect(onError).toHaveBeenCalledOnce();
+        expect(onError).toHaveBeenCalledWith(failure);
+    });
+
+    it("suppresses an in-flight failure after cancellation", async () => {
+        vi.useFakeTimers();
+        let rejectRefresh: (error: Error) => void = () => {};
+        const onError = vi.fn();
+        const scheduled = callEvenInterval(
+            () =>
+                new Promise<void>((_resolve, reject) => {
+                    rejectRefresh = reject;
+                }),
+            500,
+            onError
+        );
+
+        scheduled();
+        vi.advanceTimersByTime(500);
+        await Promise.resolve();
+        scheduled.cancel();
+        rejectRefresh(new Error("stale refresh failed"));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(onError).not.toHaveBeenCalled();
+    });
+});

--- a/packages/file-share/frontend/tests/remote-root-confirmation.unit.test.ts
+++ b/packages/file-share/frontend/tests/remote-root-confirmation.unit.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+    SearchRequest,
+    StringMatch,
+    StringMatchMethod,
+} from "@peerbit/document";
+import type { AbstractFile, Files } from "@peerbit/please-lib";
+import {
+    DEFAULT_REMOTE_ROOT_CONFIRMATION_TIMEOUT_MS,
+    confirmRemoteRoot,
+} from "../src/remote-root-confirmation";
+
+const root = {
+    id: "root",
+    name: "root.bin",
+    size: 1n,
+} as AbstractFile;
+
+const createProgram = (properties?: {
+    hints?: string[] | undefined;
+    search?: ReturnType<typeof vi.fn>;
+    get?: ReturnType<typeof vi.fn>;
+}) => {
+    const search = properties?.search ?? vi.fn().mockResolvedValue([root]);
+    const get = properties?.get ?? vi.fn();
+    const hints =
+        properties && "hints" in properties
+            ? properties.hints
+            : ["peer-a", "peer-b"];
+    const getReadPeerHints = vi.fn().mockResolvedValue(hints);
+    const program = {
+        getReadPeerHints,
+        files: { index: { get, search } },
+    } as unknown as Files;
+    return { get, getReadPeerHints, program, search };
+};
+
+describe("remote root confirmation", () => {
+    it("uses a frozen peer snapshot for a bounded, non-replicating exact lookup", async () => {
+        const hints = ["peer-a", "peer-b"];
+        const { get, program, search } = createProgram({ hints });
+        const controller = new AbortController();
+
+        await expect(
+            confirmRemoteRoot(program, "root", controller.signal)
+        ).resolves.toEqual({ status: "present", root });
+
+        expect(get).not.toHaveBeenCalled();
+        expect(search).toHaveBeenCalledOnce();
+        const [request, options] = search.mock.calls[0];
+        expect(request).toBeInstanceOf(SearchRequest);
+        expect(request.fetch).toBe(0xffffffff);
+        expect(request.query).toHaveLength(1);
+        expect(request.query[0]).toBeInstanceOf(StringMatch);
+        expect(request.query[0]).toMatchObject({
+            key: ["id"],
+            value: "root",
+            caseInsensitive: false,
+            method: StringMatchMethod.exact,
+        });
+        expect(options).toEqual({
+            local: false,
+            signal: controller.signal,
+            remote: {
+                from: ["peer-a", "peer-b"],
+                replicate: false,
+                timeout: DEFAULT_REMOTE_ROOT_CONFIRMATION_TIMEOUT_MS,
+                throwOnMissing: true,
+                retryMissingResponses: false,
+                strategy: "fallback",
+            },
+        });
+        expect(options.remote.from).not.toBe(hints);
+    });
+
+    it("keeps a later peer result when an earlier response set is empty", async () => {
+        const responseSets = [[], [root]] as AbstractFile[][];
+        const get = vi.fn().mockResolvedValue(undefined);
+        const search = vi
+            .fn()
+            .mockResolvedValue(responseSets.flatMap((results) => results));
+        const { program } = createProgram({ get, search });
+
+        await expect(
+            confirmRemoteRoot(program, "root", new AbortController().signal)
+        ).resolves.toEqual({ status: "present", root });
+        expect(get).not.toHaveBeenCalled();
+        expect(search).toHaveBeenCalledOnce();
+    });
+
+    it.each([undefined, []])(
+        "returns unknown without querying when hints are %s",
+        async (hints) => {
+            const search = vi.fn();
+            const { program } = createProgram({ hints, search });
+
+            await expect(
+                confirmRemoteRoot(program, "root", new AbortController().signal)
+            ).resolves.toMatchObject({ status: "unknown" });
+            expect(search).not.toHaveBeenCalled();
+        }
+    );
+
+    it("classifies a successful empty response as missing", async () => {
+        const { program } = createProgram({
+            search: vi.fn().mockResolvedValue([]),
+        });
+
+        await expect(
+            confirmRemoteRoot(program, "root", new AbortController().signal)
+        ).resolves.toEqual({ status: "missing" });
+    });
+
+    it("classifies lookup failures as unknown and preserves their message", async () => {
+        const { program } = createProgram({
+            search: vi
+                .fn()
+                .mockRejectedValue(new Error("missing peer response")),
+        });
+
+        await expect(
+            confirmRemoteRoot(program, "root", new AbortController().signal)
+        ).resolves.toEqual({
+            status: "unknown",
+            diagnostic: "missing peer response",
+        });
+    });
+
+    it("classifies cancellation as unknown without starting a lookup", async () => {
+        const search = vi.fn();
+        const { getReadPeerHints, program } = createProgram({ search });
+        const controller = new AbortController();
+        controller.abort();
+
+        await expect(
+            confirmRemoteRoot(program, "root", controller.signal)
+        ).resolves.toMatchObject({ status: "unknown" });
+        expect(getReadPeerHints).not.toHaveBeenCalled();
+        expect(search).not.toHaveBeenCalled();
+    });
+
+    it("does not classify a returned child document as a present root", async () => {
+        const child = {
+            ...root,
+            id: "child",
+            parentId: "root",
+        } as AbstractFile;
+        const { program } = createProgram({
+            search: vi.fn().mockResolvedValue([child]),
+        });
+
+        await expect(
+            confirmRemoteRoot(program, "root", new AbortController().signal)
+        ).resolves.toEqual({
+            status: "unknown",
+            diagnostic: "Exact root search returned no valid root document",
+        });
+    });
+
+    it("does not classify a mismatched document id as the requested root", async () => {
+        const mismatch = {
+            ...root,
+            id: "different-root",
+        } as AbstractFile;
+        const { program } = createProgram({
+            search: vi.fn().mockResolvedValue([mismatch]),
+        });
+
+        await expect(
+            confirmRemoteRoot(program, "root", new AbortController().signal)
+        ).resolves.toEqual({
+            status: "unknown",
+            diagnostic: "Exact root search returned no valid root document",
+        });
+    });
+});

--- a/packages/file-share/frontend/tests/remote-root-reconciliation.unit.test.ts
+++ b/packages/file-share/frontend/tests/remote-root-reconciliation.unit.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AbstractFile } from "@peerbit/please-lib";
+import {
+    applyRemoteRootConfirmation,
+    createRemoteRootConfirmationScheduler,
+    createRemoteRootReconciliationState,
+    invalidateRemoteRootAbsenceForVisibleRoots,
+    isRemoteRootObservationCurrent,
+    observeLocalRootSnapshot,
+    observeRemoteRootSnapshot,
+    recordExplicitRootChange,
+} from "../src/remote-root-reconciliation";
+
+const root = (id: string, modified = 1n, head = `${id}-${modified}`) =>
+    ({
+        id,
+        name: `${id}.bin`,
+        size: 1n,
+        __context: { head, modified },
+    }) as AbstractFile;
+
+describe("remote root reconciliation", () => {
+    it("retains a partial absence until an exact lookup confirms missing", () => {
+        const state = createRemoteRootReconciliationState();
+        const discovered = root("remote");
+        observeLocalRootSnapshot(state, []);
+        expect(observeRemoteRootSnapshot(state, [discovered])).toMatchObject({
+            visibleRoots: [discovered],
+            confirmationIds: [],
+        });
+        expect(state.remoteOnlyIds.has("remote")).toBe(true);
+
+        const partial = observeRemoteRootSnapshot(state, []);
+        expect(partial.confirmationIds).toEqual(["remote"]);
+        expect(state.remoteOnlyIds.has("remote")).toBe(true);
+        expect(
+            applyRemoteRootConfirmation(state, "remote", {
+                status: "unknown",
+            })
+        ).toEqual({ type: "retain", retry: true });
+        expect(state.remoteOnlyIds.has("remote")).toBe(true);
+
+        expect(
+            applyRemoteRootConfirmation(state, "remote", {
+                status: "missing",
+            })
+        ).toEqual({ type: "remove", retry: false });
+        expect(state.remoteOnlyIds.has("remote")).toBe(false);
+        expect(state.suppressedIds.has("remote")).toBe(true);
+        expect(state.suppressedIds.get("remote")?.version).toEqual({
+            head: "remote-1",
+            modified: 1n,
+        });
+    });
+
+    it("never schedules or removes a locally observed root for remote absence", () => {
+        const state = createRemoteRootReconciliationState();
+        const local = root("local");
+        observeLocalRootSnapshot(state, [local]);
+        observeRemoteRootSnapshot(state, [local]);
+
+        expect(observeRemoteRootSnapshot(state, []).confirmationIds).toEqual(
+            []
+        );
+        expect(
+            applyRemoteRootConfirmation(state, "local", {
+                status: "missing",
+            })
+        ).toEqual({ type: "retain", retry: false });
+        expect(state.localRootIds.has("local")).toBe(true);
+        expect(state.suppressedIds.has("local")).toBe(false);
+    });
+
+    it("moves a root that vanished locally into exact-confirmation provenance", () => {
+        const state = createRemoteRootReconciliationState();
+        observeLocalRootSnapshot(state, [root("local")]);
+
+        observeLocalRootSnapshot(state, []);
+        expect(state.localRootIds.has("local")).toBe(false);
+        expect(state.remoteOnlyIds.has("local")).toBe(true);
+        expect(observeRemoteRootSnapshot(state, []).confirmationIds).toEqual([
+            "local",
+        ]);
+    });
+
+    it("filters stale bulk additions without clearing suppression", () => {
+        const state = createRemoteRootReconciliationState();
+        recordExplicitRootChange(state, {
+            removed: [root("root", 5n)],
+            added: [],
+        });
+
+        const bulk = observeRemoteRootSnapshot(state, [root("root", 5n)]);
+        expect(bulk.visibleRoots).toEqual([]);
+        expect(bulk.confirmationIds).toEqual(["root"]);
+        expect(state.suppressedIds.has("root")).toBe(true);
+    });
+
+    it("rejects stale or unversioned exact presence and accepts only a newer recreation", () => {
+        const state = createRemoteRootReconciliationState();
+        const removed = root("root", 5n);
+        recordExplicitRootChange(state, {
+            removed: [removed],
+            added: [],
+        });
+
+        expect(
+            applyRemoteRootConfirmation(state, "root", {
+                status: "present",
+                root: removed,
+            })
+        ).toEqual({ type: "retain", retry: true });
+        expect(
+            applyRemoteRootConfirmation(state, "root", {
+                status: "present",
+                root: root("root", 4n),
+            })
+        ).toEqual({ type: "retain", retry: true });
+        expect(
+            applyRemoteRootConfirmation(state, "root", {
+                status: "present",
+                root: {
+                    id: "root",
+                    name: "root.bin",
+                    size: 1n,
+                } as AbstractFile,
+            })
+        ).toEqual({ type: "retain", retry: true });
+        expect(state.suppressedIds.has("root")).toBe(true);
+
+        const recreated = root("root", 6n);
+        expect(
+            applyRemoteRootConfirmation(state, "root", {
+                status: "present",
+                root: recreated,
+            })
+        ).toEqual({ type: "merge", root: recreated, retry: false });
+        expect(state.suppressedIds.has("root")).toBe(false);
+        expect(state.remoteOnlyIds.has("root")).toBe(true);
+    });
+
+    it("lets an authoritative explicit add win after a removal", () => {
+        const state = createRemoteRootReconciliationState();
+
+        recordExplicitRootChange(state, {
+            removed: [root("root", 5n)],
+            added: [root("root", 6n)],
+        });
+        expect(state.suppressedIds.has("root")).toBe(false);
+        expect(state.remoteOnlyIds.has("root")).toBe(false);
+        expect(state.localRootIds.has("root")).toBe(true);
+    });
+
+    it("invalidates an older missing confirmation when a newer bulk snapshot sees the root", async () => {
+        const state = createRemoteRootReconciliationState();
+        const discovered = root("remote", 1n);
+        observeRemoteRootSnapshot(state, [discovered]);
+        expect(observeRemoteRootSnapshot(state, []).confirmationIds).toEqual([
+            "remote",
+        ]);
+
+        let releaseMissing: () => void = () => {};
+        const onResult = vi.fn((id: string) => {
+            applyRemoteRootConfirmation(state, id, { status: "missing" });
+            return "complete" as const;
+        });
+        const scheduler = createRemoteRootConfirmationScheduler<
+            { revision: number },
+            { status: "missing" }
+        >({
+            confirm: () =>
+                new Promise((resolve) => {
+                    releaseMissing = () => resolve({ status: "missing" });
+                }),
+            onResult,
+        });
+
+        const pending = scheduler.schedule(["remote"], { revision: 1 });
+        await Promise.resolve();
+        await Promise.resolve();
+        const visible = observeRemoteRootSnapshot(state, [root("remote", 2n)]);
+        invalidateRemoteRootAbsenceForVisibleRoots(
+            scheduler,
+            visible.visibleRoots
+        );
+        releaseMissing();
+        await pending;
+
+        expect(onResult).not.toHaveBeenCalled();
+        expect(state.remoteOnlyIds.has("remote")).toBe(true);
+        expect(state.suppressedIds.has("remote")).toBe(false);
+    });
+
+    it("rejects stale generation, program, and root-revision observations", () => {
+        const program = {};
+        const expected = { generation: 2, program, rootRevision: 4 };
+        expect(isRemoteRootObservationCurrent(expected, expected)).toBe(true);
+        expect(
+            isRemoteRootObservationCurrent(
+                { ...expected, generation: 3 },
+                expected
+            )
+        ).toBe(false);
+        expect(
+            isRemoteRootObservationCurrent(
+                { ...expected, program: {} },
+                expected
+            )
+        ).toBe(false);
+        expect(
+            isRemoteRootObservationCurrent(
+                { ...expected, rootRevision: 5 },
+                expected
+            )
+        ).toBe(false);
+    });
+
+    it("caps and rotates work while respecting concurrency", async () => {
+        let active = 0;
+        let maxActive = 0;
+        let release: () => void = () => {};
+        const gate = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+        const calls: string[] = [];
+        let firstRetry = true;
+        const scheduler = createRemoteRootConfirmationScheduler<
+            { revision: number },
+            string
+        >({
+            maxCandidatesPerRun: 8,
+            concurrency: 2,
+            confirm: async (id) => {
+                calls.push(id);
+                active += 1;
+                maxActive = Math.max(maxActive, active);
+                await gate;
+                active -= 1;
+                return id;
+            },
+            onResult: (id) => {
+                if (id === "root-0" && firstRetry) {
+                    firstRetry = false;
+                    return "retry";
+                }
+                return "complete";
+            },
+        });
+
+        const firstRun = scheduler.schedule(
+            Array.from({ length: 10 }, (_, index) => `root-${index}`),
+            { revision: 1 }
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(calls).toEqual(["root-0", "root-1"]);
+        expect(maxActive).toBe(2);
+        release();
+        await firstRun;
+        expect(calls).toEqual(
+            Array.from({ length: 8 }, (_, index) => `root-${index}`)
+        );
+        expect(scheduler.queuedSize).toBe(3);
+
+        await scheduler.schedule([], { revision: 2 });
+        expect(calls.slice(8)).toEqual(["root-8", "root-9", "root-0"]);
+        expect(maxActive).toBe(2);
+        expect(scheduler.queuedSize).toBe(0);
+    });
+
+    it("defers an immediate reschedule after forgetting an in-flight id", async () => {
+        const releases: Array<() => void> = [];
+        const calls: string[] = [];
+        const scheduler = createRemoteRootConfirmationScheduler<
+            { revision: number },
+            string
+        >({
+            confirm: (id) => {
+                calls.push(id);
+                return new Promise<string>((resolve) => {
+                    releases.push(() => resolve(id));
+                });
+            },
+            onResult: () => "complete",
+        });
+
+        const first = scheduler.schedule(["root"], { revision: 1 });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(scheduler.isPending("root")).toBe(true);
+        scheduler.forget("root");
+        const replacement = scheduler.schedule(["root"], { revision: 2 });
+        expect(scheduler.isPending("root")).toBe(true);
+
+        releases.shift()!();
+        await vi.waitFor(() => {
+            expect(calls).toEqual(["root", "root"]);
+        });
+        releases.shift()!();
+        await Promise.all([first, replacement]);
+        expect(scheduler.isPending("root")).toBe(false);
+    });
+
+    it("requeues a stale result with the latest observed context", async () => {
+        let releaseFirst: () => void = () => {};
+        let attempt = 0;
+        const appliedRevisions: number[] = [];
+        const scheduler = createRemoteRootConfirmationScheduler<
+            { revision: number },
+            string
+        >({
+            confirm: async (id) => {
+                attempt += 1;
+                if (attempt === 1) {
+                    await new Promise<void>((resolve) => {
+                        releaseFirst = resolve;
+                    });
+                }
+                return id;
+            },
+            onResult: (_id, _result, context) => {
+                appliedRevisions.push(context.revision);
+                return context.revision === 2 ? "complete" : "retry";
+            },
+        });
+
+        const first = scheduler.schedule(["root"], { revision: 1 });
+        await Promise.resolve();
+        await Promise.resolve();
+        const latest = scheduler.schedule(["root"], { revision: 2 });
+        releaseFirst();
+        await Promise.all([first, latest]);
+
+        expect(attempt).toBe(2);
+        expect(appliedRevisions).toEqual([1, 2]);
+        expect(scheduler.isPending("root")).toBe(false);
+    });
+
+    it("starts and awaits a new epoch immediately after reset", async () => {
+        let releaseFresh: () => void = () => {};
+        const scheduler = createRemoteRootConfirmationScheduler<
+            { revision: number },
+            string
+        >({
+            confirm: (id, signal) => {
+                if (id === "old") {
+                    return new Promise<string>((resolve) => {
+                        signal.addEventListener("abort", () => resolve(id), {
+                            once: true,
+                        });
+                    });
+                }
+                return new Promise<string>((resolve) => {
+                    releaseFresh = () => resolve(id);
+                });
+            },
+            onResult: () => "complete",
+        });
+
+        const oldDrain = scheduler.schedule(["old"], { revision: 1 });
+        await Promise.resolve();
+        await Promise.resolve();
+        scheduler.reset();
+        const freshDrain = scheduler.schedule(["fresh"], { revision: 2 });
+        expect(freshDrain).not.toBe(oldDrain);
+        let freshSettled = false;
+        void freshDrain.then(() => {
+            freshSettled = true;
+        });
+        await oldDrain;
+        await Promise.resolve();
+        expect(freshSettled).toBe(false);
+
+        releaseFresh();
+        await freshDrain;
+        expect(freshSettled).toBe(true);
+        expect(scheduler.isPending("fresh")).toBe(false);
+    });
+
+    it("singleflights ids and aborts shared in-flight work on reset", async () => {
+        const signals: AbortSignal[] = [];
+        const onResult = vi.fn(() => "complete" as const);
+        const scheduler = createRemoteRootConfirmationScheduler<
+            { revision: number },
+            string
+        >({
+            confirm: (id, signal) => {
+                signals.push(signal);
+                return new Promise<string>((resolve) => {
+                    signal.addEventListener("abort", () => resolve(id), {
+                        once: true,
+                    });
+                });
+            },
+            onResult,
+        });
+
+        const first = scheduler.schedule(["root"], { revision: 1 });
+        await Promise.resolve();
+        await Promise.resolve();
+        const duplicate = scheduler.schedule(["root"], { revision: 1 });
+        expect(signals).toHaveLength(1);
+        scheduler.reset();
+        await Promise.all([first, duplicate]);
+
+        expect(signals[0].aborted).toBe(true);
+        expect(onResult).not.toHaveBeenCalled();
+        expect(scheduler.inFlightSize).toBe(0);
+        expect(scheduler.queuedSize).toBe(0);
+    });
+});

--- a/packages/file-share/frontend/tests/root-list.unit.test.ts
+++ b/packages/file-share/frontend/tests/root-list.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { LargeFile, TinyFile } from "@peerbit/please-lib";
 import {
     applyRootFileChangeToList,
+    getPendingReadyRootReconciliation,
     getRootFileChange,
     shouldRefreshRootListForFileChange,
 } from "../src/root-list";
@@ -36,9 +37,9 @@ describe("root list change handling", () => {
         });
 
         expect(shouldRefreshRootListForFileChange(event)).to.equal(true);
-        expect(getRootFileChange(event).added.map((file) => file.id)).to.deep.eq(
-            ["root"]
-        );
+        expect(
+            getRootFileChange(event).added.map((file) => file.id)
+        ).to.deep.eq(["root"]);
     });
 
     it("does not refresh for child-only change batches", () => {
@@ -65,6 +66,21 @@ describe("root list change handling", () => {
                 (file) => file.name
             )
         ).to.deep.eq(["root.bin"]);
+    });
+
+    it("merges partial root snapshots without removing roots by absence", () => {
+        const existing = largeFile({ id: "existing", name: "existing.bin" });
+        const discovered = largeFile({
+            id: "discovered",
+            name: "discovered.bin",
+        });
+
+        expect(
+            applyRootFileChangeToList([existing], {
+                added: [discovered],
+                removed: [],
+            }).map((file) => file.id)
+        ).to.deep.eq(["discovered", "existing"]);
     });
 
     it("keeps ready root metadata over older pending metadata", () => {
@@ -97,5 +113,43 @@ describe("root list change handling", () => {
         });
 
         expect(next).to.deep.eq([]);
+    });
+
+    it("keeps an added root when the same change also removes its id", () => {
+        const previous = largeFile({ id: "root", name: "previous.bin" });
+        const replacement = largeFile({
+            id: "root",
+            name: "replacement.bin",
+            ready: true,
+            finalHash: "replacement-final",
+        });
+        const next = applyRootFileChangeToList([previous], {
+            added: [replacement],
+            removed: [{ id: "root", parentId: undefined }],
+        });
+
+        expect(next).to.deep.eq([replacement]);
+    });
+
+    it("partitions accepted root snapshots into pending starts and ready cancellations", () => {
+        const pending = largeFile({ id: "pending", name: "pending.bin" });
+        const ready = largeFile({
+            id: "ready",
+            name: "ready.bin",
+            ready: true,
+            finalHash: "final",
+        });
+        const tiny = new TinyFile({
+            id: "tiny",
+            name: "tiny.bin",
+            file: new Uint8Array([1]),
+        });
+
+        expect(
+            getPendingReadyRootReconciliation([pending, ready, tiny])
+        ).toEqual({
+            pending: [pending],
+            readyIds: ["ready"],
+        });
     });
 });

--- a/packages/file-share/frontend/tests/routes.unit.test.ts
+++ b/packages/file-share/frontend/tests/routes.unit.test.ts
@@ -1,0 +1,300 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import {
+    MemoryRouter,
+    Route,
+    Routes,
+    useNavigate,
+    type NavigateFunction,
+} from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AddressKeyedDrop } from "../src/routes";
+import {
+    applyReplicationRoleGuarded,
+    applyReplicationRoleUntilStable,
+    createFileShareReplicationRole,
+    DEFAULT_REPLICATION_ROLE,
+    FILE_SHARE_QUIET_REBALANCE_INTERVAL_MS,
+    formatFileShareStorageMegabytes,
+    getInitialReplicationRole,
+    normalizeFileShareReplicationRole,
+    parseFileShareStorageMegabytes,
+} from "../src/role-state";
+import type { Files } from "@peerbit/please-lib";
+import type { ReplicationOptions } from "@peerbit/shared-log";
+
+const dropLifecycle = vi.hoisted(() => ({ mounts: 0, unmounts: 0 }));
+
+vi.mock("../src/Drop", async () => {
+    const { useEffect } = await import("react");
+    return {
+        Drop: () => {
+            useEffect(() => {
+                dropLifecycle.mounts += 1;
+                return () => {
+                    dropLifecycle.unmounts += 1;
+                };
+            }, []);
+            return null;
+        },
+    };
+});
+
+describe("file-share route state", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("remounts route state when only the address parameter changes", async () => {
+        dropLifecycle.mounts = 0;
+        dropLifecycle.unmounts = 0;
+        let navigate: NavigateFunction | undefined;
+        const RouteHarness = () => {
+            navigate = useNavigate();
+            return createElement(
+                Routes,
+                null,
+                createElement(Route, {
+                    path: "/s/:address",
+                    element: createElement(AddressKeyedDrop),
+                })
+            );
+        };
+        const container = document.createElement("div");
+        document.body.append(container);
+        const root = createRoot(container);
+        (
+            globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+        ).IS_REACT_ACT_ENVIRONMENT = true;
+
+        await act(async () => {
+            root.render(
+                createElement(
+                    MemoryRouter,
+                    { initialEntries: ["/s/first"] },
+                    createElement(RouteHarness)
+                )
+            );
+        });
+        expect(dropLifecycle.mounts).toBe(1);
+
+        await act(async () => {
+            navigate?.("/s/second");
+        });
+        expect(dropLifecycle.mounts).toBe(2);
+        expect(dropLifecycle.unmounts).toBe(1);
+
+        await act(async () => root.unmount());
+    });
+
+    it("uses the default replication role when a share has no stored role", () => {
+        expect(getInitialReplicationRole(null)).toBe(DEFAULT_REPLICATION_ROLE);
+        expect(getInitialReplicationRole("false")).toBe(false);
+    });
+
+    it("quiets only unconstrained file-share replication roles", () => {
+        expect(createFileShareReplicationRole({ cpuMax: 1 })).toEqual({
+            limits: {
+                cpu: { max: 1 },
+                storage: undefined,
+                interval: FILE_SHARE_QUIET_REBALANCE_INTERVAL_MS,
+            },
+        });
+        expect(createFileShareReplicationRole({})).toEqual({
+            limits: {
+                cpu: undefined,
+                storage: undefined,
+                interval: FILE_SHARE_QUIET_REBALANCE_INTERVAL_MS,
+            },
+        });
+        expect(createFileShareReplicationRole({ cpuMax: 0.5 })).toEqual({
+            limits: {
+                cpu: { max: 0.5 },
+                storage: undefined,
+            },
+        });
+        expect(
+            createFileShareReplicationRole({ cpuMax: 1, storage: 1_000_000 })
+        ).toEqual({
+            limits: {
+                cpu: { max: 1 },
+                storage: 1_000_000,
+            },
+        });
+    });
+
+    it("round-trips persisted storage bytes through the megabyte input", () => {
+        const persistedStorageBytes = 100_000_000;
+        const inputValue = formatFileShareStorageMegabytes(
+            persistedStorageBytes
+        );
+
+        expect(inputValue).toBe("100");
+        expect(parseFileShareStorageMegabytes(inputValue)).toBe(
+            persistedStorageBytes
+        );
+    });
+
+    it("normalizes legacy default roles without overriding explicit intervals", () => {
+        expect(
+            normalizeFileShareReplicationRole({
+                limits: { cpu: { max: 1 } },
+            })
+        ).toEqual({
+            limits: {
+                cpu: { max: 1 },
+                interval: FILE_SHARE_QUIET_REBALANCE_INTERVAL_MS,
+            },
+        });
+        const explicit = {
+            limits: { cpu: { max: 1 }, interval: 12_345 },
+        } satisfies ReplicationOptions;
+        expect(normalizeFileShareReplicationRole(explicit)).toBe(explicit);
+    });
+
+    it("enables the requested replication role while its context stays current", async () => {
+        const calls: ReplicationOptions[] = [];
+        const program = {
+            closed: false,
+            persistChunkReads: false,
+            files: {
+                log: {
+                    replicate: vi.fn(async (role: ReplicationOptions) => {
+                        calls.push(role);
+                    }),
+                },
+            },
+        } as unknown as Files;
+        const requestedRole: ReplicationOptions = { limits: {} };
+
+        await applyReplicationRoleGuarded(program, requestedRole, {
+            expectedRevision: 1,
+            getCurrentRevision: () => 1,
+            getCurrentRole: () => requestedRole,
+            isContextActive: () => true,
+        });
+
+        expect(calls).toEqual([false, requestedRole]);
+        expect(program.persistChunkReads).toBe(true);
+    });
+
+    it("does not re-enable a role that changed while replication was disabling", async () => {
+        let releaseDisable: () => void = () => {};
+        const disabled = new Promise<void>((resolve) => {
+            releaseDisable = resolve;
+        });
+        const calls: ReplicationOptions[] = [];
+        const program = {
+            closed: false,
+            persistChunkReads: false,
+            files: {
+                log: {
+                    replicate: vi.fn(async (role: ReplicationOptions) => {
+                        calls.push(role);
+                        if (role === false) {
+                            await disabled;
+                        }
+                    }),
+                },
+            },
+        } as unknown as Files;
+        const requestedRole: ReplicationOptions = { limits: {} };
+        let currentRole: ReplicationOptions = requestedRole;
+        let revision = 1;
+
+        const applying = applyReplicationRoleGuarded(program, requestedRole, {
+            expectedRevision: revision,
+            getCurrentRevision: () => revision,
+            getCurrentRole: () => currentRole,
+            isContextActive: () => true,
+        });
+        currentRole = false;
+        revision += 1;
+        releaseDisable();
+        await applying;
+
+        expect(calls).toEqual([false]);
+    });
+
+    it("does not re-enable replication after its share context becomes stale", async () => {
+        let releaseDisable: () => void = () => {};
+        const disabled = new Promise<void>((resolve) => {
+            releaseDisable = resolve;
+        });
+        const calls: ReplicationOptions[] = [];
+        const program = {
+            closed: false,
+            persistChunkReads: false,
+            files: {
+                log: {
+                    replicate: vi.fn(async (role: ReplicationOptions) => {
+                        calls.push(role);
+                        if (role === false) {
+                            await disabled;
+                        }
+                    }),
+                },
+            },
+        } as unknown as Files;
+        const requestedRole: ReplicationOptions = { limits: {} };
+        let active = true;
+
+        const applying = applyReplicationRoleGuarded(program, requestedRole, {
+            expectedRevision: 1,
+            getCurrentRevision: () => 1,
+            getCurrentRole: () => requestedRole,
+            isContextActive: () => active,
+        });
+        active = false;
+        releaseDisable();
+        await applying;
+
+        expect(calls).toEqual([false]);
+    });
+
+    it("reapplies the newest role until multiple racing revisions settle", async () => {
+        const role1: ReplicationOptions = { limits: { memory: 1 } };
+        const role2: ReplicationOptions = { limits: { memory: 2 } };
+        const role3: ReplicationOptions = { limits: { memory: 3 } };
+        let currentRole = role1;
+        let revision = 1;
+        let disableCount = 0;
+        const calls: ReplicationOptions[] = [];
+        const program = {
+            closed: false,
+            persistChunkReads: false,
+            files: {
+                log: {
+                    replicate: vi.fn(async (role: ReplicationOptions) => {
+                        calls.push(role);
+                        if (role !== false) {
+                            return;
+                        }
+                        disableCount += 1;
+                        if (disableCount === 1) {
+                            currentRole = role2;
+                            revision = 2;
+                        } else if (disableCount === 2) {
+                            currentRole = role3;
+                            revision = 3;
+                        }
+                    }),
+                },
+            },
+        } as unknown as Files;
+
+        const appliedRevision = await applyReplicationRoleUntilStable(
+            program,
+            1,
+            {
+                getCurrentRevision: () => revision,
+                getCurrentRole: () => currentRole,
+                isContextActive: () => true,
+            }
+        );
+
+        expect(appliedRevision).toBe(3);
+        expect(calls).toEqual([false, false, false, role3]);
+        expect(program.persistChunkReads).toBe(true);
+    });
+});

--- a/packages/file-share/frontend/tests/transfer-benchmark.ts
+++ b/packages/file-share/frontend/tests/transfer-benchmark.ts
@@ -1,0 +1,350 @@
+export const READER_COHORTS = [
+    "live-replicator",
+    "cold-observer",
+    "cold-persisted-read",
+] as const;
+
+export type ReaderCohort = (typeof READER_COHORTS)[number];
+
+export const TINY_FILE_SIZE_LIMIT_BYTES = 5_000_000;
+const MEBIBYTE_BYTES = 1024 * 1024;
+
+export const validateLargeFileBenchmarkSizeMb = (fileSizeMb: number) => {
+    const sizeBytes = fileSizeMb * MEBIBYTE_BYTES;
+    if (!Number.isSafeInteger(sizeBytes) || sizeBytes < 0) {
+        throw new Error(
+            `Invalid file-share benchmark configuration: PW_FILE_MB='${fileSizeMb}' must resolve to a non-negative safe-integer byte size`
+        );
+    }
+    if (sizeBytes <= TINY_FILE_SIZE_LIMIT_BYTES) {
+        throw new Error(
+            `Invalid file-share benchmark configuration: PW_FILE_MB='${fileSizeMb}' resolves to ${sizeBytes} bytes, which uses TinyFile at or below the ${TINY_FILE_SIZE_LIMIT_BYTES}-byte cutoff; this benchmark requires the LargeFile ready-manifest protocol (use 6 MiB or larger)`
+        );
+    }
+    return sizeBytes;
+};
+
+export const stopSamplerAtCompletion = <TResult, TMeasurement>(
+    completion: Promise<TResult>,
+    sampler: { stop: () => Promise<TMeasurement> }
+) =>
+    completion.then(async (result) => ({
+        result,
+        measurement: await sampler.stop(),
+    }));
+
+export type JsHeapMeasurementSummary = {
+    sampleCount: number;
+    startBytes: number | null;
+    endBytes: number | null;
+    peakBytes: number | null;
+};
+
+const isFiniteHeapByteValue = (value: unknown): value is number =>
+    typeof value === "number" && Number.isFinite(value) && value >= 0;
+
+export const validateJsHeapMeasurement = (
+    measurement: JsHeapMeasurementSummary | null | undefined
+) => {
+    const validationReasons: string[] = [];
+    if (measurement == null) {
+        validationReasons.push("missing-js-heap-measurement");
+        return { valid: false, validationReasons };
+    }
+    if (
+        !Number.isFinite(measurement.sampleCount) ||
+        measurement.sampleCount <= 0
+    ) {
+        validationReasons.push("invalid-js-heap-sample-count");
+    }
+    if (!isFiniteHeapByteValue(measurement.startBytes)) {
+        validationReasons.push("invalid-js-heap-start-bytes");
+    }
+    if (!isFiniteHeapByteValue(measurement.endBytes)) {
+        validationReasons.push("invalid-js-heap-end-bytes");
+    }
+    if (!isFiniteHeapByteValue(measurement.peakBytes)) {
+        validationReasons.push("invalid-js-heap-peak-bytes");
+    }
+    return {
+        valid: validationReasons.length === 0,
+        validationReasons,
+    };
+};
+
+const BROWSER_DIAL_TRANSPORT =
+    /\/(?:ws|wss|webrtc|webrtc-direct|webtransport)(?:\/|$)/;
+
+export const getBrowserDialablePeerAddresses = (value: unknown) => {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    return [
+        ...new Set(
+            value
+                .filter(
+                    (address): address is string => typeof address === "string"
+                )
+                .map((address) => address.trim())
+                .filter(
+                    (address) =>
+                        address.length > 0 &&
+                        address.includes("/p2p/") &&
+                        BROWSER_DIAL_TRANSPORT.test(address)
+                )
+        ),
+    ];
+};
+
+export const buildReaderShareUrlWithPeerHints = (
+    shareHref: string,
+    addresses: unknown
+) => {
+    const peerAddresses = getBrowserDialablePeerAddresses(addresses);
+    if (peerAddresses.length === 0) {
+        throw new Error(
+            "Writer did not expose a browser-dialable direct peer address"
+        );
+    }
+    const url = new URL(shareHref);
+    url.searchParams.delete("bootstrap");
+    url.searchParams.set("peer", peerAddresses.join(","));
+    return {
+        href: url.toString(),
+        peerAddresses,
+    };
+};
+
+export const resolveReaderCohort = (
+    explicitCohort?: string,
+    legacyRole?: string
+): ReaderCohort => {
+    if (explicitCohort) {
+        if ((READER_COHORTS as readonly string[]).includes(explicitCohort)) {
+            return explicitCohort as ReaderCohort;
+        }
+        throw new Error(`Unsupported PW_READER_COHORT='${explicitCohort}'`);
+    }
+
+    if (!legacyRole || legacyRole === "adaptive") {
+        return "live-replicator";
+    }
+    if (legacyRole === "observer") {
+        return "cold-observer";
+    }
+    throw new Error(`Unsupported PW_READER_ROLE='${legacyRole}'`);
+};
+
+export const getLegacyReaderRole = (cohort: ReaderCohort) =>
+    cohort === "live-replicator" ? "adaptive" : "observer";
+
+export type ReaderTopologyEvidence = {
+    capturedAt: number | null;
+    peersProvided: boolean | null;
+    peerHintSource: string | null;
+    peerAddressCount: number | null;
+    appConnectionState: string | null;
+    appDialStartedAt: number | null;
+    appDialFinishedAt: number | null;
+    connectionCount: number | null;
+    peerHash: string | null;
+    replicatorCount: number | null;
+    selfInReplicatorSet: boolean | null;
+};
+
+export const classifyReaderTopology = (
+    cohort: ReaderCohort,
+    evidence: ReaderTopologyEvidence
+) => {
+    const validationReasons: string[] = [];
+    if (evidence.appConnectionState !== "ready") {
+        validationReasons.push("app-dial-not-ready");
+    }
+    if (evidence.peersProvided !== true) {
+        validationReasons.push("app-peer-hints-not-provided");
+    }
+    if (evidence.peerHintSource !== "peer") {
+        validationReasons.push("app-direct-peer-hints-not-provided");
+    }
+    if (evidence.peerAddressCount == null) {
+        validationReasons.push("missing-app-peer-address-count");
+    } else if (evidence.peerAddressCount < 1) {
+        validationReasons.push("no-app-peer-addresses");
+    }
+    if (evidence.appDialStartedAt == null) {
+        validationReasons.push("app-dial-not-started");
+    }
+    if (evidence.appDialFinishedAt == null) {
+        validationReasons.push("app-dial-not-finished");
+    } else if (
+        evidence.appDialStartedAt != null &&
+        evidence.appDialFinishedAt < evidence.appDialStartedAt
+    ) {
+        validationReasons.push("app-dial-timestamps-invalid");
+    }
+    if (evidence.connectionCount == null) {
+        validationReasons.push("missing-libp2p-connection-count");
+    } else if (evidence.connectionCount < 1) {
+        validationReasons.push("no-libp2p-connections");
+    }
+    if (!evidence.peerHash) {
+        validationReasons.push("missing-peer-hash");
+    }
+    if (evidence.selfInReplicatorSet == null) {
+        validationReasons.push("missing-replicator-membership");
+    } else if (cohort === "live-replicator" && !evidence.selfInReplicatorSet) {
+        validationReasons.push("reader-not-in-replicator-set");
+    } else if (cohort !== "live-replicator" && evidence.selfInReplicatorSet) {
+        validationReasons.push("cold-reader-in-replicator-set");
+    }
+
+    return {
+        cohort,
+        expectedSelfInReplicatorSet: cohort === "live-replicator",
+        ready: validationReasons.length === 0,
+        evidence,
+        validationReasons,
+    };
+};
+
+export type ReaderCohortEvidence = {
+    integrityVerified: boolean;
+    programPersistChunkReads: boolean | null;
+    persistChunkReads: boolean | null;
+    initialLocalChunkCount: number | null;
+    initialLocalChunkBlockCount: number | null;
+    readAheadSource: string | null;
+    postReadLocalChunkCount: number | null;
+    postReadLocalChunkBlockCount: number | null;
+    chunkCount: number | null;
+};
+
+const classifyLiveRead = ({
+    initialLocalChunkCount,
+    chunkCount,
+}: ReaderCohortEvidence) => {
+    if (initialLocalChunkCount == null) {
+        return "indexed-unknown";
+    }
+    if (initialLocalChunkCount === 0) {
+        return "indexed-cold";
+    }
+    if (
+        chunkCount != null &&
+        chunkCount > 0 &&
+        initialLocalChunkCount >= chunkCount
+    ) {
+        return "indexed-local";
+    }
+    return "indexed-hybrid";
+};
+
+export const classifyReaderCohort = (
+    cohort: ReaderCohort,
+    evidence: ReaderCohortEvidence
+) => {
+    const validationReasons: string[] = [];
+    if (!evidence.integrityVerified) {
+        validationReasons.push("integrity-not-verified");
+    }
+
+    let classification:
+        | "indexed-local"
+        | "indexed-hybrid"
+        | "indexed-cold"
+        | "indexed-unknown"
+        | "cold";
+    let classificationBasis: string;
+    if (cohort === "live-replicator") {
+        classification = classifyLiveRead(evidence);
+        classificationBasis = "initial-index-row-count";
+        if (evidence.programPersistChunkReads !== true) {
+            validationReasons.push("live-program-persistence-mismatch");
+        }
+        if (evidence.persistChunkReads !== true) {
+            validationReasons.push("live-effective-persistence-mismatch");
+        }
+        if (
+            evidence.readAheadSource !== "persisted-local" &&
+            evidence.readAheadSource !== "persisted-remote-adaptive"
+        ) {
+            validationReasons.push("live-read-ahead-mismatch");
+        }
+    } else if (cohort === "cold-observer") {
+        classification = "cold";
+        classificationBasis = "configured-cold-observer";
+        if (evidence.persistChunkReads !== false) {
+            validationReasons.push("observer-persistence-mismatch");
+        }
+        if (!evidence.readAheadSource?.startsWith("observer")) {
+            validationReasons.push("observer-read-ahead-mismatch");
+        }
+        if (
+            evidence.postReadLocalChunkBlockCount != null &&
+            evidence.postReadLocalChunkBlockCount !== 0
+        ) {
+            validationReasons.push("observer-persisted-chunks");
+        }
+    } else {
+        classification = "cold";
+        classificationBasis = "configured-cold-persisted-read";
+        if (evidence.programPersistChunkReads !== true) {
+            validationReasons.push(
+                "persisted-read-program-persistence-mismatch"
+            );
+        }
+        if (evidence.persistChunkReads !== true) {
+            validationReasons.push("persisted-read-persistence-mismatch");
+        }
+        if (evidence.initialLocalChunkCount !== 0) {
+            validationReasons.push(
+                evidence.initialLocalChunkCount == null
+                    ? "missing-initial-local-count"
+                    : "preloaded-local-chunks"
+            );
+        }
+        if (evidence.initialLocalChunkBlockCount !== 0) {
+            validationReasons.push(
+                evidence.initialLocalChunkBlockCount == null
+                    ? "missing-initial-local-block-count"
+                    : "preloaded-local-chunk-blocks"
+            );
+        }
+        if (evidence.readAheadSource !== "persisted-remote-adaptive") {
+            validationReasons.push("persisted-read-ahead-mismatch");
+        }
+        const hasKnownPositiveChunkCount =
+            evidence.chunkCount != null &&
+            Number.isFinite(evidence.chunkCount) &&
+            evidence.chunkCount > 0;
+        if (!hasKnownPositiveChunkCount) {
+            validationReasons.push(
+                evidence.chunkCount == null
+                    ? "missing-chunk-count"
+                    : "invalid-chunk-count"
+            );
+        }
+        if (evidence.postReadLocalChunkBlockCount == null) {
+            validationReasons.push("missing-post-read-local-block-count");
+        } else if (
+            hasKnownPositiveChunkCount &&
+            evidence.postReadLocalChunkBlockCount < evidence.chunkCount!
+        ) {
+            validationReasons.push("incomplete-post-read-local-chunk-blocks");
+        }
+    }
+
+    const valid = validationReasons.length === 0;
+    return {
+        cohort,
+        classification,
+        // Live replication is observational: all index-row starting states are
+        // eligible and must never be censored. Integrity and policy mismatches
+        // still mark the sample invalid.
+        eligible: cohort === "live-replicator" ? true : valid,
+        valid,
+        ...evidence,
+        classificationBasis,
+        validationReasons,
+    };
+};

--- a/packages/file-share/frontend/tests/transfer-benchmark.unit.test.ts
+++ b/packages/file-share/frontend/tests/transfer-benchmark.unit.test.ts
@@ -1,0 +1,479 @@
+import { describe, expect, it } from "vitest";
+import {
+    buildReaderShareUrlWithPeerHints,
+    classifyReaderCohort,
+    classifyReaderTopology,
+    getBrowserDialablePeerAddresses,
+    resolveReaderCohort,
+    stopSamplerAtCompletion,
+    TINY_FILE_SIZE_LIMIT_BYTES,
+    validateLargeFileBenchmarkSizeMb,
+    validateJsHeapMeasurement,
+    type ReaderCohortEvidence,
+    type ReaderTopologyEvidence,
+} from "./transfer-benchmark";
+
+const validEvidence = (
+    overrides: Partial<ReaderCohortEvidence> = {}
+): ReaderCohortEvidence => ({
+    integrityVerified: true,
+    programPersistChunkReads: true,
+    persistChunkReads: true,
+    initialLocalChunkCount: 0,
+    initialLocalChunkBlockCount: 0,
+    readAheadSource: "persisted-remote-adaptive",
+    postReadLocalChunkCount: 0,
+    postReadLocalChunkBlockCount: 8,
+    chunkCount: 8,
+    ...overrides,
+});
+
+const readyTopology = (
+    overrides: Partial<ReaderTopologyEvidence> = {}
+): ReaderTopologyEvidence => ({
+    capturedAt: 1_000,
+    peersProvided: true,
+    peerHintSource: "peer",
+    peerAddressCount: 1,
+    appConnectionState: "ready",
+    appDialStartedAt: 900,
+    appDialFinishedAt: 950,
+    connectionCount: 1,
+    peerHash: "reader-peer",
+    replicatorCount: 2,
+    selfInReplicatorSet: true,
+    ...overrides,
+});
+
+describe("file-share transfer benchmark cohorts", () => {
+    it("selects browser-dialable writer addresses without duplicates", () => {
+        expect(
+            getBrowserDialablePeerAddresses([
+                " /ip4/127.0.0.1/tcp/9000/ws/p2p/writer ",
+                "/ip4/127.0.0.1/tcp/9000/ws/p2p/writer",
+                "/ip4/127.0.0.1/tcp/9001/p2p/server-only",
+                123,
+            ])
+        ).toEqual(["/ip4/127.0.0.1/tcp/9000/ws/p2p/writer"]);
+    });
+
+    it("builds a direct reader URL while preserving the share hash", () => {
+        const result = buildReaderShareUrlWithPeerHints(
+            "http://127.0.0.1:9000/?bootstrap=relay#/s/share-address",
+            ["/ip4/127.0.0.1/tcp/9001/ws/p2p/writer"]
+        );
+        const url = new URL(result.href);
+
+        expect(url.hash).toBe("#/s/share-address");
+        expect(url.searchParams.has("bootstrap")).toBe(false);
+        expect(url.searchParams.get("peer")).toBe(
+            "/ip4/127.0.0.1/tcp/9001/ws/p2p/writer"
+        );
+        expect(result.peerAddresses).toHaveLength(1);
+    });
+
+    it("rejects reader URLs without a browser-dialable writer address", () => {
+        expect(() =>
+            buildReaderShareUrlWithPeerHints(
+                "http://127.0.0.1:9000/#/s/share-address",
+                ["/ip4/127.0.0.1/tcp/9001/p2p/server-only"]
+            )
+        ).toThrow("browser-dialable direct peer address");
+    });
+
+    it("stops sampling as soon as the primary sink completes", async () => {
+        let resolveSink: (result: {
+            sinkCompletedAt: number;
+        }) => void = () => {};
+        const sinkCompletion = new Promise<{ sinkCompletedAt: number }>(
+            (resolve) => {
+                resolveSink = resolve;
+            }
+        );
+        let writerWaitFinished = false;
+        let stopCount = 0;
+        const measuredCompletion = stopSamplerAtCompletion(sinkCompletion, {
+            stop: async () => {
+                stopCount += 1;
+                return {
+                    stoppedBeforeWriterWait: !writerWaitFinished,
+                };
+            },
+        });
+
+        resolveSink({ sinkCompletedAt: 123 });
+        const measured = await measuredCompletion;
+
+        expect(measured).toEqual({
+            result: { sinkCompletedAt: 123 },
+            measurement: { stoppedBeforeWriterWait: true },
+        });
+        expect(stopCount).toBe(1);
+        writerWaitFinished = true;
+    });
+
+    it("accepts a finite JS heap measurement with at least one sample", () => {
+        expect(
+            validateJsHeapMeasurement({
+                sampleCount: 1,
+                startBytes: 10,
+                endBytes: 12,
+                peakBytes: 14,
+            })
+        ).toEqual({ valid: true, validationReasons: [] });
+    });
+
+    it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+        "rejects an invalid JS heap sample count (%s)",
+        (sampleCount) => {
+            expect(
+                validateJsHeapMeasurement({
+                    sampleCount,
+                    startBytes: 10,
+                    endBytes: 12,
+                    peakBytes: 14,
+                }).validationReasons
+            ).toContain("invalid-js-heap-sample-count");
+        }
+    );
+
+    it("rejects missing or non-finite JS heap byte values", () => {
+        expect(
+            validateJsHeapMeasurement({
+                sampleCount: 3,
+                startBytes: null,
+                endBytes: Number.POSITIVE_INFINITY,
+                peakBytes: Number.NaN,
+            })
+        ).toEqual({
+            valid: false,
+            validationReasons: [
+                "invalid-js-heap-start-bytes",
+                "invalid-js-heap-end-bytes",
+                "invalid-js-heap-peak-bytes",
+            ],
+        });
+        expect(validateJsHeapMeasurement(undefined)).toEqual({
+            valid: false,
+            validationReasons: ["missing-js-heap-measurement"],
+        });
+    });
+
+    it("rejects TinyFile-sized benchmark fixtures at the exact byte boundary", () => {
+        const thresholdMiB = TINY_FILE_SIZE_LIMIT_BYTES / (1024 * 1024);
+        expect(() => validateLargeFileBenchmarkSizeMb(1)).toThrow(
+            "which uses TinyFile"
+        );
+        expect(() => validateLargeFileBenchmarkSizeMb(thresholdMiB)).toThrow(
+            "5000000-byte cutoff"
+        );
+    });
+
+    it("accepts the first byte above TinyFile and preserves 6 MiB benchmarks", () => {
+        expect(
+            validateLargeFileBenchmarkSizeMb(
+                (TINY_FILE_SIZE_LIMIT_BYTES + 1) / (1024 * 1024)
+            )
+        ).toBe(TINY_FILE_SIZE_LIMIT_BYTES + 1);
+        expect(validateLargeFileBenchmarkSizeMb(6)).toBe(6 * 1024 * 1024);
+    });
+
+    it("rejects benchmark sizes that cannot produce an integer byte length", () => {
+        expect(() => validateLargeFileBenchmarkSizeMb(Number.NaN)).toThrow(
+            "must resolve to a non-negative safe-integer byte size"
+        );
+        expect(() => validateLargeFileBenchmarkSizeMb(4.8)).toThrow(
+            "must resolve to a non-negative safe-integer byte size"
+        );
+    });
+
+    it("accepts explicit cohorts and maps legacy reader roles", () => {
+        expect(resolveReaderCohort("cold-persisted-read", "observer")).toBe(
+            "cold-persisted-read"
+        );
+        expect(resolveReaderCohort(undefined, "adaptive")).toBe(
+            "live-replicator"
+        );
+        expect(resolveReaderCohort(undefined, "observer")).toBe(
+            "cold-observer"
+        );
+        expect(() => resolveReaderCohort("unknown")).toThrow(
+            "Unsupported PW_READER_COHORT"
+        );
+    });
+
+    it("requires a connected live reader to appear in the replicator set", () => {
+        expect(
+            classifyReaderTopology("live-replicator", readyTopology())
+        ).toMatchObject({
+            ready: true,
+            expectedSelfInReplicatorSet: true,
+            validationReasons: [],
+        });
+        expect(
+            classifyReaderTopology(
+                "live-replicator",
+                readyTopology({ selfInReplicatorSet: false })
+            ).validationReasons
+        ).toContain("reader-not-in-replicator-set");
+    });
+
+    it.each(["cold-observer", "cold-persisted-read"] as const)(
+        "requires a connected %s reader to remain outside the replicator set",
+        (cohort) => {
+            expect(
+                classifyReaderTopology(
+                    cohort,
+                    readyTopology({ selfInReplicatorSet: false })
+                )
+            ).toMatchObject({
+                ready: true,
+                expectedSelfInReplicatorSet: false,
+                validationReasons: [],
+            });
+            expect(
+                classifyReaderTopology(cohort, readyTopology())
+                    .validationReasons
+            ).toContain("cold-reader-in-replicator-set");
+        }
+    );
+
+    it("does not accept role membership before app dialing and libp2p connectivity are ready", () => {
+        expect(
+            classifyReaderTopology(
+                "live-replicator",
+                readyTopology({
+                    appConnectionState: "pending",
+                    connectionCount: 0,
+                })
+            )
+        ).toMatchObject({
+            ready: false,
+            validationReasons: ["app-dial-not-ready", "no-libp2p-connections"],
+        });
+    });
+
+    it("requires supplied peer hints and completed explicit dial evidence", () => {
+        expect(
+            classifyReaderTopology(
+                "live-replicator",
+                readyTopology({
+                    peersProvided: false,
+                    peerHintSource: "bootstrap",
+                    peerAddressCount: 0,
+                    appDialStartedAt: null,
+                    appDialFinishedAt: null,
+                })
+            )
+        ).toMatchObject({
+            ready: false,
+            validationReasons: [
+                "app-peer-hints-not-provided",
+                "app-direct-peer-hints-not-provided",
+                "no-app-peer-addresses",
+                "app-dial-not-started",
+                "app-dial-not-finished",
+            ],
+        });
+        expect(
+            classifyReaderTopology(
+                "live-replicator",
+                readyTopology({ appDialFinishedAt: null })
+            ).validationReasons
+        ).toContain("app-dial-not-finished");
+    });
+
+    it("never censors live replication and classifies its starting locality", () => {
+        expect(
+            classifyReaderCohort(
+                "live-replicator",
+                validEvidence({ initialLocalChunkCount: 8 })
+            )
+        ).toMatchObject({
+            eligible: true,
+            valid: true,
+            classification: "indexed-local",
+            classificationBasis: "initial-index-row-count",
+        });
+        expect(
+            classifyReaderCohort(
+                "live-replicator",
+                validEvidence({ initialLocalChunkCount: 3 })
+            ).classification
+        ).toBe("indexed-hybrid");
+        expect(
+            classifyReaderCohort(
+                "live-replicator",
+                validEvidence({ initialLocalChunkCount: 0 })
+            ).classification
+        ).toBe("indexed-cold");
+        expect(
+            classifyReaderCohort(
+                "live-replicator",
+                validEvidence({ integrityVerified: false })
+            )
+        ).toMatchObject({
+            eligible: true,
+            valid: false,
+            validationReasons: ["integrity-not-verified"],
+        });
+        expect(
+            classifyReaderCohort(
+                "live-replicator",
+                validEvidence({ programPersistChunkReads: false })
+            ).validationReasons
+        ).toContain("live-program-persistence-mismatch");
+        expect(
+            classifyReaderCohort(
+                "live-replicator",
+                validEvidence({ persistChunkReads: false })
+            ).validationReasons
+        ).toContain("live-effective-persistence-mismatch");
+        expect(
+            classifyReaderCohort(
+                "live-replicator",
+                validEvidence({ readAheadSource: "observer-adaptive" })
+            ).validationReasons
+        ).toContain("live-read-ahead-mismatch");
+    });
+
+    it("validates a non-persisting observer read", () => {
+        expect(
+            classifyReaderCohort(
+                "cold-observer",
+                validEvidence({
+                    programPersistChunkReads: false,
+                    persistChunkReads: false,
+                    initialLocalChunkCount: null,
+                    readAheadSource: "observer-adaptive",
+                    postReadLocalChunkBlockCount: 0,
+                })
+            )
+        ).toMatchObject({
+            eligible: true,
+            valid: true,
+            classification: "cold",
+        });
+
+        expect(
+            classifyReaderCohort(
+                "cold-observer",
+                validEvidence({
+                    programPersistChunkReads: false,
+                    persistChunkReads: false,
+                    initialLocalChunkCount: null,
+                    readAheadSource: "observer-adaptive",
+                    postReadLocalChunkBlockCount: 1,
+                })
+            ).validationReasons
+        ).toContain("observer-persisted-chunks");
+    });
+
+    it("requires a cold persisted remote adaptive read that stores every manifest block", () => {
+        expect(
+            classifyReaderCohort(
+                "cold-persisted-read",
+                validEvidence({
+                    persistChunkReads: true,
+                    readAheadSource: "persisted-remote-adaptive",
+                    postReadLocalChunkBlockCount: 8,
+                })
+            )
+        ).toMatchObject({
+            eligible: true,
+            valid: true,
+            classification: "cold",
+        });
+        expect(
+            classifyReaderCohort(
+                "cold-persisted-read",
+                validEvidence({
+                    persistChunkReads: true,
+                    initialLocalChunkCount: 1,
+                    readAheadSource: "persisted-remote-adaptive",
+                    postReadLocalChunkBlockCount: 8,
+                })
+            ).validationReasons
+        ).toContain("preloaded-local-chunks");
+        expect(
+            classifyReaderCohort(
+                "cold-persisted-read",
+                validEvidence({ initialLocalChunkBlockCount: 1 })
+            ).validationReasons
+        ).toContain("preloaded-local-chunk-blocks");
+    });
+
+    it("rejects cold persisted reads when program persistence is disabled", () => {
+        expect(
+            classifyReaderCohort(
+                "cold-persisted-read",
+                validEvidence({
+                    programPersistChunkReads: false,
+                    postReadLocalChunkBlockCount: 8,
+                })
+            )
+        ).toMatchObject({
+            eligible: false,
+            valid: false,
+            validationReasons: ["persisted-read-program-persistence-mismatch"],
+        });
+    });
+
+    it("rejects cold persisted reads when effective persistence is disabled", () => {
+        expect(
+            classifyReaderCohort(
+                "cold-persisted-read",
+                validEvidence({
+                    persistChunkReads: false,
+                    postReadLocalChunkBlockCount: 8,
+                })
+            )
+        ).toMatchObject({
+            eligible: false,
+            valid: false,
+            validationReasons: ["persisted-read-persistence-mismatch"],
+        });
+    });
+
+    it.each([
+        ["zero", 0],
+        ["partial", 7],
+    ] as const)(
+        "rejects cold persisted reads with a %s post-read local block count",
+        (_description, postReadLocalChunkBlockCount) => {
+            expect(
+                classifyReaderCohort(
+                    "cold-persisted-read",
+                    validEvidence({ postReadLocalChunkBlockCount })
+                )
+            ).toMatchObject({
+                eligible: false,
+                valid: false,
+                validationReasons: ["incomplete-post-read-local-chunk-blocks"],
+            });
+        }
+    );
+
+    it.each([
+        [null, 8, "missing-chunk-count"],
+        [0, 0, "invalid-chunk-count"],
+        [8, null, "missing-post-read-local-block-count"],
+    ] as const)(
+        "rejects cold persisted reads with chunk count %s and post-read block count %s",
+        (chunkCount, postReadLocalChunkBlockCount, validationReason) => {
+            expect(
+                classifyReaderCohort(
+                    "cold-persisted-read",
+                    validEvidence({
+                        chunkCount,
+                        postReadLocalChunkBlockCount,
+                    })
+                )
+            ).toMatchObject({
+                eligible: false,
+                valid: false,
+                validationReasons: [validationReason],
+            });
+        }
+    );
+});

--- a/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
@@ -1,36 +1,88 @@
-import { test, type Page } from "@playwright/test";
+import {
+    test,
+    type BrowserContext,
+    type CDPSession,
+    type Page,
+} from "@playwright/test";
+import { createReadStream } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { startBootstrapPeer } from "./bootstrapPeer";
 import {
+    armDownloadedFile,
+    armSavedViaPicker,
+    crc32SavedViaPicker,
+    createCrc32,
     createSyntheticFileOnDisk,
-    expectDownloadedFile,
-    expectSavedViaPicker,
-    installMockSaveFilePicker,
+    installNodeBackedMockSaveFilePicker,
     rootUrl,
+    sha256AndCrc32File,
+    sha256FileBase64,
+    type DownloadSinkResult,
+    type SyntheticFixtureMetadata,
+    type SyntheticFixtureMode,
     waitForFileListed,
     waitForUploadComplete,
     withBootstrap,
 } from "./helpers";
+import {
+    buildReaderShareUrlWithPeerHints,
+    classifyReaderCohort,
+    classifyReaderTopology,
+    getBrowserDialablePeerAddresses,
+    getLegacyReaderRole,
+    resolveReaderCohort,
+    stopSamplerAtCompletion,
+    validateJsHeapMeasurement,
+    validateLargeFileBenchmarkSizeMb,
+    type ReaderCohort,
+    type ReaderTopologyEvidence,
+} from "./transfer-benchmark";
+import { createFileShareReplicationRole } from "../src/role-state";
 
 const ENABLED = process.env.PW_BENCH === "1";
 const SCENARIO = process.env.PW_BENCH_SCENARIO || "local";
-const READER_ROLE = process.env.PW_READER_ROLE || "adaptive";
-const ADAPTIVE_REPLICATION_ROLE = { limits: { cpu: { max: 1 } } };
+const READER_COHORT = resolveReaderCohort(
+    process.env.PW_READER_COHORT,
+    process.env.PW_READER_ROLE
+);
+const LEGACY_READER_ROLE = getLegacyReaderRole(READER_COHORT);
+const ADAPTIVE_REPLICATION_ROLE = createFileShareReplicationRole({ cpuMax: 1 });
 const FILE_SIZE_MB = Number(process.env.PW_FILE_MB || "1024");
+const FILE_SIZE_BYTES = ENABLED
+    ? validateLargeFileBenchmarkSizeMb(FILE_SIZE_MB)
+    : FILE_SIZE_MB * 1024 * 1024;
 const RESULT_FILE = process.env.PW_RESULT_FILE;
+const parseFixtureMode = (value: string): SyntheticFixtureMode => {
+    if (value === "sparse" || value === "deterministic") {
+        return value;
+    }
+    throw new Error(`Unsupported PW_FIXTURE_MODE='${value}'`);
+};
+const FIXTURE_MODE = parseFixtureMode(
+    process.env.PW_FIXTURE_MODE || "deterministic"
+);
+const FIXTURE_SEED = process.env.PW_FIXTURE_SEED || "peerbit-file-share-v1";
 const UPLOAD_TIMEOUT_MS = Number(process.env.PW_UPLOAD_TIMEOUT_MS || "1800000");
 const DOWNLOAD_TIMEOUT_MS = Number(
     process.env.PW_DOWNLOAD_TIMEOUT_MS || "1800000"
 );
+const TOPOLOGY_TIMEOUT_MS = Number(
+    process.env.PW_TOPOLOGY_TIMEOUT_MS || "180000"
+);
+const TOPOLOGY_POLL_INTERVAL_MS = 250;
+const requestedJsHeapSampleIntervalMs = Number(
+    process.env.PW_JS_HEAP_SAMPLE_INTERVAL_MS || "500"
+);
+const JS_HEAP_SAMPLE_INTERVAL_MS =
+    Number.isFinite(requestedJsHeapSampleIntervalMs) &&
+    requestedJsHeapSampleIntervalMs >= 100
+        ? requestedJsHeapSampleIntervalMs
+        : 500;
 const STREAMING_DOWNLOAD_THRESHOLD_BYTES = 250_000_000;
 
 if (!["local", "prod"].includes(SCENARIO)) {
     throw new Error(`Unsupported PW_BENCH_SCENARIO='${SCENARIO}'`);
-}
-
-if (!["adaptive", "observer"].includes(READER_ROLE)) {
-    throw new Error(`Unsupported PW_READER_ROLE='${READER_ROLE}'`);
 }
 
 const persistResult = async (result: Record<string, unknown>) => {
@@ -41,12 +93,21 @@ const persistResult = async (result: Record<string, unknown>) => {
     await writeFile(RESULT_FILE, `${JSON.stringify(result, null, 2)}\n`);
 };
 
+const crc32FileHex = async (filePath: string) => {
+    const crc32 = createCrc32();
+    for await (const chunk of createReadStream(filePath)) {
+        crc32.update(chunk);
+    }
+    return crc32.digestHex();
+};
+
 const logStage = (stage: string, details: Record<string, unknown> = {}) => {
     console.log(
         `FILE_SHARE_TRANSFER_BENCH_STAGE ${JSON.stringify({
             stage,
             scenario: SCENARIO,
-            readerRole: READER_ROLE,
+            readerCohort: READER_COHORT,
+            readerRole: LEGACY_READER_ROLE,
             fileSizeMb: FILE_SIZE_MB,
             ...details,
         })}`
@@ -81,6 +142,251 @@ const getDiagnostics = async (page: Page) => {
         }
         return await hooks.getDiagnostics();
     });
+};
+
+const getLightweightSnapshot = async (page: Page) => {
+    return await page.evaluate(() => {
+        const hooks = (window as any).__peerbitFileShareTestHooks;
+        if (!hooks?.getLightweightSnapshot) {
+            throw new Error(
+                "Missing __peerbitFileShareTestHooks.getLightweightSnapshot"
+            );
+        }
+        return hooks.getLightweightSnapshot();
+    });
+};
+
+const getTopologySnapshot = async (page: Page) => {
+    return (await page.evaluate(async () => {
+        const hooks = (window as any).__peerbitFileShareTestHooks;
+        if (!hooks?.getTopologySnapshot) {
+            throw new Error(
+                "Missing __peerbitFileShareTestHooks.getTopologySnapshot"
+            );
+        }
+        return await hooks.getTopologySnapshot();
+    })) as ReaderTopologyEvidence;
+};
+
+type ReaderTopologyReadiness = {
+    cohort: ReaderCohort;
+    expectedSelfInReplicatorSet: boolean;
+    timeoutMs: number;
+    pollingIntervalMs: number;
+    waitStartedAt: number | null;
+    waitFinishedAt: number | null;
+    waitDurationMs: number | null;
+    attempts: number;
+    ready: boolean;
+    evidence: ReaderTopologyEvidence | null;
+    validationReasons: string[];
+    lastProbeError: string | null;
+};
+
+const createReaderTopologyReadiness = (): ReaderTopologyReadiness => ({
+    cohort: READER_COHORT,
+    expectedSelfInReplicatorSet: READER_COHORT === "live-replicator",
+    timeoutMs: TOPOLOGY_TIMEOUT_MS,
+    pollingIntervalMs: TOPOLOGY_POLL_INTERVAL_MS,
+    waitStartedAt: null,
+    waitFinishedAt: null,
+    waitDurationMs: null,
+    attempts: 0,
+    ready: false,
+    evidence: null,
+    validationReasons: ["topology-not-checked"],
+    lastProbeError: null,
+});
+
+const waitForReaderTopology = async (
+    page: Page,
+    readiness: ReaderTopologyReadiness
+) => {
+    const startedAt = Date.now();
+    const deadline = startedAt + readiness.timeoutMs;
+    readiness.waitStartedAt = startedAt;
+    readiness.validationReasons = [];
+
+    while (Date.now() <= deadline) {
+        readiness.attempts += 1;
+        try {
+            const evidence = await getTopologySnapshot(page);
+            const classification = classifyReaderTopology(
+                readiness.cohort,
+                evidence
+            );
+            readiness.evidence = evidence;
+            readiness.ready = classification.ready;
+            readiness.validationReasons = classification.validationReasons;
+            readiness.lastProbeError = null;
+            if (classification.ready) {
+                readiness.waitFinishedAt = Date.now();
+                readiness.waitDurationMs = readiness.waitFinishedAt - startedAt;
+                return;
+            }
+        } catch (error) {
+            readiness.ready = false;
+            readiness.validationReasons = ["topology-probe-error"];
+            readiness.lastProbeError =
+                error instanceof Error ? error.message : String(error);
+        }
+
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+            break;
+        }
+        await new Promise((resolve) =>
+            setTimeout(
+                resolve,
+                Math.min(readiness.pollingIntervalMs, remainingMs)
+            )
+        );
+    }
+
+    readiness.waitFinishedAt = Date.now();
+    readiness.waitDurationMs = readiness.waitFinishedAt - startedAt;
+    throw new Error(
+        `Reader topology was not ready for ${readiness.cohort}: ${readiness.validationReasons.join(", ") || "unknown"}`
+    );
+};
+
+type ReaderJsHeapMeasurement = {
+    memoryKind: "javascript-heap";
+    scope: "reader-renderer";
+    metric: "JSHeapUsedSize";
+    unit: "bytes";
+    sampleIntervalMs: number;
+    startedAt: number;
+    finishedAt: number | null;
+    firstSampleAt: number | null;
+    lastSampleAt: number | null;
+    sampleCount: number;
+    startBytes: number | null;
+    endBytes: number | null;
+    peakBytes: number | null;
+    samplingErrors: string[];
+};
+
+type ReaderJsHeapSampler = {
+    stop: () => Promise<ReaderJsHeapMeasurement>;
+    snapshot: () => ReaderJsHeapMeasurement;
+};
+
+const getErrorMessage = (error: unknown) =>
+    error instanceof Error ? error.message : String(error);
+
+const startReaderJsHeapSampler = async (
+    context: BrowserContext,
+    page: Page
+): Promise<ReaderJsHeapSampler> => {
+    const measurement: ReaderJsHeapMeasurement = {
+        memoryKind: "javascript-heap",
+        scope: "reader-renderer",
+        metric: "JSHeapUsedSize",
+        unit: "bytes",
+        sampleIntervalMs: JS_HEAP_SAMPLE_INTERVAL_MS,
+        startedAt: Date.now(),
+        finishedAt: null,
+        firstSampleAt: null,
+        lastSampleAt: null,
+        sampleCount: 0,
+        startBytes: null,
+        endBytes: null,
+        peakBytes: null,
+        samplingErrors: [],
+    };
+    const snapshot = (): ReaderJsHeapMeasurement => ({
+        ...measurement,
+        samplingErrors: [...measurement.samplingErrors],
+    });
+
+    let session: CDPSession | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let activeSample: Promise<void> | undefined;
+    let stopped = false;
+    let stopPromise: Promise<ReaderJsHeapMeasurement> | undefined;
+
+    const takeSample = async () => {
+        if (!session) {
+            return;
+        }
+        try {
+            const response = await session.send("Performance.getMetrics");
+            const heapMetric = response.metrics.find(
+                (metric) => metric.name === "JSHeapUsedSize"
+            );
+            if (!heapMetric || !Number.isFinite(heapMetric.value)) {
+                measurement.samplingErrors.push(
+                    "Performance.getMetrics omitted JSHeapUsedSize"
+                );
+                return;
+            }
+            const capturedAt = Date.now();
+            if (measurement.sampleCount === 0) {
+                measurement.firstSampleAt = capturedAt;
+                measurement.startBytes = heapMetric.value;
+            }
+            measurement.lastSampleAt = capturedAt;
+            measurement.endBytes = heapMetric.value;
+            measurement.peakBytes = Math.max(
+                measurement.peakBytes ?? heapMetric.value,
+                heapMetric.value
+            );
+            measurement.sampleCount += 1;
+        } catch (error) {
+            measurement.samplingErrors.push(getErrorMessage(error));
+        }
+    };
+
+    const scheduleSample = () => {
+        if (stopped || !session) {
+            return;
+        }
+        timer = setTimeout(() => {
+            activeSample = takeSample().finally(() => {
+                activeSample = undefined;
+                scheduleSample();
+            });
+        }, JS_HEAP_SAMPLE_INTERVAL_MS);
+    };
+
+    try {
+        session = await context.newCDPSession(page);
+        await session.send("Performance.enable");
+        await takeSample();
+        scheduleSample();
+    } catch (error) {
+        measurement.samplingErrors.push(getErrorMessage(error));
+    }
+
+    return {
+        snapshot,
+        stop: () => {
+            if (stopPromise) {
+                return stopPromise;
+            }
+            stopped = true;
+            stopPromise = (async () => {
+                if (timer) {
+                    clearTimeout(timer);
+                }
+                await activeSample;
+                await takeSample();
+                measurement.finishedAt = Date.now();
+                if (session) {
+                    await session.send("Performance.disable").catch((error) => {
+                        measurement.samplingErrors.push(getErrorMessage(error));
+                    });
+                    await session.detach().catch((error) => {
+                        measurement.samplingErrors.push(getErrorMessage(error));
+                    });
+                    session = undefined;
+                }
+                return snapshot();
+            })();
+            return stopPromise;
+        },
+    };
 };
 
 const seedReplicationRole = async (
@@ -118,11 +424,358 @@ const waitForShareUrlPeerHints = async (page: Page, timeout = 180_000) => {
     );
 };
 
-const toMiBPerSecond = (bytes: number, durationMs: number) =>
-    durationMs > 0 ? bytes / (1024 * 1024) / (durationMs / 1000) : null;
+type ReaderPeerHintEvidence = {
+    source: "writer-direct-diagnostics" | "writer-share-url";
+    count: number;
+    waitStartedAt: number;
+    waitFinishedAt: number;
+    waitDurationMs: number;
+    attempts: number;
+    lastProbeError: string | null;
+};
 
-const toMbps = (bytes: number, durationMs: number) =>
-    durationMs > 0 ? (bytes * 8) / 1_000_000 / (durationMs / 1000) : null;
+const waitForWriterDirectPeerHints = async (page: Page, timeout = 180_000) => {
+    const waitStartedAt = Date.now();
+    const deadline = waitStartedAt + timeout;
+    let attempts = 0;
+    let lastProbeError: string | null = null;
+    while (Date.now() <= deadline) {
+        attempts += 1;
+        try {
+            const diagnostics = await getDiagnostics(page);
+            const peerAddresses = getBrowserDialablePeerAddresses(
+                (diagnostics as Record<string, unknown>)?.peerAddresses
+            );
+            if (peerAddresses.length > 0) {
+                const waitFinishedAt = Date.now();
+                return {
+                    peerAddresses,
+                    evidence: {
+                        source: "writer-direct-diagnostics",
+                        count: peerAddresses.length,
+                        waitStartedAt,
+                        waitFinishedAt,
+                        waitDurationMs: waitFinishedAt - waitStartedAt,
+                        attempts,
+                        lastProbeError,
+                    } satisfies ReaderPeerHintEvidence,
+                };
+            }
+            lastProbeError = "No browser-dialable writer addresses yet";
+        } catch (error) {
+            lastProbeError = getErrorMessage(error);
+        }
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+            break;
+        }
+        await new Promise((resolve) =>
+            setTimeout(resolve, Math.min(250, remainingMs))
+        );
+    }
+    throw new Error(
+        `Writer did not expose a browser-dialable direct peer address: ${lastProbeError ?? "unknown"}`
+    );
+};
+
+const waitForReaderProgramState = async (
+    page: Page,
+    expectedProgramAddress: string,
+    expectedPersistChunkReads: boolean,
+    timeout: number
+) => {
+    const handle = await page.waitForFunction(
+        ({ expectedAddress, expectedPersist }) => {
+            const hooks = (window as any).__peerbitFileShareTestHooks;
+            if (!hooks?.getLightweightSnapshot) {
+                return null;
+            }
+            const snapshot = hooks.getLightweightSnapshot();
+            if (snapshot?.programHookStatus === "error") {
+                return {
+                    state: "error",
+                    message:
+                        typeof snapshot.programHookError === "string"
+                            ? snapshot.programHookError
+                            : "unknown program-open error",
+                };
+            }
+            return snapshot?.programAddress === expectedAddress &&
+                snapshot?.programClosed === false &&
+                snapshot?.persistChunkReads === expectedPersist
+                ? { state: "ready" }
+                : null;
+        },
+        {
+            expectedAddress: expectedProgramAddress,
+            expectedPersist: expectedPersistChunkReads,
+        },
+        { polling: 25, timeout }
+    );
+    const result = (await handle.jsonValue()) as {
+        state: "ready" | "error";
+        message?: string;
+    };
+    await handle.dispose();
+    if (result.state === "error") {
+        throw new Error(`Reader program failed to open: ${result.message}`);
+    }
+};
+
+type ReadyDownloadClick = {
+    capturedAt: number;
+    clickedAt: number;
+    manifestFinalHash: string;
+    persistChunkReadsBeforeClick: boolean | null;
+    persistChunkReadsAtClick: boolean | null;
+    snapshot: Record<string, unknown>;
+};
+
+const armReadyManifestDownload = (
+    page: Page,
+    properties: {
+        fileName: string;
+        expectedProgramAddress: string;
+        expectedFinalHash: string;
+        enablePersistOnly: boolean;
+        timeout: number;
+    }
+) => {
+    const pending = page
+        .waitForFunction(
+            ({
+                expectedName,
+                expectedAddress,
+                expectedHash,
+                enablePersistOnly,
+            }) => {
+                const hooks = (window as any).__peerbitFileShareTestHooks;
+                if (!hooks?.getLightweightSnapshot) {
+                    return null;
+                }
+                const snapshot = hooks.getLightweightSnapshot();
+                if (
+                    snapshot?.programAddress !== expectedAddress ||
+                    snapshot?.programClosed !== false
+                ) {
+                    return null;
+                }
+                const file = snapshot?.listedFiles?.find(
+                    (candidate: Record<string, unknown>) =>
+                        candidate.name === expectedName
+                );
+                if (
+                    !file ||
+                    file.ready !== true ||
+                    typeof file.finalHash !== "string" ||
+                    file.finalHash.length === 0
+                ) {
+                    return null;
+                }
+                if (file.finalHash !== expectedHash) {
+                    throw new Error(
+                        `Visible manifest hash ${file.finalHash} does not match fixture hash ${expectedHash}`
+                    );
+                }
+
+                const row = Array.from(document.querySelectorAll("li")).find(
+                    (candidate) =>
+                        Array.from(candidate.querySelectorAll("span")).some(
+                            (label) => label.textContent === expectedName
+                        )
+                );
+                const button = row?.querySelector(
+                    '[data-testid="download-file"]'
+                );
+                if (
+                    !(button instanceof HTMLButtonElement) ||
+                    button.disabled ||
+                    button.textContent?.includes("pending")
+                ) {
+                    return null;
+                }
+
+                const capturedAt = Date.now();
+                const persistChunkReadsBeforeClick =
+                    typeof snapshot.persistChunkReads === "boolean"
+                        ? snapshot.persistChunkReads
+                        : null;
+                let persistChunkReadsAtClick = persistChunkReadsBeforeClick;
+                if (enablePersistOnly) {
+                    if (!hooks.setPersistChunkReads) {
+                        throw new Error(
+                            "Missing persist-only file-share benchmark hook"
+                        );
+                    }
+                    persistChunkReadsAtClick = hooks.setPersistChunkReads(true);
+                    if (persistChunkReadsAtClick !== true) {
+                        throw new Error(
+                            "Failed to enable persisted reads before click"
+                        );
+                    }
+                }
+
+                const clickedAt = Date.now();
+                button.click();
+                return {
+                    capturedAt,
+                    clickedAt,
+                    manifestFinalHash: file.finalHash,
+                    persistChunkReadsBeforeClick,
+                    persistChunkReadsAtClick,
+                    snapshot,
+                };
+            },
+            {
+                expectedName: properties.fileName,
+                expectedAddress: properties.expectedProgramAddress,
+                expectedHash: properties.expectedFinalHash,
+                enablePersistOnly: properties.enablePersistOnly,
+            },
+            { polling: 25, timeout: properties.timeout }
+        )
+        .then(async (handle) => {
+            try {
+                return (await handle.jsonValue()) as ReadyDownloadClick;
+            } finally {
+                await handle.dispose();
+            }
+        });
+    void pending.catch(() => {});
+    return pending;
+};
+
+const toMiBPerSecond = (bytes: number, durationMs: number | null) =>
+    durationMs != null && durationMs > 0
+        ? bytes / (1024 * 1024) / (durationMs / 1000)
+        : null;
+
+const toMbps = (bytes: number, durationMs: number | null) =>
+    durationMs != null && durationMs > 0
+        ? (bytes * 8) / 1_000_000 / (durationMs / 1000)
+        : null;
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+    value != null && typeof value === "object"
+        ? (value as Record<string, unknown>)
+        : undefined;
+
+const asNumber = (value: unknown) =>
+    typeof value === "number" && Number.isFinite(value) ? value : null;
+
+const durationBetween = (
+    startedAt: number | null,
+    finishedAt: number | null
+) => (startedAt != null && finishedAt != null ? finishedAt - startedAt : null);
+
+const getListedFile = (
+    diagnostics: Record<string, unknown> | undefined,
+    fileName: string
+) => {
+    const listedFiles = diagnostics?.listedFiles;
+    if (!Array.isArray(listedFiles)) {
+        return undefined;
+    }
+    return listedFiles
+        .map(asRecord)
+        .find((candidate) => candidate?.name === fileName);
+};
+
+const createFixtureResult = ({
+    fixture,
+    manifestFinalHash,
+    downloadSha256Base64,
+    downloadCrc32Hex,
+    downloadCompleted,
+    usesStreamingDownload,
+}: {
+    fixture: SyntheticFixtureMetadata;
+    manifestFinalHash: string | null;
+    downloadSha256Base64: string | null;
+    downloadCrc32Hex: string | null;
+    downloadCompleted: boolean;
+    usesStreamingDownload: boolean;
+}) => {
+    const sourceManifestMatch = fixture.sha256Base64
+        ? fixture.sha256Base64 === manifestFinalHash
+        : null;
+    const directDownloadHashMatch = fixture.sha256Base64
+        ? downloadSha256Base64 == null
+            ? null
+            : fixture.sha256Base64 === downloadSha256Base64
+        : null;
+    const libraryDownloadFinalHashVerified = fixture.sha256Base64
+        ? downloadCompleted
+        : null;
+    const streamingReadbackCrc32Match = usesStreamingDownload
+        ? fixture.crc32Hex != null && downloadCrc32Hex != null
+            ? fixture.crc32Hex === downloadCrc32Hex
+            : false
+        : null;
+    const integrityVerified = fixture.sha256Base64
+        ? sourceManifestMatch === true &&
+          libraryDownloadFinalHashVerified === true &&
+          (usesStreamingDownload
+              ? directDownloadHashMatch === true &&
+                streamingReadbackCrc32Match === true
+              : directDownloadHashMatch === true)
+        : null;
+
+    return {
+        mode: fixture.mode,
+        seed: fixture.seed,
+        sourceSha256Base64: fixture.sha256Base64,
+        manifestFinalHash,
+        downloadSha256Base64,
+        sourceCrc32Hex: fixture.crc32Hex,
+        downloadCrc32Hex,
+        crc32Match: streamingReadbackCrc32Match,
+        streamingReadbackCrc32Match,
+        sourceManifestMatch,
+        directDownloadHashMatch,
+        libraryDownloadFinalHashVerified,
+        integrityVerified,
+        verification: fixture.sha256Base64
+            ? usesStreamingDownload
+                ? "source-manifest-library-stream-and-node-file-sha256-crc32"
+                : "source-manifest-library-and-browser-download-sha256"
+            : "missing",
+    };
+};
+
+const createCohortResult = (
+    cohort: ReaderCohort,
+    diagnostics: Record<string, unknown> | undefined,
+    fileName: string,
+    integrityVerified: boolean
+) => {
+    const read = asRecord(diagnostics?.lastReadDiagnostics);
+    const listedFile = getListedFile(diagnostics, fileName);
+    return classifyReaderCohort(cohort, {
+        integrityVerified,
+        programPersistChunkReads:
+            typeof read?.programPersistChunkReads === "boolean"
+                ? read.programPersistChunkReads
+                : null,
+        persistChunkReads:
+            typeof read?.persistChunkReads === "boolean"
+                ? read.persistChunkReads
+                : null,
+        initialLocalChunkCount: asNumber(read?.initialLocalChunkCount),
+        initialLocalChunkBlockCount: asNumber(
+            read?.initialLocalChunkBlockCount
+        ),
+        readAheadSource:
+            typeof read?.readAheadSource === "string"
+                ? read.readAheadSource
+                : null,
+        postReadLocalChunkCount: asNumber(listedFile?.localChunkCount),
+        postReadLocalChunkBlockCount: asNumber(
+            listedFile?.localChunkBlockCount
+        ),
+        chunkCount: asNumber(listedFile?.chunkCount),
+    });
+};
 
 test.describe("file-share transfer benchmark", () => {
     test.skip(!ENABLED, "Set PW_BENCH=1 to run file-share benchmark");
@@ -142,169 +795,466 @@ test.describe("file-share transfer benchmark", () => {
         }
 
         const usesLocalBootstrap = SCENARIO === "local";
-        const bootstrap = usesLocalBootstrap
-            ? await startBootstrapPeer()
-            : undefined;
-        const writerContext = await browser.newContext({
-            acceptDownloads: true,
-        });
-        const readerContext = await browser.newContext({
-            acceptDownloads: true,
-        });
-        const writer = await writerContext.newPage();
-        const reader = await readerContext.newPage();
         const fileName = `file-share-transfer-bench-${Date.now()}.bin`;
-        const preparedFile = await createSyntheticFileOnDisk(
-            fileName,
-            FILE_SIZE_MB
-        );
-        let writerDiagnostics: Record<string, unknown> | undefined;
-        let readerDiagnostics: Record<string, unknown> | undefined;
+        let bootstrap:
+            | Awaited<ReturnType<typeof startBootstrapPeer>>
+            | undefined;
+        let writerContext: BrowserContext | undefined;
+        let readerContext: BrowserContext | undefined;
+        let writer: Page | undefined;
+        let reader: Page | undefined;
+        let preparedFile:
+            | Awaited<ReturnType<typeof createSyntheticFileOnDisk>>
+            | undefined;
+        let shareUrl: URL | undefined;
         let writerDiagnosticsAfterDownload: Record<string, unknown> | undefined;
         let readerDiagnosticsAfterDownload: Record<string, unknown> | undefined;
-        const usesStreamingDownload =
-            preparedFile != null &&
-            FILE_SIZE_MB * 1024 * 1024 >= STREAMING_DOWNLOAD_THRESHOLD_BYTES;
+        let writerLightweightSnapshotAfterSink:
+            | Record<string, unknown>
+            | undefined;
+        let readyDownloadClick: ReadyDownloadClick | undefined;
+        let sinkResult: DownloadSinkResult | undefined;
+        let manifestFinalHash: string | null = null;
+        let downloadSha256Base64: string | null = null;
+        let downloadCrc32Hex: string | null = null;
+        let downloadCompleted = false;
+        let cleanupDownloadedFile: (() => Promise<void>) | undefined;
+        let nodeSinkController:
+            | Awaited<ReturnType<typeof installNodeBackedMockSaveFilePicker>>
+            | undefined;
+        let usesStreamingDownload = false;
+        let fixtureResult: ReturnType<typeof createFixtureResult> | undefined;
+        let cohortResult: ReturnType<typeof createCohortResult> | undefined;
+        let readerPeerHints: ReaderPeerHintEvidence | undefined;
+        const readerTopologyReadiness = createReaderTopologyReadiness();
+        let readerJsHeapSampler: ReaderJsHeapSampler | undefined;
+        let readerJsHeap: ReaderJsHeapMeasurement | undefined;
+        let readerJsHeapValidation:
+            | ReturnType<typeof validateJsHeapMeasurement>
+            | undefined;
 
         try {
-            if (usesStreamingDownload) {
-                await installMockSaveFilePicker(reader);
+            const fixtureFile = await createSyntheticFileOnDisk(
+                fileName,
+                FILE_SIZE_MB,
+                { mode: FIXTURE_MODE, seed: FIXTURE_SEED }
+            );
+            preparedFile = fixtureFile;
+            if (!fixtureFile.fixture.sha256Base64) {
+                fixtureFile.fixture.sha256Base64 = await sha256FileBase64(
+                    fixtureFile.filePath
+                );
             }
+            if (!fixtureFile.fixture.crc32Hex) {
+                fixtureFile.fixture.crc32Hex = await crc32FileHex(
+                    fixtureFile.filePath
+                );
+            }
+            const expectedFinalHash = fixtureFile.fixture.sha256Base64;
+            if (!expectedFinalHash) {
+                throw new Error("Benchmark fixture is missing its source hash");
+            }
+
+            usesStreamingDownload =
+                FILE_SIZE_BYTES >= STREAMING_DOWNLOAD_THRESHOLD_BYTES;
+            bootstrap = usesLocalBootstrap
+                ? await startBootstrapPeer()
+                : undefined;
+            writerContext = await browser.newContext({
+                acceptDownloads: true,
+            });
+            readerContext = await browser.newContext({
+                acceptDownloads: true,
+            });
+            const writerPage = await writerContext.newPage();
+            const readerPage = await readerContext.newPage();
+            writer = writerPage;
+            reader = readerPage;
+            if (usesStreamingDownload) {
+                nodeSinkController = await installNodeBackedMockSaveFilePicker(
+                    readerPage,
+                    {
+                        expectedName: fileName,
+                        expectedSizeBytes: FILE_SIZE_BYTES,
+                    }
+                );
+            }
+
             logStage("create-space");
             const entryUrl =
                 usesLocalBootstrap && bootstrap
                     ? withBootstrap(rootUrl(baseURL), bootstrap.addrs)
                     : rootUrl(baseURL);
-            await enableOpenProfiler(writer);
-            await enableOpenProfiler(reader);
-            await writer.goto(entryUrl, { waitUntil: "domcontentloaded" });
-            await waitForCreateSpaceHook(writer);
-            const address = await createSpaceFromHook(
-                writer,
-                `file-share-transfer-bench-${Date.now()}`
-            );
-            let shareUrl = new URL(writer.url());
-            logStage("seed-reader-role");
-            await seedReplicationRole(
-                reader,
-                address,
-                READER_ROLE === "observer" ? false : ADAPTIVE_REPLICATION_ROLE
-            );
-
-            logStage("open-reader", { shareUrl: shareUrl.toString() });
-            logStage("writer-page-ready");
-            if (!usesLocalBootstrap) {
-                logStage("wait-for-share-peer-hints");
-                await waitForShareUrlPeerHints(writer);
-            }
-            shareUrl = new URL(writer.url());
-            await reader.goto(shareUrl.toString(), {
+            await enableOpenProfiler(writerPage);
+            await enableOpenProfiler(readerPage);
+            await writerPage.goto(entryUrl, {
                 waitUntil: "domcontentloaded",
             });
-            logStage("reader-page-ready");
+            await waitForCreateSpaceHook(writerPage);
+            const address = await createSpaceFromHook(
+                writerPage,
+                `file-share-transfer-bench-${Date.now()}`
+            );
+            shareUrl = new URL(writerPage.url());
+
+            const initialReaderPersist = READER_COHORT === "live-replicator";
+            logStage("seed-reader-cohort", {
+                initialPersistChunkReads: initialReaderPersist,
+            });
+            await seedReplicationRole(
+                readerPage,
+                address,
+                initialReaderPersist ? ADAPTIVE_REPLICATION_ROLE : false
+            );
+
+            if (usesLocalBootstrap) {
+                logStage("wait-for-writer-direct-peer-hints");
+                const directHints =
+                    await waitForWriterDirectPeerHints(writerPage);
+                const readerShare = buildReaderShareUrlWithPeerHints(
+                    writerPage.url(),
+                    directHints.peerAddresses
+                );
+                shareUrl = new URL(readerShare.href);
+                readerPeerHints = directHints.evidence;
+            } else {
+                const waitStartedAt = Date.now();
+                logStage("wait-for-share-peer-hints");
+                await waitForShareUrlPeerHints(writerPage);
+                shareUrl = new URL(writerPage.url());
+                const peerAddresses = getBrowserDialablePeerAddresses(
+                    shareUrl.searchParams.get("peer")?.split(",")
+                );
+                if (peerAddresses.length === 0) {
+                    throw new Error(
+                        "Writer share URL did not expose a browser-dialable direct peer address"
+                    );
+                }
+                const waitFinishedAt = Date.now();
+                readerPeerHints = {
+                    source: "writer-share-url",
+                    count: peerAddresses.length,
+                    waitStartedAt,
+                    waitFinishedAt,
+                    waitDurationMs: waitFinishedAt - waitStartedAt,
+                    attempts: 1,
+                    lastProbeError: null,
+                };
+            }
+            logStage("open-reader", {
+                shareUrl: shareUrl.toString(),
+                peerHintSource: readerPeerHints.source,
+                peerHintCount: readerPeerHints.count,
+            });
+            await readerPage.goto(shareUrl.toString(), {
+                waitUntil: "domcontentloaded",
+            });
+            logStage("wait-for-reader-program-state");
+            await waitForReaderProgramState(
+                readerPage,
+                address,
+                initialReaderPersist,
+                UPLOAD_TIMEOUT_MS
+            );
+            logStage("wait-for-reader-topology", {
+                expectedSelfInReplicatorSet:
+                    readerTopologyReadiness.expectedSelfInReplicatorSet,
+            });
+            await waitForReaderTopology(readerPage, readerTopologyReadiness);
+            logStage("reader-topology-ready", {
+                waitDurationMs: readerTopologyReadiness.waitDurationMs,
+                attempts: readerTopologyReadiness.attempts,
+                evidence: readerTopologyReadiness.evidence,
+            });
 
             logStage("wait-for-input");
-            await writer.locator("#imgupload").waitFor({
+            await writerPage.locator("#imgupload").waitFor({
                 state: "attached",
                 timeout: 60_000,
             });
 
-            logStage("upload");
-            const uploadStartedAt = Date.now();
-            await writer
-                .locator("#imgupload")
-                .setInputFiles(preparedFile.filePath);
-            logStage("wait-for-writer-listing");
-            await waitForFileListed(writer, fileName, UPLOAD_TIMEOUT_MS);
-            logStage("wait-for-upload-complete");
-            await waitForUploadComplete(writer, UPLOAD_TIMEOUT_MS);
-            const uploadFinishedAt = Date.now();
-            writerDiagnostics = await getDiagnostics(writer);
-
-            logStage("wait-for-reader-listing");
-            await waitForFileListed(reader, fileName, UPLOAD_TIMEOUT_MS);
-            const readerVisibleAt = Date.now();
-            readerDiagnostics = await getDiagnostics(reader);
-
-            logStage("download");
-            const downloadStartedAt = Date.now();
-            const downloaded = usesStreamingDownload
-                ? await expectSavedViaPicker(
-                      reader,
+            logStage("arm-download-sink-and-ready-click");
+            const sinkCompletion = usesStreamingDownload
+                ? armSavedViaPicker(
+                      readerPage,
                       fileName,
                       FILE_SIZE_MB,
                       DOWNLOAD_TIMEOUT_MS
-                  ).then(() => ({
-                      size: preparedFile ? FILE_SIZE_MB * 1024 * 1024 : 0,
-                  }))
-                : await expectDownloadedFile(
-                      reader,
+                  )
+                : armDownloadedFile(
+                      readerPage,
                       fileName,
                       FILE_SIZE_MB,
                       DOWNLOAD_TIMEOUT_MS
                   );
-            const downloadFinishedAt = Date.now();
-            writerDiagnosticsAfterDownload =
-                (await getDiagnostics(writer).catch(() => undefined)) ??
-                writerDiagnostics;
-            readerDiagnosticsAfterDownload =
-                (await getDiagnostics(reader).catch(() => undefined)) ??
-                readerDiagnostics;
+            const readyDownload = armReadyManifestDownload(readerPage, {
+                fileName,
+                expectedProgramAddress: address,
+                expectedFinalHash,
+                enablePersistOnly: READER_COHORT === "cold-persisted-read",
+                timeout: UPLOAD_TIMEOUT_MS,
+            });
+
+            readerJsHeapSampler = await startReaderJsHeapSampler(
+                readerContext,
+                readerPage
+            );
+            const activeReaderJsHeapSampler = readerJsHeapSampler;
+            const measuredSinkCompletion = stopSamplerAtCompletion(
+                sinkCompletion,
+                activeReaderJsHeapSampler
+            ).then(({ result, measurement }) => {
+                readerJsHeap = measurement;
+                if (readerJsHeapSampler === activeReaderJsHeapSampler) {
+                    readerJsHeapSampler = undefined;
+                }
+                return result;
+            });
+            void measuredSinkCompletion.catch(() => {});
+            logStage("upload");
+            const uploadStartedAt = Date.now();
+            await writerPage
+                .locator("#imgupload")
+                .setInputFiles(fixtureFile.filePath);
+            await waitForFileListed(writerPage, fileName, UPLOAD_TIMEOUT_MS);
+            await waitForUploadComplete(writerPage, UPLOAD_TIMEOUT_MS);
+            const uploadFinishedAt = Date.now();
+
+            logStage("wait-for-ready-click-and-sink");
+            readyDownloadClick = await readyDownload;
+            manifestFinalHash = readyDownloadClick.manifestFinalHash;
+            sinkResult = await measuredSinkCompletion;
+            cleanupDownloadedFile = sinkResult.cleanup;
+            downloadCompleted = true;
+            readerJsHeapValidation = validateJsHeapMeasurement(readerJsHeap);
+            if (!readerJsHeapValidation.valid) {
+                throw new Error(
+                    `Invalid reader JS heap measurement: ${readerJsHeapValidation.validationReasons.join(", ")}`
+                );
+            }
+
+            // All snapshots, hashing, and rich diagnostics happen after the
+            // primary sink completion timestamp. Capture browser diagnostics
+            // first so post-sink disk verification cannot change them.
+            [
+                writerLightweightSnapshotAfterSink,
+                writerDiagnosticsAfterDownload,
+                readerDiagnosticsAfterDownload,
+            ] = await Promise.all([
+                getLightweightSnapshot(writerPage),
+                getDiagnostics(writerPage).catch(() => undefined),
+                getDiagnostics(readerPage).catch(() => undefined),
+            ]);
+            if (usesStreamingDownload && sinkResult.downloadPath) {
+                logStage("verify-streaming-node-file-digests");
+                const digests = await sha256AndCrc32File(
+                    sinkResult.downloadPath
+                );
+                downloadSha256Base64 = digests.sha256Base64;
+                downloadCrc32Hex = digests.crc32Hex;
+            } else if (usesStreamingDownload) {
+                logStage("verify-streaming-sink-crc32");
+                downloadCrc32Hex = await crc32SavedViaPicker(
+                    readerPage,
+                    fileName
+                );
+            }
+            if (sinkResult.downloadPath && downloadSha256Base64 == null) {
+                downloadSha256Base64 = await sha256FileBase64(
+                    sinkResult.downloadPath
+                );
+                if (downloadSha256Base64 !== expectedFinalHash) {
+                    throw new Error(
+                        `Downloaded file hash ${downloadSha256Base64} does not match fixture hash ${expectedFinalHash}`
+                    );
+                }
+            }
+
+            fixtureResult = createFixtureResult({
+                fixture: fixtureFile.fixture,
+                manifestFinalHash,
+                downloadSha256Base64,
+                downloadCrc32Hex,
+                downloadCompleted,
+                usesStreamingDownload,
+            });
+            if (fixtureResult.integrityVerified !== true) {
+                throw new Error(
+                    "Benchmark transfer integrity was not verified"
+                );
+            }
+            cohortResult = createCohortResult(
+                READER_COHORT,
+                readerDiagnosticsAfterDownload,
+                fileName,
+                true
+            );
+            if (!cohortResult.valid) {
+                throw new Error(
+                    `Invalid ${READER_COHORT} sample: ${cohortResult.validationReasons.join(", ")}`
+                );
+            }
+
+            const read = asRecord(
+                readerDiagnosticsAfterDownload?.lastReadDiagnostics
+            );
+            const libraryStreamStartedAt = asNumber(read?.startedAt);
+            const libraryStreamFinishedAt = asNumber(read?.finishedAt);
+            const uploadDurationMs = uploadFinishedAt - uploadStartedAt;
+            const uploadStartedToReadyVisibleMs =
+                readyDownloadClick.capturedAt - uploadStartedAt;
+            const uploadFinishedToReadyVisibleMs =
+                readyDownloadClick.capturedAt - uploadFinishedAt;
+            const readyVisibleToClickMs =
+                readyDownloadClick.clickedAt - readyDownloadClick.capturedAt;
+            const clickToSinkCompleteMs =
+                sinkResult.sinkCompletedAt - readyDownloadClick.clickedAt;
+            const libraryStreamDurationMs = durationBetween(
+                libraryStreamStartedAt,
+                libraryStreamFinishedAt
+            );
+            const clickToLibraryStreamStartMs = durationBetween(
+                readyDownloadClick.clickedAt,
+                libraryStreamStartedAt
+            );
+            const libraryStreamEndToSinkCompleteMs = durationBetween(
+                libraryStreamFinishedAt,
+                sinkResult.sinkCompletedAt
+            );
+            const readyManifestVisibilityLagMs = Math.max(
+                0,
+                uploadFinishedToReadyVisibleMs
+            );
 
             const result = {
                 status: "passed",
                 scenario: SCENARIO,
-                readerRole: READER_ROLE,
+                readerCohort: READER_COHORT,
+                readerRole: LEGACY_READER_ROLE,
                 baseURL,
                 shareUrl: shareUrl.toString(),
                 fileName,
                 fileSizeMb: FILE_SIZE_MB,
-                downloadMode: usesStreamingDownload
-                    ? "save-picker-stream"
-                    : "browser-download",
-                sizeBytes: downloaded.size,
-                uploadDurationMs: uploadFinishedAt - uploadStartedAt,
-                discoveryLagMs: readerVisibleAt - uploadFinishedAt,
-                downloadDurationMs: downloadFinishedAt - downloadStartedAt,
-                writerDiagnostics,
-                readerDiagnostics,
+                sink: sinkResult.sink,
+                downloadMode: sinkResult.sink,
+                sinkServerWriteCalls: sinkResult.serverWriteCalls,
+                sinkServerWriteDurationMs: sinkResult.serverWriteDurationMs,
+                sinkServerWriteDurationDefinition:
+                    "loopback-request-body-receive-and-node-filesystem-write-only",
+                sizeBytes: sinkResult.size,
+                fixture: fixtureResult,
+                readerCohortValidation: cohortResult,
+                readerPeerHints,
+                readerTopologyReadiness,
+                readerJsHeap,
+                readerJsHeapValidation,
+                timings: {
+                    uploadDurationMs,
+                    uploadStartedToReadyVisibleMs,
+                    uploadFinishedToReadyVisibleMs,
+                    readyVisibleToClickMs,
+                    clickToSinkCompleteMs,
+                    libraryStreamDurationMs,
+                    clickToLibraryStreamStartMs,
+                    libraryStreamEndToSinkCompleteMs,
+                },
+                uploadDurationMs,
+                uploadStartedToReadyVisibleMs,
+                uploadFinishedToReadyVisibleMs,
+                readyVisibleToClickMs,
+                clickToSinkCompleteMs,
+                libraryStreamDurationMs,
+                clickToLibraryStreamStartMs,
+                libraryStreamEndToSinkCompleteMs,
+                readerReadyManifestVisibleAt: readyDownloadClick.capturedAt,
+                readyManifestVisibilityLagMs,
+                readyManifestVisibilityOffsetFromUploadFinishedMs:
+                    uploadFinishedToReadyVisibleMs,
+                readyManifestVisibleToDownloadStartMs: readyVisibleToClickMs,
+                discoveryLagMs: readyManifestVisibilityLagMs,
+                discoveryLagDefinition:
+                    "reader-ready-visible-minus-writer-upload-finished-clamped-at-zero",
+                downloadDurationMs: clickToSinkCompleteMs,
+                downloadDurationDefinition:
+                    "browser-row-click-to-primary-sink-complete",
+                downloadStartedAt: readyDownloadClick.clickedAt,
+                downloadFinishedAt: sinkResult.sinkCompletedAt,
+                libraryStreamStartedAt,
+                libraryStreamFinishedAt,
+                writerLightweightSnapshotAfterSink,
+                readerLightweightSnapshotAtVisibility:
+                    readyDownloadClick.snapshot,
+                persistChunkReadsBeforeClick:
+                    readyDownloadClick.persistChunkReadsBeforeClick,
+                persistChunkReadsAtClick:
+                    readyDownloadClick.persistChunkReadsAtClick,
+                diagnosticsCapturedAfterSink: true,
+                writerDiagnostics: writerDiagnosticsAfterDownload,
+                readerDiagnostics: readerDiagnosticsAfterDownload,
                 writerDiagnosticsAfterDownload,
                 readerDiagnosticsAfterDownload,
-                uploadMiBps: toMiBPerSecond(
-                    downloaded.size,
-                    uploadFinishedAt - uploadStartedAt
-                ),
-                uploadMbps: toMbps(
-                    downloaded.size,
-                    uploadFinishedAt - uploadStartedAt
-                ),
+                uploadMiBps: toMiBPerSecond(sinkResult.size, uploadDurationMs),
+                uploadMbps: toMbps(sinkResult.size, uploadDurationMs),
                 downloadMiBps: toMiBPerSecond(
-                    downloaded.size,
-                    downloadFinishedAt - downloadStartedAt
+                    sinkResult.size,
+                    clickToSinkCompleteMs
                 ),
-                downloadMbps: toMbps(
-                    downloaded.size,
-                    downloadFinishedAt - downloadStartedAt
-                ),
+                downloadMbps: toMbps(sinkResult.size, clickToSinkCompleteMs),
                 startedAt: uploadStartedAt,
-                finishedAt: downloadFinishedAt,
+                finishedAt: sinkResult.sinkCompletedAt,
             };
 
             await persistResult(result);
             console.log(`FILE_SHARE_TRANSFER_BENCH ${JSON.stringify(result)}`);
         } catch (error: any) {
-            const failureWriterDiagnostics =
-                writerDiagnostics ??
-                (await getDiagnostics(writer).catch(() => undefined));
-            const failureReaderDiagnostics =
-                (await getDiagnostics(reader).catch(() => undefined)) ??
-                readerDiagnostics;
+            if (readerJsHeapSampler) {
+                readerJsHeap = await readerJsHeapSampler.stop();
+                readerJsHeapSampler = undefined;
+            }
+            const [failureWriterDiagnostics, failureReaderDiagnostics] =
+                await Promise.all([
+                    writer
+                        ? getDiagnostics(writer).catch(() => undefined)
+                        : undefined,
+                    reader
+                        ? getDiagnostics(reader).catch(() => undefined)
+                        : undefined,
+                ]);
             const result = {
                 status: "failed",
                 scenario: SCENARIO,
-                readerRole: READER_ROLE,
+                readerCohort: READER_COHORT,
+                readerRole: LEGACY_READER_ROLE,
+                shareUrl: shareUrl?.toString(),
                 fileName,
                 fileSizeMb: FILE_SIZE_MB,
+                sink: sinkResult?.sink,
+                fixture:
+                    fixtureResult ??
+                    (preparedFile
+                        ? createFixtureResult({
+                              fixture: preparedFile.fixture,
+                              manifestFinalHash,
+                              downloadSha256Base64,
+                              downloadCrc32Hex,
+                              downloadCompleted,
+                              usesStreamingDownload,
+                          })
+                        : {
+                              requestedMode: FIXTURE_MODE,
+                              seed:
+                                  FIXTURE_MODE === "deterministic"
+                                      ? FIXTURE_SEED
+                                      : null,
+                              setupComplete: false,
+                          }),
+                readerCohortValidation: cohortResult,
+                readerPeerHints,
+                readerTopologyReadiness,
+                readerJsHeap,
+                readerJsHeapValidation,
+                readyDownloadClick,
+                writerLightweightSnapshotAfterSink,
                 failure: {
                     message:
                         typeof error?.message === "string"
@@ -324,13 +1274,25 @@ test.describe("file-share transfer benchmark", () => {
             );
             throw error;
         } finally {
-            await writerContext.close().catch(() => {});
-            await readerContext.close().catch(() => {});
+            if (readerJsHeapSampler) {
+                readerJsHeap = await readerJsHeapSampler
+                    .stop()
+                    .catch(() => readerJsHeapSampler?.snapshot());
+                readerJsHeapSampler = undefined;
+            }
+            if (cleanupDownloadedFile) {
+                await cleanupDownloadedFile().catch(() => {});
+            }
+            await nodeSinkController?.cleanup().catch(() => {});
+            await writerContext?.close().catch(() => {});
+            await readerContext?.close().catch(() => {});
             await bootstrap?.stop().catch(() => {});
-            await rm(preparedFile.dir, {
-                recursive: true,
-                force: true,
-            }).catch(() => {});
+            if (preparedFile) {
+                await rm(preparedFile.dir, {
+                    recursive: true,
+                    force: true,
+                }).catch(() => {});
+            }
         }
     });
 });

--- a/packages/file-share/frontend/tests/two-runner.bench.mjs
+++ b/packages/file-share/frontend/tests/two-runner.bench.mjs
@@ -39,7 +39,7 @@ const getReaderRoleOptions = () => {
         return false;
     }
     if (READER_ROLE === "adaptive") {
-        return { limits: { cpu: { max: 1 } } };
+        return { limits: { interval: 300_000, cpu: { max: 1 } } };
     }
     throw new Error(`Unsupported PW_READER_ROLE='${READER_ROLE}'`);
 };
@@ -137,7 +137,7 @@ const waitForTestHooks = async (page, timeout = TEST_HOOK_TIMEOUT_MS) => {
         () =>
             Boolean(
                 window.__peerbitFileShareTestHooks &&
-                    window.__peerbitFileShareTestHooks.getDiagnostics
+                window.__peerbitFileShareTestHooks.getDiagnostics
             ),
         undefined,
         { timeout }
@@ -593,9 +593,7 @@ const getLinkHeaderUrl = (linkHeader, rel) => {
         return undefined;
     }
     for (const part of linkHeader.split(",")) {
-        const match = part
-            .trim()
-            .match(/^<([^>]+)>;\s*rel="([^"]+)"$/);
+        const match = part.trim().match(/^<([^>]+)>;\s*rel="([^"]+)"$/);
         if (match?.[2] === rel) {
             return match[1];
         }

--- a/packages/file-share/frontend/tests/upload-lifecycle.unit.test.ts
+++ b/packages/file-share/frontend/tests/upload-lifecycle.unit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { settleUploadBatch } from "../src/upload-lifecycle";
+
+describe("upload lifecycle", () => {
+    it("reports a rejection and waits for the remaining uploads", async () => {
+        let finishRemaining: () => void = () => {};
+        const remaining = new Promise<void>((resolve) => {
+            finishRemaining = resolve;
+        });
+        const onError = vi.fn();
+        let settled = false;
+        const batch = settleUploadBatch(
+            [Promise.reject(new Error("upload failed")), remaining],
+            onError
+        ).then(() => {
+            settled = true;
+        });
+
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(onError).toHaveBeenCalledOnce();
+        expect(settled).toBe(false);
+
+        finishRemaining();
+        await batch;
+        expect(settled).toBe(true);
+    });
+
+    it("resolves cleanly when every upload succeeds", async () => {
+        const onError = vi.fn();
+        await settleUploadBatch(
+            [Promise.resolve(), Promise.resolve()],
+            onError
+        );
+        expect(onError).not.toHaveBeenCalled();
+    });
+});

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -1,5 +1,6 @@
 import { Peerbit } from "peerbit";
 import {
+    AbstractFile,
     Files,
     IndexableFile,
     LargeFile,
@@ -22,6 +23,21 @@ const getQueryValue = (query: any) => query?.value?.value ?? query?.value;
 const stripChunkEntryHeads = (file: LargeFile | undefined) => {
     (file as any).chunkEntryHeads = undefined;
 };
+
+const uploadLargeThrough = (
+    filestore: Files,
+    path: "bytes" | "source",
+    name: string,
+    bytes: Uint8Array
+) =>
+    path === "bytes"
+        ? filestore.add(name, bytes)
+        : filestore.addSource(name, {
+              size: BigInt(bytes.byteLength),
+              readChunks: async function* () {
+                  yield bytes;
+              },
+          });
 
 describe("index", () => {
     let peer: Peerbit, peer2: Peerbit;
@@ -60,6 +76,166 @@ describe("index", () => {
         expect(await filestoreReader.getByName("tiny file")).to.be.undefined;
     });
 
+    it("removes a remote-only root through a non-replicating observer", async () => {
+        const writer = await peer.open(new Files());
+        const fileId = await writer.add(
+            "remote-only observer removal",
+            new Uint8Array([1, 2, 3])
+        );
+        const reader = await peer2.open<Files>(writer.address, {
+            args: { replicate: false },
+        });
+        await reader.files.log.waitForReplicator(peer.identity.publicKey);
+
+        expect(
+            await reader.files.index.get(fileId, {
+                local: true,
+                remote: false,
+            })
+        ).to.be.undefined;
+
+        const originalSearch = reader.files.index.search.bind(
+            reader.files.index
+        );
+        const originalDelete = reader.files.del.bind(reader.files);
+        let exactRemoteOptions: any;
+        let localHeadAtDelete: string | undefined;
+        (reader.files.index as any).search = async (
+            request: any,
+            options: any
+        ) => {
+            const queries = Array.isArray(request.query)
+                ? request.query
+                : [request.query];
+            if (
+                queries.some(
+                    (query: any) =>
+                        getQueryKey(query) === "id" &&
+                        getQueryValue(query) === fileId
+                )
+            ) {
+                exactRemoteOptions = options;
+            }
+            return originalSearch(request, options);
+        };
+        (reader.files as any).del = async (id: string, ...args: any[]) => {
+            const local = await reader.files.index.get(id, {
+                local: true,
+                remote: false,
+            });
+            localHeadAtDelete = (local as any)?.__context?.head;
+            return (originalDelete as any)(id, ...args);
+        };
+
+        try {
+            await reader.removeById(fileId);
+        } finally {
+            (reader.files.index as any).search = originalSearch;
+            (reader.files as any).del = originalDelete;
+        }
+
+        expect(localHeadAtDelete).to.be.a("string");
+        expect(exactRemoteOptions?.local).to.be.false;
+        expect(exactRemoteOptions?.remote?.replicate).to.be.true;
+        expect(exactRemoteOptions?.remote?.throwOnMissing).to.be.true;
+        expect(exactRemoteOptions?.remote?.from).to.deep.eq([
+            peer.identity.publicKey.hashcode(),
+        ]);
+        expect(
+            await reader.files.index.get(fileId, {
+                local: true,
+                remote: false,
+            })
+        ).to.be.undefined;
+        await waitForResolved(async () => {
+            expect(
+                await writer.files.index.get(fileId, {
+                    local: true,
+                    remote: false,
+                })
+            ).to.be.undefined;
+        });
+    });
+
+    it("keeps public nested tiny files across restart state and removal", async () => {
+        const filestore = await peer.open(new Files());
+        const parentId = await filestore.add(
+            "nested parent",
+            new Uint8Array([1])
+        );
+        const nestedBytes = new Uint8Array([2, 3]);
+        const nestedId = await filestore.add(
+            "public nested tiny",
+            nestedBytes,
+            parentId
+        );
+        const nested = (await filestore.files.index.get(nestedId, {
+            local: true,
+            remote: false,
+        })) as TinyFile;
+        const nestedHead = (nested as any).__context.head as string;
+        const nestedEntry = await filestore.files.log.log.get(nestedHead);
+
+        expect(nested).to.be.instanceOf(TinyFile);
+        expect(nested.parentId).to.eq(parentId);
+        expect(nested.index).to.be.undefined;
+
+        const reader = await peer2.open<Files>(filestore.address);
+        await reader.files.log.waitForReplicator(peer.identity.publicKey);
+        await reader.files.index.get(nestedId, {
+            local: true,
+            remote: {
+                timeout: 10_000,
+                throwOnMissing: false,
+                replicate: true,
+            },
+        } as any);
+        await waitForResolved(async () => {
+            const local = await reader.files.index.get(nestedId, {
+                local: true,
+                remote: false,
+            });
+            expect((local as any)?.__context?.head).to.eq(nestedHead);
+        });
+        (reader as any).clearFileRuntimeState();
+        expect(await (reader as any).shouldKeepFileEntry(nestedEntry)).to.be
+            .true;
+        expect(
+            (reader as any).retainedEntryHeadsByFileId.get(nestedId)
+        ).to.deep.eq(new Set([nestedHead]));
+        expect((reader as any).retainedChunkIds.has(nestedId)).to.be.false;
+
+        // Runtime retention maps are intentionally empty after a restart. The
+        // current authored document must rebuild ownership under its own id,
+        // not be subjected to LargeFile chunk validation under its parent.
+        (filestore as any).clearFileRuntimeState();
+        expect(await (filestore as any).shouldKeepFileEntry(nestedEntry)).to.be
+            .true;
+        expect(
+            (filestore as any).retainedEntryHeadsByFileId.get(nestedId)
+        ).to.deep.eq(new Set([nestedHead]));
+        expect((filestore as any).retainedEntryHeadsByFileId.has(parentId)).to
+            .be.false;
+        expect((filestore as any).retainedChunkIds.has(nestedId)).to.be.false;
+
+        await filestore.removeById(nestedId);
+
+        expect(
+            await filestore.files.index.get(nestedId, {
+                local: true,
+                remote: false,
+            })
+        ).to.be.undefined;
+        expect(
+            await filestore.files.index.get(parentId, {
+                local: true,
+                remote: false,
+            })
+        ).not.to.be.undefined;
+        expect((filestore as any).retainedChunkEntryHeads.has(nestedHead)).to.be
+            .false;
+    });
+
     it("small file", async () => {
         // Peer 1 is subscribing to a replication topic (to start helping the network)
         const filestore = await peer.open(new Files());
@@ -86,16 +262,63 @@ describe("index", () => {
     });
 
     describe("large file", () => {
-        it("keeps self-signed shallow chunk entries during adaptive pruning", async () => {
+        it("keeps only current or pending self-authored puts and signed deletes", async () => {
             const filestore = await peer.open(new Files());
-            const entryHash = "self-signed-chunk-entry";
-
-            expect(
-                await (filestore as any).shouldKeepFileEntry({
-                    hash: entryHash,
-                    signatures: [{ publicKey: peer.identity.publicKey }],
+            const fileId = "self-authored-pruning";
+            const first = await filestore.files.put(
+                new TinyFile({
+                    id: fileId,
+                    name: "self-authored-pruning-first.bin",
+                    file: new Uint8Array([1]),
                 })
-            ).to.be.true;
+            );
+
+            expect(await (filestore as any).shouldKeepFileEntry(first.entry)).to
+                .be.true;
+
+            const second = await filestore.files.put(
+                new TinyFile({
+                    id: fileId,
+                    name: "self-authored-pruning-second.bin",
+                    file: new Uint8Array([2]),
+                })
+            );
+            (filestore as any).pendingAuthoredDocumentIds.set(fileId, 1);
+            expect(await (filestore as any).shouldKeepFileEntry(first.entry)).to
+                .be.true;
+            (filestore as any).pendingAuthoredDocumentIds.delete(fileId);
+            expect(await (filestore as any).shouldKeepFileEntry(first.entry)).to
+                .be.false;
+            expect(await (filestore as any).shouldKeepFileEntry(second.entry))
+                .to.be.true;
+
+            const deleted = await filestore.files.del(fileId);
+            expect(await (filestore as any).shouldKeepFileEntry(second.entry))
+                .to.be.false;
+            expect(await (filestore as any).shouldKeepFileEntry(deleted.entry))
+                .to.be.true;
+
+            // Simulate a restart where all in-memory retention maps and release
+            // tombstones are empty. The index is still the source of truth.
+            (filestore as any).clearFileRuntimeState();
+            expect(await (filestore as any).shouldKeepFileEntry(first.entry)).to
+                .be.false;
+            expect(await (filestore as any).shouldKeepFileEntry(second.entry))
+                .to.be.false;
+            expect(await (filestore as any).shouldKeepFileEntry(deleted.entry))
+                .to.be.true;
+
+            const readded = await filestore.files.put(
+                new TinyFile({
+                    id: fileId,
+                    name: "self-authored-pruning-readded.bin",
+                    file: new Uint8Array([3]),
+                })
+            );
+            expect(await (filestore as any).shouldKeepFileEntry(readded.entry))
+                .to.be.true;
+            expect(await (filestore as any).shouldKeepFileEntry(second.entry))
+                .to.be.false;
         });
 
         it("keeps retained chunk entries by payload during adaptive pruning", async () => {
@@ -117,6 +340,15 @@ describe("index", () => {
             const retainedHead = (retainedChunk as any).__context.head;
             const retainedEntry = await writer.files.log.log.get(retainedHead);
             reader.retainChunkRead(retainedChunkId);
+            await reader.files.log.waitForReplicator(peer.identity.publicKey);
+            await waitForResolved(async () => {
+                const current = await reader.files.index.get(retainedChunkId, {
+                    resolve: false,
+                    local: true,
+                    remote: false,
+                } as any);
+                expect((current as any)?.__context?.head).to.eq(retainedHead);
+            });
 
             expect(await (reader as any).shouldKeepFileEntry(retainedEntry)).to
                 .be.true;
@@ -190,6 +422,7 @@ describe("index", () => {
         it("keeps ready root manifests during adaptive pruning", async () => {
             const writer = await peer.open(new Files());
             const reader = await peer2.open<Files>(writer.address);
+            await reader.files.log.waitForReplicator(peer.identity.publicKey);
             const readyRoot = new LargeFileWithChunkHeads({
                 id: "adaptive-root-ready",
                 name: "adaptive-root-ready.bin",
@@ -200,6 +433,16 @@ describe("index", () => {
                 chunkEntryHeads: ["chunk-head-0", "chunk-head-1"],
             });
             const appended = await writer.files.put(readyRoot);
+            await waitForResolved(async () => {
+                const current = await reader.files.index.get(readyRoot.id, {
+                    resolve: false,
+                    local: true,
+                    remote: false,
+                } as any);
+                expect((current as any)?.__context?.head).to.eq(
+                    appended.entry.hash
+                );
+            });
 
             expect(await (reader as any).shouldKeepFileEntry(appended.entry)).to
                 .be.true;
@@ -251,6 +494,83 @@ describe("index", () => {
             await filestore.removeByName("random large file");
             expect(await filestoreReader.getByName("random large file")).to.be
                 .undefined;
+        });
+
+        it("retries exact child cleanup after the root deletion commits", async () => {
+            const filestore = await peer.open(new Files());
+            const fileId = await filestore.add(
+                "retry child cleanup",
+                new Uint8Array(5_000_001)
+            );
+            const ready = await filestore.files.index.get(fileId, {
+                local: true,
+                remote: false,
+            });
+            expect(isLargeFileLike(ready)).to.be.true;
+            const chunkCount = (ready as LargeFile).chunkCount;
+            const failedChunkId = `${fileId}:1`;
+            const originalDelete = filestore.files.del.bind(filestore.files);
+            let rootDeleteCommitted = false;
+            let rejectedChildDelete = false;
+
+            (filestore.files as any).del = async (
+                id: string,
+                ...args: any[]
+            ) => {
+                if (id === fileId) {
+                    const result = await (originalDelete as any)(id, ...args);
+                    rootDeleteCommitted = true;
+                    return result;
+                }
+                if (id === failedChunkId && !rejectedChildDelete) {
+                    expect(rootDeleteCommitted).to.be.true;
+                    rejectedChildDelete = true;
+                    throw new Error("injected child delete failure");
+                }
+                return (originalDelete as any)(id, ...args);
+            };
+
+            try {
+                await expect(filestore.removeById(fileId)).rejects.toThrow(
+                    "injected child delete failure"
+                );
+            } finally {
+                (filestore.files as any).del = originalDelete;
+            }
+
+            expect(rootDeleteCommitted).to.be.true;
+            expect(rejectedChildDelete).to.be.true;
+            expect(
+                await filestore.files.index.get(fileId, {
+                    local: true,
+                    remote: false,
+                })
+            ).to.be.undefined;
+            expect(
+                await filestore.files.index.get(failedChunkId, {
+                    local: true,
+                    remote: false,
+                })
+            ).not.to.be.undefined;
+            expect((filestore as any).pendingLargeFileDeletions.has(fileId)).to
+                .be.true;
+
+            await filestore.removeById(fileId);
+
+            for (let index = 0; index < chunkCount; index++) {
+                expect(
+                    await filestore.files.index.get(`${fileId}:${index}`, {
+                        local: true,
+                        remote: false,
+                    })
+                ).to.be.undefined;
+            }
+            expect((filestore as any).retainedChunkIdsByFileId.has(fileId)).to
+                .be.false;
+            expect((filestore as any).retainedEntryHeadsByFileId.has(fileId)).to
+                .be.false;
+            expect((filestore as any).pendingLargeFileDeletions.has(fileId)).to
+                .be.false;
         });
 
         it("streams blob uploads without changing the root hash", async () => {
@@ -349,6 +669,734 @@ describe("index", () => {
             }
         });
 
+        for (const uploadPath of ["bytes", "source"] as const) {
+            it(`does not leave a pending ${uploadPath} root after a precommit put rejection`, async () => {
+                const filestore = await peer.open(new Files());
+                const bytes = new Uint8Array(5_000_001);
+                const originalPut = filestore.files.put.bind(filestore.files);
+                const originalDelete = filestore.files.del.bind(
+                    filestore.files
+                );
+                let uploadId: string | undefined;
+                let rootDeleteCalls = 0;
+
+                (filestore.files as any).put = async (
+                    value: AbstractFile,
+                    ...args: any[]
+                ) => {
+                    if (isLargeFileLike(value) && !value.ready) {
+                        uploadId = value.id;
+                        throw new Error("pending put rejected before commit");
+                    }
+                    return (originalPut as any)(value, ...args);
+                };
+                (filestore.files as any).del = async (
+                    id: string,
+                    ...args: any[]
+                ) => {
+                    if (id === uploadId) {
+                        rootDeleteCalls += 1;
+                    }
+                    return (originalDelete as any)(id, ...args);
+                };
+
+                try {
+                    await expect(
+                        uploadLargeThrough(
+                            filestore,
+                            uploadPath,
+                            `precommit pending ${uploadPath}`,
+                            bytes
+                        )
+                    ).rejects.toThrow("pending put rejected before commit");
+                } finally {
+                    (filestore.files as any).put = originalPut;
+                    (filestore.files as any).del = originalDelete;
+                }
+
+                expect(uploadId).to.be.a("string");
+                expect(rootDeleteCalls).to.eq(0);
+                expect(
+                    await filestore.files.index.get(uploadId!, {
+                        local: true,
+                        remote: false,
+                    })
+                ).to.be.undefined;
+            });
+
+            it(`cleans a committed pending ${uploadPath} root when put rejects`, async () => {
+                const filestore = await peer.open(new Files());
+                const bytes = new Uint8Array(5_000_001);
+                const originalPut = filestore.files.put.bind(filestore.files);
+                let uploadId: string | undefined;
+
+                (filestore.files as any).put = async (
+                    value: AbstractFile,
+                    ...args: any[]
+                ) => {
+                    const result = await (originalPut as any)(value, ...args);
+                    if (isLargeFileLike(value) && !value.ready) {
+                        uploadId = value.id;
+                        throw new Error("pending put rejected after commit");
+                    }
+                    return result;
+                };
+
+                try {
+                    await expect(
+                        uploadLargeThrough(
+                            filestore,
+                            uploadPath,
+                            `postcommit pending ${uploadPath}`,
+                            bytes
+                        )
+                    ).rejects.toThrow("pending put rejected after commit");
+                } finally {
+                    (filestore.files as any).put = originalPut;
+                }
+
+                expect(uploadId).to.be.a("string");
+                expect(
+                    await filestore.files.index.get(uploadId!, {
+                        local: true,
+                        remote: false,
+                    })
+                ).to.be.undefined;
+                expect(
+                    (filestore as any).retainedEntryHeadsByFileId.has(uploadId)
+                ).to.be.false;
+                expect(
+                    (filestore as any).retainedLargeFileChunkCounts.has(
+                        uploadId
+                    )
+                ).to.be.false;
+            });
+
+            it(`accepts a committed ready ${uploadPath} manifest when put rejects`, async () => {
+                const filestore = await peer.open(new Files());
+                const bytes = new Uint8Array(5_000_001);
+                bytes[bytes.length - 1] = 7;
+                const originalPut = filestore.files.put.bind(filestore.files);
+                let rejectedReadyPut = false;
+                let pendingHead: string | undefined;
+
+                (filestore.files as any).put = async (
+                    value: AbstractFile,
+                    ...args: any[]
+                ) => {
+                    const result = await (originalPut as any)(value, ...args);
+                    if (isLargeFileLike(value) && !value.ready) {
+                        pendingHead = result.entry.hash;
+                    }
+                    if (
+                        isLargeFileLike(value) &&
+                        value.ready &&
+                        !rejectedReadyPut
+                    ) {
+                        rejectedReadyPut = true;
+                        throw new Error("ready put rejected after commit");
+                    }
+                    return result;
+                };
+
+                let uploadId: string;
+                try {
+                    uploadId = await uploadLargeThrough(
+                        filestore,
+                        uploadPath,
+                        `postcommit ready ${uploadPath}`,
+                        bytes
+                    );
+                } finally {
+                    (filestore.files as any).put = originalPut;
+                }
+
+                const ready = await filestore.files.index.get(uploadId!, {
+                    local: true,
+                    remote: false,
+                });
+                expect(rejectedReadyPut).to.be.true;
+                expect(isLargeFileLike(ready)).to.be.true;
+                expect((ready as LargeFile).ready).to.be.true;
+                expect((ready as LargeFile).finalHash).to.eq(
+                    sha256Base64Sync(bytes)
+                );
+                const retainedHeads = (
+                    filestore as any
+                ).retainedEntryHeadsByFileId.get(uploadId) as Set<string>;
+                expect(retainedHeads).to.contain((ready as any).__context.head);
+                expect(retainedHeads).not.to.contain(pendingHead);
+            });
+
+            it(`cancels a ${uploadPath} upload deleted before its ready commit`, async () => {
+                const filestore = await peer.open(new Files());
+                const bytes = new Uint8Array(5_000_001);
+                const originalCommit = (
+                    filestore as any
+                ).commitReadyManifest.bind(filestore);
+                let uploadId: string | undefined;
+                let releaseCommit!: () => void;
+                let markCommitReached!: () => void;
+                const commitGate = new Promise<void>((resolve) => {
+                    releaseCommit = resolve;
+                });
+                const commitReached = new Promise<void>((resolve) => {
+                    markCommitReached = resolve;
+                });
+
+                (filestore as any).commitReadyManifest = async (
+                    pendingFile: LargeFile,
+                    ...args: any[]
+                ) => {
+                    uploadId = pendingFile.id;
+                    markCommitReached();
+                    await commitGate;
+                    return originalCommit(pendingFile, ...args);
+                };
+
+                try {
+                    const upload = uploadLargeThrough(
+                        filestore,
+                        uploadPath,
+                        `delete-before-ready ${uploadPath}`,
+                        bytes
+                    );
+                    await commitReached;
+                    const chunkIds = [
+                        ...(((filestore as any).retainedChunkIdsByFileId.get(
+                            uploadId
+                        ) as Set<string> | undefined) ?? []),
+                    ];
+                    expect(chunkIds.length).to.be.greaterThan(0);
+
+                    await filestore.removeById(uploadId!);
+                    releaseCommit();
+                    await expect(upload).rejects.toThrow(
+                        "cancelled or superseded before ready manifest commit"
+                    );
+
+                    expect(
+                        await filestore.files.index.get(uploadId!, {
+                            local: true,
+                            remote: false,
+                        })
+                    ).to.be.undefined;
+                    for (const chunkId of chunkIds) {
+                        expect(
+                            await filestore.files.index.get(chunkId, {
+                                local: true,
+                                remote: false,
+                            })
+                        ).to.be.undefined;
+                    }
+                    expect(
+                        (filestore as any).retainedEntryHeadsByFileId.has(
+                            uploadId
+                        )
+                    ).to.be.false;
+                    expect(
+                        (filestore as any).retainedChunkIdsByFileId.has(
+                            uploadId
+                        )
+                    ).to.be.false;
+                    expect(
+                        (filestore as any).retainedLargeFileChunkCounts.has(
+                            uploadId
+                        )
+                    ).to.be.false;
+                } finally {
+                    releaseCommit();
+                    (filestore as any).commitReadyManifest = originalCommit;
+                }
+            });
+
+            it(`preserves a pending replacement that supersedes a ${uploadPath} upload`, async () => {
+                const filestore = await peer.open(new Files());
+                const bytes = new Uint8Array(5_000_001);
+                const originalCommit = (
+                    filestore as any
+                ).commitReadyManifest.bind(filestore);
+                const originalCleanup = (
+                    filestore as any
+                ).cleanupChunkedUpload.bind(filestore);
+                let pendingFile: LargeFile | undefined;
+                let releaseCommit!: () => void;
+                let markCommitReached!: () => void;
+                let cleanupCalls = 0;
+                const commitGate = new Promise<void>((resolve) => {
+                    releaseCommit = resolve;
+                });
+                const commitReached = new Promise<void>((resolve) => {
+                    markCommitReached = resolve;
+                });
+
+                (filestore as any).commitReadyManifest = async (
+                    candidate: LargeFile,
+                    ...args: any[]
+                ) => {
+                    pendingFile = candidate;
+                    markCommitReached();
+                    await commitGate;
+                    return originalCommit(candidate, ...args);
+                };
+                (filestore as any).cleanupChunkedUpload = async (
+                    ...args: any[]
+                ) => {
+                    cleanupCalls += 1;
+                    return originalCleanup(...args);
+                };
+
+                try {
+                    const upload = uploadLargeThrough(
+                        filestore,
+                        uploadPath,
+                        `superseded-before-ready ${uploadPath}`,
+                        bytes
+                    );
+                    await commitReached;
+                    const replacement = new LargeFile({
+                        id: pendingFile!.id,
+                        name: `replacement ${uploadPath}`,
+                        size: pendingFile!.size,
+                        chunkCount: pendingFile!.chunkCount,
+                        ready: false,
+                    });
+                    const replacementPut = await (
+                        filestore as any
+                    ).putAuthoredFile(replacement);
+                    const replacementChunk = new TinyFile({
+                        name: `replacement ${uploadPath}/owned`,
+                        file: new Uint8Array([9]),
+                        parentId: replacement.id,
+                        index: replacement.chunkCount + 10,
+                    });
+                    const replacementChunkPut = await (
+                        filestore as any
+                    ).putAuthoredFile(replacementChunk);
+
+                    releaseCommit();
+                    await expect(upload).rejects.toThrow(
+                        "cancelled or superseded before ready manifest commit"
+                    );
+
+                    expect(cleanupCalls).to.eq(0);
+                    const current = await filestore.files.index.get(
+                        replacement.id,
+                        { local: true, remote: false }
+                    );
+                    expect((current as any)?.__context?.head).to.eq(
+                        replacementPut.entry.hash
+                    );
+                    expect((current as LargeFile).name).to.eq(
+                        `replacement ${uploadPath}`
+                    );
+                    expect(
+                        await filestore.files.index.get(replacementChunk.id, {
+                            local: true,
+                            remote: false,
+                        })
+                    ).not.to.be.undefined;
+                    expect(
+                        (filestore as any).retainedChunkEntryHeads
+                    ).to.contain(replacementChunkPut.entry.hash);
+                    expect(
+                        (filestore as any).retainedEntryHeadsByFileId.get(
+                            replacement.id
+                        )
+                    ).to.contain(replacementPut.entry.hash);
+                } finally {
+                    releaseCommit();
+                    (filestore as any).commitReadyManifest = originalCommit;
+                    (filestore as any).cleanupChunkedUpload = originalCleanup;
+                }
+            });
+
+            it(`preserves a replacement inserted after failed ${uploadPath} root proof`, async () => {
+                const filestore = await peer.open(new Files());
+                const bytes = new Uint8Array(5_000_001);
+                bytes[bytes.length - 1] = 4;
+                const originalCommit = (
+                    filestore as any
+                ).commitReadyManifest.bind(filestore);
+                const originalCleanup = (
+                    filestore as any
+                ).cleanupChunkedUpload.bind(filestore);
+                let replacementRootHead: string | undefined;
+                let replacementChunkHead: string | undefined;
+                let failedChunkHeads: string[] = [];
+
+                (filestore as any).commitReadyManifest = async () => {
+                    throw new Error(`forced ${uploadPath} ready failure`);
+                };
+                (filestore as any).cleanupChunkedUpload = async (
+                    uploadId: string,
+                    expectedChunkCount: number,
+                    chunkEntryHeads: string[]
+                ) => {
+                    failedChunkHeads = [...chunkEntryHeads];
+                    const replacementChunk = new TinyFile({
+                        id: `${uploadId}:0`,
+                        name: `replacement after proof ${uploadPath}/0`,
+                        file: new Uint8Array([7, 8, 9]),
+                        parentId: uploadId,
+                        index: 0,
+                    });
+                    const replacementChunkPut = await (
+                        filestore as any
+                    ).putAuthoredFile(replacementChunk);
+                    replacementChunkHead = replacementChunkPut.entry.hash;
+                    const replacementRoot = new LargeFileWithChunkHeads({
+                        id: uploadId,
+                        name: `replacement after proof ${uploadPath}`,
+                        size: 3n,
+                        chunkCount: 1,
+                        ready: true,
+                        finalHash: sha256Base64Sync(replacementChunk.file),
+                        chunkEntryHeads: [replacementChunkHead!],
+                    });
+                    const replacementRootPut = await (
+                        filestore as any
+                    ).putAuthoredFile(replacementRoot);
+                    replacementRootHead = replacementRootPut.entry.hash;
+                    return originalCleanup(
+                        uploadId,
+                        expectedChunkCount,
+                        chunkEntryHeads
+                    );
+                };
+
+                try {
+                    await expect(
+                        uploadLargeThrough(
+                            filestore,
+                            uploadPath,
+                            `replacement after proof ${uploadPath}`,
+                            bytes
+                        )
+                    ).rejects.toThrow(`forced ${uploadPath} ready failure`);
+                } finally {
+                    (filestore as any).commitReadyManifest = originalCommit;
+                    (filestore as any).cleanupChunkedUpload = originalCleanup;
+                }
+
+                const uploadId = filestore.lastUploadDiagnostics!.uploadId;
+                const currentRoot = await filestore.files.index.get(uploadId, {
+                    local: true,
+                    remote: false,
+                });
+                const currentChunk = await filestore.files.index.get(
+                    `${uploadId}:0`,
+                    { local: true, remote: false }
+                );
+                expect(failedChunkHeads.length).to.be.greaterThan(0);
+                expect(failedChunkHeads).not.to.contain(replacementChunkHead);
+                expect((currentRoot as any)?.__context?.head).to.eq(
+                    replacementRootHead
+                );
+                expect((currentChunk as any)?.__context?.head).to.eq(
+                    replacementChunkHead
+                );
+                expect((filestore as any).retainedChunkEntryHeads).to.contain(
+                    replacementRootHead
+                );
+                expect((filestore as any).retainedChunkEntryHeads).to.contain(
+                    replacementChunkHead
+                );
+                expect((filestore as any).retainedChunkIds).to.contain(
+                    `${uploadId}:0`
+                );
+                expect(
+                    (filestore as any).retainedLargeFileChunkCounts.get(
+                        uploadId
+                    )
+                ).to.eq(1);
+            });
+        }
+
+        it("serializes a ready commit that wins against concurrent deletion", async () => {
+            const filestore = await peer.open(new Files());
+            const bytes = new Uint8Array(5_000_001);
+            const originalPut = filestore.files.put.bind(filestore.files);
+            let readyId: string | undefined;
+            let releaseReadyPut!: () => void;
+            let markReadyPutStarted!: () => void;
+            const readyPutGate = new Promise<void>((resolve) => {
+                releaseReadyPut = resolve;
+            });
+            const readyPutStarted = new Promise<void>((resolve) => {
+                markReadyPutStarted = resolve;
+            });
+
+            (filestore.files as any).put = async (
+                value: AbstractFile,
+                ...args: any[]
+            ) => {
+                if (isLargeFileLike(value) && value.ready) {
+                    readyId = value.id;
+                    markReadyPutStarted();
+                    await readyPutGate;
+                }
+                return (originalPut as any)(value, ...args);
+            };
+
+            try {
+                const upload = filestore.add(
+                    "ready-commit-wins-delete-race",
+                    bytes
+                );
+                await readyPutStarted;
+                let deleteFinished = false;
+                const deletion = filestore.removeById(readyId!).then(() => {
+                    deleteFinished = true;
+                });
+                await Promise.resolve();
+                expect(deleteFinished).to.be.false;
+
+                releaseReadyPut();
+                expect(await upload).to.eq(readyId);
+                await deletion;
+                expect(
+                    await filestore.files.index.get(readyId!, {
+                        local: true,
+                        remote: false,
+                    })
+                ).to.be.undefined;
+                expect((filestore as any).fileMutationTails.has(readyId)).to.be
+                    .false;
+            } finally {
+                releaseReadyPut();
+                (filestore.files as any).put = originalPut;
+            }
+        });
+
+        it("preserves a byte-identical pending replacement when the original put rejects", async () => {
+            const filestore = await peer.open(new Files());
+            const bytes = new Uint8Array(5_000_001);
+            const originalPut = filestore.files.put.bind(filestore.files);
+            const originalDelete = filestore.files.del.bind(filestore.files);
+            const originalCleanup = (
+                filestore as any
+            ).cleanupChunkedUpload.bind(filestore);
+            let originalHead: string | undefined;
+            let replacementHead: string | undefined;
+            let uploadId: string | undefined;
+            let deleteCalls = 0;
+            let cleanupCalls = 0;
+
+            (filestore.files as any).put = async (
+                value: AbstractFile,
+                ...args: any[]
+            ) => {
+                const result = await (originalPut as any)(value, ...args);
+                if (isLargeFileLike(value) && !value.ready) {
+                    uploadId = value.id;
+                    originalHead = result.entry.hash;
+                    const replacement = new LargeFile({
+                        id: value.id,
+                        name: value.name,
+                        size: value.size,
+                        chunkCount: value.chunkCount,
+                        ready: false,
+                    });
+                    replacementHead = (await originalPut(replacement)).entry
+                        .hash;
+                    filestore.retainChunkEntryHead(
+                        "replacement-retention-sentinel",
+                        value.id,
+                        value.id
+                    );
+                    throw new Error(
+                        "original pending put rejected after replacement"
+                    );
+                }
+                return result;
+            };
+            (filestore.files as any).del = async (
+                id: string,
+                ...args: any[]
+            ) => {
+                deleteCalls += 1;
+                return (originalDelete as any)(id, ...args);
+            };
+            (filestore as any).cleanupChunkedUpload = async (
+                ...args: any[]
+            ) => {
+                cleanupCalls += 1;
+                return originalCleanup(...args);
+            };
+
+            try {
+                await expect(
+                    filestore.add("identical pending replacement", bytes)
+                ).rejects.toThrow(
+                    "original pending put rejected after replacement"
+                );
+            } finally {
+                (filestore.files as any).put = originalPut;
+                (filestore.files as any).del = originalDelete;
+                (filestore as any).cleanupChunkedUpload = originalCleanup;
+            }
+
+            expect(originalHead).to.be.a("string");
+            expect(replacementHead).to.be.a("string");
+            expect(replacementHead).not.to.eq(originalHead);
+            expect(deleteCalls).to.eq(0);
+            expect(cleanupCalls).to.eq(0);
+            const current = await filestore.files.index.get(uploadId!, {
+                local: true,
+                remote: false,
+            });
+            expect((current as any)?.__context?.head).to.eq(replacementHead);
+            expect(isLargeFileLike(current)).to.be.true;
+            expect((current as LargeFile).ready).to.be.false;
+            expect((filestore as any).retainedChunkEntryHeads).to.contain(
+                "replacement-retention-sentinel"
+            );
+        });
+
+        it("cleans a failed upload when root deletion rejects after commit", async () => {
+            const filestore = await peer.open(new Files());
+            const originalDelete = filestore.files.del.bind(filestore.files);
+            let deletedRootId: string | undefined;
+
+            (filestore.files as any).del = async (
+                id: string,
+                ...args: any[]
+            ) => {
+                deletedRootId = id;
+                await (originalDelete as any)(id, ...args);
+                throw new Error("root delete delivery failed after commit");
+            };
+
+            try {
+                await expect(
+                    filestore.addSource("postcommit failed upload delete", {
+                        size: 5_000_001n,
+                        readChunks: async function* () {
+                            yield new Uint8Array(5_000_002);
+                        },
+                    })
+                ).rejects.toThrow("Source size changed during upload");
+            } finally {
+                (filestore.files as any).del = originalDelete;
+            }
+
+            expect(deletedRootId).to.eq(
+                filestore.lastUploadDiagnostics?.uploadId
+            );
+            expect(
+                await filestore.files.index.get(deletedRootId!, {
+                    local: true,
+                    remote: false,
+                })
+            ).to.be.undefined;
+            expect(
+                (filestore as any).retainedEntryHeadsByFileId.has(deletedRootId)
+            ).to.be.false;
+        });
+
+        it("preserves a concurrent ready replacement after failed-upload deletion rejects", async () => {
+            const filestore = await peer.open(new Files());
+            const originalPut = filestore.files.put.bind(filestore.files);
+            const originalDelete = filestore.files.del.bind(filestore.files);
+            let replacementHead: string | undefined;
+
+            (filestore.files as any).del = async (id: string) => {
+                const pending = (await filestore.files.index.get(id, {
+                    local: true,
+                    remote: false,
+                })) as LargeFile;
+                const replacement = new LargeFileWithChunkHeads({
+                    id,
+                    name: pending.name,
+                    size: pending.size,
+                    chunkCount: pending.chunkCount,
+                    ready: true,
+                    finalHash: "concurrent-ready-replacement",
+                    chunkEntryHeads: [],
+                });
+                const put = await originalPut(replacement);
+                replacementHead = put.entry.hash;
+                throw new Error("delete lost to concurrent replacement");
+            };
+
+            try {
+                await expect(
+                    filestore.addSource("replacement after failed upload", {
+                        size: 5_000_001n,
+                        readChunks: async function* () {
+                            yield new Uint8Array(5_000_002);
+                        },
+                    })
+                ).rejects.toThrow("Source size changed during upload");
+            } finally {
+                (filestore.files as any).put = originalPut;
+                (filestore.files as any).del = originalDelete;
+            }
+
+            const uploadId = filestore.lastUploadDiagnostics!.uploadId;
+            const current = await filestore.files.index.get(uploadId, {
+                local: true,
+                remote: false,
+            });
+            expect((current as any)?.__context?.head).to.eq(replacementHead);
+            expect(isLargeFileLike(current)).to.be.true;
+            expect((current as LargeFile).ready).to.be.true;
+            expect((current as LargeFile).finalHash).to.eq(
+                "concurrent-ready-replacement"
+            );
+        });
+
+        it("preserves a concurrent replacement when ready-manifest put rejects", async () => {
+            const filestore = await peer.open(new Files());
+            const bytes = new Uint8Array(5_000_001);
+            const originalPut = filestore.files.put.bind(filestore.files);
+            let replacementHead: string | undefined;
+            let injected = false;
+
+            (filestore.files as any).put = async (
+                value: AbstractFile,
+                ...args: any[]
+            ) => {
+                const result = await (originalPut as any)(value, ...args);
+                if (isLargeFileLike(value) && value.ready && !injected) {
+                    injected = true;
+                    const replacement = new LargeFileWithChunkHeads({
+                        id: value.id,
+                        name: "newer ready replacement",
+                        size: value.size,
+                        chunkCount: value.chunkCount,
+                        ready: true,
+                        finalHash: "newer-ready-hash",
+                        chunkEntryHeads: [],
+                    });
+                    replacementHead = (await originalPut(replacement)).entry
+                        .hash;
+                    throw new Error("ready put lost to replacement");
+                }
+                return result;
+            };
+
+            try {
+                await expect(
+                    filestore.add("ready replacement race", bytes)
+                ).rejects.toThrow("ready put lost to replacement");
+            } finally {
+                (filestore.files as any).put = originalPut;
+            }
+
+            const uploadId = filestore.lastUploadDiagnostics!.uploadId;
+            const current = await filestore.files.index.get(uploadId, {
+                local: true,
+                remote: false,
+            });
+            expect((current as any)?.__context?.head).to.eq(replacementHead);
+            expect((current as LargeFile).name).to.eq(
+                "newer ready replacement"
+            );
+            expect((current as LargeFile).finalHash).to.eq("newer-ready-hash");
+        });
+
         it("streams downloaded files chunk by chunk", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
@@ -376,7 +1424,7 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
-        it("pins persisted large-file chunk reads before streaming starts", async () => {
+        it("pins persisted large-file range metadata before scanning chunks", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
             const fileId = await filestore.add(
@@ -384,22 +1432,231 @@ describe("index", () => {
                 largeFile
             );
             const file = (await filestore.files.index.get(fileId)) as LargeFile;
-            const retainedChunks = new Set<string>();
-            const retainChunkRead = filestore.retainChunkRead.bind(filestore);
-            let firstWriteRetainedCount: number | undefined;
+            const retainedChunkCounts = (filestore as any)
+                .retainedLargeFileChunkCounts as Map<string, number>;
+            retainedChunkCounts.clear();
+            const countLocalChunks = filestore.countLocalChunks.bind(filestore);
+            let rangePinnedBeforeChunkScan = false;
 
-            (filestore as any).retainChunkRead = (chunkId: string) => {
-                retainedChunks.add(chunkId);
-                return retainChunkRead(chunkId);
+            (filestore as any).countLocalChunks = (candidate: LargeFile) => {
+                rangePinnedBeforeChunkScan =
+                    retainedChunkCounts.get(candidate.id) ===
+                    candidate.chunkCount;
+                return countLocalChunks(candidate);
             };
 
-            await file.writeFile(filestore, {
-                write: async () => {
-                    firstWriteRetainedCount ??= retainedChunks.size;
-                },
+            try {
+                await file.writeFile(filestore, {
+                    write: async () => {},
+                });
+            } finally {
+                (filestore as any).countLocalChunks = countLocalChunks;
+            }
+
+            expect(rangePinnedBeforeChunkScan).to.be.true;
+            expect(retainedChunkCounts.get(file.id)).to.eq(file.chunkCount);
+        });
+
+        it("cancels outstanding read-ahead and releases listeners when a stream closes early", async () => {
+            const filestore = await peer.open(new Files());
+            const largeFile = crypto.randomBytes(20 * 1e6) as Uint8Array;
+            const fileId = await filestore.add(
+                "cancelled streamed download",
+                largeFile
+            );
+            const file = (await filestore.files.index.get(fileId)) as LargeFile;
+            const originalGet = filestore.files.index.get.bind(
+                filestore.files.index
+            );
+            const originalSearch = filestore.files.index.search.bind(
+                filestore.files.index
+            );
+            let delayedChunkGets = 0;
+            let highestRequestedChunkIndex = -1;
+            let pendingBatchSignal: AbortSignal | undefined;
+            let pendingBatchAborted = false;
+            let markPendingBatchStarted!: () => void;
+            const pendingBatchStarted = new Promise<void>((resolve) => {
+                markPendingBatchStarted = resolve;
             });
 
-            expect(firstWriteRetainedCount).to.eq(file.chunkCount);
+            (filestore.files.index as any).get = async (
+                id: string,
+                options: unknown
+            ) => {
+                if (id.startsWith(`${fileId}:`)) {
+                    highestRequestedChunkIndex = Math.max(
+                        highestRequestedChunkIndex,
+                        Number(id.slice(fileId.length + 1))
+                    );
+                }
+                if (id.startsWith(`${fileId}:`) && id !== `${fileId}:0`) {
+                    delayedChunkGets += 1;
+                    await delay(300);
+                }
+                return originalGet(id as never, options as never);
+            };
+            (filestore.files.index as any).search = async (
+                request: any,
+                options: any
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const idQueries = queries.find((query: any) =>
+                    Array.isArray(query?.or)
+                )?.or;
+                const indices = Array.isArray(idQueries)
+                    ? idQueries
+                          .map((query: any) => getQueryValue(query))
+                          .filter(
+                              (id: unknown): id is string =>
+                                  typeof id === "string"
+                          )
+                          .map((id: string) =>
+                              Number(id.slice(fileId.length + 1))
+                          )
+                    : [];
+                if (
+                    options.remote === false &&
+                    indices.some((index: number) => index >= 2)
+                ) {
+                    pendingBatchSignal = options.signal;
+                    markPendingBatchStarted();
+                    return new Promise((_, reject) => {
+                        const abort = () => {
+                            pendingBatchAborted = true;
+                            reject(
+                                pendingBatchSignal?.reason ??
+                                    new Error("batch search aborted")
+                            );
+                        };
+                        if (pendingBatchSignal?.aborted) {
+                            abort();
+                        } else {
+                            pendingBatchSignal?.addEventListener(
+                                "abort",
+                                abort,
+                                { once: true }
+                            );
+                        }
+                    });
+                }
+                return originalSearch(request as never, options as never);
+            };
+
+            const stream = file.streamFile(filestore)[Symbol.asyncIterator]();
+            try {
+                const first = await stream.next();
+                expect(first.done).to.be.false;
+                const second = await stream.next();
+                expect(second.done).to.be.false;
+                expect(
+                    (filestore as any).activeFileChangeSignals.size
+                ).to.be.greaterThan(0);
+                await Promise.race([
+                    pendingBatchStarted,
+                    delay(1_000).then(() => {
+                        throw new Error("read-ahead batch did not start");
+                    }),
+                ]);
+
+                const returnStartedAt = Date.now();
+                await stream.return?.();
+                expect(Date.now() - returnStartedAt).to.be.lessThan(500);
+                expect(pendingBatchSignal).to.be.instanceOf(AbortSignal);
+                expect(pendingBatchSignal?.aborted).to.be.true;
+                expect(pendingBatchAborted).to.be.true;
+                expect((filestore as any).activeFileChangeSignals.size).to.eq(
+                    0
+                );
+
+                const callsAfterReturn = delayedChunkGets;
+                await delay(350);
+                expect(delayedChunkGets).to.eq(callsAfterReturn);
+                expect(file.chunkCount).to.be.greaterThan(33);
+                expect(highestRequestedChunkIndex).to.be.lessThanOrEqual(32);
+                expect((filestore as any).activeFileChangeSignals.size).to.eq(
+                    0
+                );
+            } finally {
+                await stream.return?.();
+                (filestore.files.index as any).get = originalGet;
+                (filestore.files.index as any).search = originalSearch;
+            }
+        });
+
+        it("cancels a bulk chunk fetch when the Files program closes", async () => {
+            const filestore = await peer.open(new Files());
+            const file = new LargeFile({
+                id: "closing-bulk-fetch",
+                name: "closing-bulk-fetch.bin",
+                size: 1n,
+                chunkCount: 1,
+                ready: true,
+            });
+            let markStarted!: () => void;
+            const started = new Promise<void>((resolve) => {
+                markStarted = resolve;
+            });
+            let releaseLookup!: () => void;
+            const lookupGate = new Promise<void>((resolve) => {
+                releaseLookup = resolve;
+            });
+            (filestore as any).getReadPeerHints = async () => {
+                markStarted();
+                await lookupGate;
+                return undefined;
+            };
+
+            const result = file
+                .fetchChunks(filestore, { timeout: 10_000 })
+                .then(
+                    () => undefined,
+                    (error) => error as Error
+                );
+            await started;
+            await filestore.close();
+            releaseLookup();
+
+            expect((await result)?.message).to.eq("File read cancelled");
+            expect((filestore as any).activeFileChangeSignals.size).to.eq(0);
+        });
+
+        it("cancels a pending-manifest wait when the Files program drops", async () => {
+            const filestore = await peer.open(new Files());
+            const file = new LargeFile({
+                id: "dropping-ready-wait",
+                name: "dropping-ready-wait.bin",
+                size: 1n,
+                chunkCount: 1,
+                ready: false,
+            });
+            let markStarted!: () => void;
+            const started = new Promise<void>((resolve) => {
+                markStarted = resolve;
+            });
+            let releaseLookup!: () => void;
+            const lookupGate = new Promise<void>((resolve) => {
+                releaseLookup = resolve;
+            });
+            (filestore as any).getReadPeerHints = async () => {
+                markStarted();
+                await lookupGate;
+                return undefined;
+            };
+
+            const stream = file.streamFile(filestore)[Symbol.asyncIterator]();
+            const result = stream.next().then(
+                () => undefined,
+                (error) => error as Error
+            );
+            await started;
+            await filestore.drop();
+            releaseLookup();
+
+            expect((await result)?.message).to.eq("File read cancelled");
+            expect((filestore as any).activeFileChangeSignals.size).to.eq(0);
         });
 
         it("records diagnostics for chunked uploads", async () => {
@@ -423,6 +1680,12 @@ describe("index", () => {
                 filestore.lastUploadDiagnostics?.chunkCount
             );
             expect(
+                filestore.lastUploadDiagnostics?.maxConcurrentChunkPuts
+            ).to.be.within(1, 4);
+            expect(
+                filestore.lastUploadDiagnostics?.maxConcurrentChunkPutBytes
+            ).to.be.lessThanOrEqual(2 * 1024 * 1024);
+            expect(
                 filestore.lastUploadDiagnostics?.manifestFinishedAt
             ).to.not.eq(null);
             expect(
@@ -432,7 +1695,317 @@ describe("index", () => {
             expect(filestore.lastUploadDiagnostics?.failureMessage).to.eq(null);
         });
 
-        it("pipelines persisted chunk reads without using parentId searches", async () => {
+        it("copies reusable source buffers for tiny files", async () => {
+            const filestore = await peer.open(new Files());
+            const expected = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+            const fileId = await filestore.addSource("reused tiny source", {
+                size: BigInt(expected.byteLength),
+                readChunks: async function* () {
+                    const reusable = new Uint8Array(4);
+                    reusable.set(expected.subarray(0, 4));
+                    yield reusable;
+                    reusable.set(expected.subarray(4));
+                    yield reusable;
+                },
+            });
+
+            const file = await filestore.files.index.get(fileId, {
+                local: true,
+                remote: false,
+            });
+            expect(file).to.be.instanceOf(TinyFile);
+            expect(
+                equals(
+                    await file!.getFile(filestore, { as: "joined" }),
+                    expected
+                )
+            ).to.be.true;
+        });
+
+        it("cleans a pending manifest when source iterator construction fails", async () => {
+            const filestore = await peer.open(new Files());
+
+            await expect(
+                filestore.addSource("throwing source", {
+                    size: 6n * 1024n * 1024n,
+                    readChunks: () => {
+                        throw new Error("iterator construction failed");
+                    },
+                })
+            ).rejects.toThrow("iterator construction failed");
+
+            const diagnostics = filestore.lastUploadDiagnostics!;
+            expect(diagnostics.failureMessage).to.eq(
+                "iterator construction failed"
+            );
+            expect(
+                await filestore.files.index.get(diagnostics.uploadId, {
+                    local: true,
+                    remote: false,
+                })
+            ).to.be.undefined;
+        });
+
+        it("preserves a failed upload when its pending-root deletion does not commit", async () => {
+            const filestore = await peer.open(new Files());
+            const originalDelete = filestore.files.del.bind(filestore.files);
+            let deleteCalls = 0;
+            (filestore.files as any).del = async () => {
+                deleteCalls += 1;
+                throw new Error("pending root delete failed");
+            };
+
+            try {
+                await expect(
+                    filestore.addSource("preserved throwing source", {
+                        size: 6n * 1024n * 1024n,
+                        readChunks: () => {
+                            throw new Error("iterator construction failed");
+                        },
+                    })
+                ).rejects.toThrow("iterator construction failed");
+            } finally {
+                (filestore.files as any).del = originalDelete;
+            }
+
+            const diagnostics = filestore.lastUploadDiagnostics!;
+            expect(deleteCalls).to.eq(1);
+            expect(
+                await filestore.files.index.get(diagnostics.uploadId, {
+                    local: true,
+                    remote: false,
+                })
+            ).to.not.be.undefined;
+            expect(
+                (filestore as any).retainedLargeFileChunkCounts.get(
+                    diagnostics.uploadId
+                )
+            ).to.eq(diagnostics.chunkCount);
+            expect(
+                (filestore as any).retainedEntryHeadsByFileId.has(
+                    diagnostics.uploadId
+                )
+            ).to.be.true;
+
+            await originalDelete(diagnostics.uploadId);
+            filestore.releaseFileRetention(diagnostics.uploadId);
+        });
+
+        it("bounds concurrent chunk puts while preserving manifest order and integrity", async () => {
+            const filestore = await peer.open(new Files());
+            const bytes = crypto.randomBytes(8 * 1e6) as Uint8Array;
+            const originalPut = filestore.files.put.bind(filestore.files);
+            let activePuts = 0;
+            let activeBytes = 0;
+            let maxActivePuts = 0;
+            let maxActiveBytes = 0;
+            let readyManifestAfterDrain = false;
+            const completedIndices = new Set<number>();
+            const readIndices: number[] = [];
+            const progress: number[] = [];
+
+            (filestore.files as any).put = async (
+                value: any,
+                ...args: any[]
+            ) => {
+                if (value instanceof TinyFile && value.parentId != null) {
+                    activePuts += 1;
+                    activeBytes += value.file.byteLength;
+                    maxActivePuts = Math.max(maxActivePuts, activePuts);
+                    maxActiveBytes = Math.max(maxActiveBytes, activeBytes);
+                    try {
+                        await delay(10 + ((3 - (value.index! % 4)) % 4) * 10);
+                        const result = await (originalPut as any)(
+                            value,
+                            ...args
+                        );
+                        completedIndices.add(value.index!);
+                        return result;
+                    } finally {
+                        activePuts -= 1;
+                        activeBytes -= value.file.byteLength;
+                    }
+                }
+                if (isLargeFileLike(value) && value.ready) {
+                    readyManifestAfterDrain =
+                        activePuts === 0 && completedIndices.size > 0;
+                }
+                return (originalPut as any)(value, ...args);
+            };
+
+            let fileId: string;
+            try {
+                fileId = await filestore.addSource(
+                    "concurrent source upload",
+                    {
+                        size: BigInt(bytes.byteLength),
+                        readChunks: async function* (chunkSize: number) {
+                            const reusable = new Uint8Array(chunkSize);
+                            let index = 0;
+                            for (
+                                let offset = 0;
+                                offset < bytes.byteLength;
+                                offset += chunkSize
+                            ) {
+                                readIndices.push(index++);
+                                const end = Math.min(
+                                    offset + chunkSize,
+                                    bytes.byteLength
+                                );
+                                reusable.set(bytes.subarray(offset, end), 0);
+                                yield reusable.subarray(0, end - offset);
+                            }
+                        },
+                    },
+                    undefined,
+                    (value) => progress.push(value)
+                );
+            } finally {
+                (filestore.files as any).put = originalPut;
+            }
+
+            const diagnostics = filestore.lastUploadDiagnostics!;
+            expect(maxActivePuts).to.eq(4);
+            expect(maxActivePuts).to.be.lessThanOrEqual(
+                diagnostics.chunkPutConcurrencyLimit
+            );
+            expect(maxActiveBytes).to.be.lessThanOrEqual(
+                diagnostics.chunkPutByteLimit
+            );
+            expect(diagnostics.maxConcurrentChunkPuts).to.eq(maxActivePuts);
+            expect(diagnostics.maxConcurrentChunkPutBytes).to.eq(
+                maxActiveBytes
+            );
+            expect(readyManifestAfterDrain).to.be.true;
+            expect(readIndices).to.deep.eq([
+                ...Array(diagnostics.chunkCount).keys(),
+            ]);
+            expect(
+                progress.every(
+                    (value, index) =>
+                        index === 0 || value >= progress[index - 1]
+                )
+            ).to.be.true;
+            expect(progress.at(-1)).to.eq(1);
+
+            const readyFile = await filestore.files.index.get(fileId!, {
+                local: true,
+                remote: false,
+            });
+            expect(isLargeFileLike(readyFile)).to.be.true;
+            const heads = (readyFile as LargeFileWithChunkHeads)
+                .chunkEntryHeads;
+            expect(heads).to.have.length(diagnostics.chunkCount);
+            for (let index = 0; index < diagnostics.chunkCount; index++) {
+                const chunk = await filestore.files.index.get(
+                    `${fileId!}:${index}`,
+                    { local: true, remote: false }
+                );
+                expect((chunk as any).__context.head).to.eq(heads[index]);
+            }
+            const roundTrip = await readyFile!.getFile(filestore, {
+                as: "joined",
+            });
+            expect(equals(roundTrip, bytes)).to.be.true;
+        });
+
+        it("settles concurrent workers and cleans up after a chunk put fails", async () => {
+            const filestore = await peer.open(new Files());
+            const bytes = crypto.randomBytes(8 * 1e6) as Uint8Array;
+            const originalPut = filestore.files.put.bind(filestore.files);
+            const originalDelete = filestore.files.del.bind(filestore.files);
+            let activePuts = 0;
+            let maxActivePuts = 0;
+            let readyManifestWritten = false;
+            const deletedIds: string[] = [];
+
+            (filestore.files as any).put = async (
+                value: any,
+                ...args: any[]
+            ) => {
+                if (value instanceof TinyFile && value.parentId != null) {
+                    activePuts += 1;
+                    maxActivePuts = Math.max(maxActivePuts, activePuts);
+                    try {
+                        await delay(value.index === 2 ? 10 : 40);
+                        if (value.index === 2) {
+                            throw new Error("injected chunk put failure");
+                        }
+                        return (originalPut as any)(value, ...args);
+                    } finally {
+                        activePuts -= 1;
+                    }
+                }
+                if (isLargeFileLike(value) && value.ready) {
+                    readyManifestWritten = true;
+                }
+                return (originalPut as any)(value, ...args);
+            };
+            (filestore.files as any).del = async (id: string) => {
+                deletedIds.push(id);
+                return originalDelete(id);
+            };
+
+            try {
+                await expect(
+                    filestore.addSource("failing concurrent upload", {
+                        size: BigInt(bytes.byteLength),
+                        readChunks: async function* (chunkSize: number) {
+                            for (
+                                let offset = 0;
+                                offset < bytes.byteLength;
+                                offset += chunkSize
+                            ) {
+                                yield bytes.subarray(
+                                    offset,
+                                    Math.min(
+                                        offset + chunkSize,
+                                        bytes.byteLength
+                                    )
+                                );
+                            }
+                        },
+                    })
+                ).rejects.toThrow("injected chunk put failure");
+            } finally {
+                (filestore.files as any).put = originalPut;
+                (filestore.files as any).del = originalDelete;
+            }
+
+            const diagnostics = filestore.lastUploadDiagnostics!;
+            expect(maxActivePuts).to.be.greaterThan(1);
+            expect(maxActivePuts).to.be.lessThanOrEqual(4);
+            expect(activePuts).to.eq(0);
+            expect(readyManifestWritten).to.be.false;
+            expect(diagnostics.readyManifestStartedAt).to.eq(null);
+            expect(diagnostics.failureMessage).to.eq(
+                "injected chunk put failure"
+            );
+            expect(deletedIds[0]).to.eq(diagnostics.uploadId);
+            expect(
+                deletedIds
+                    .slice(1)
+                    .every((id) => id.startsWith(`${diagnostics.uploadId}:`))
+            ).to.be.true;
+            expect(
+                await filestore.countLocalChunks({
+                    id: diagnostics.uploadId,
+                } as any)
+            ).to.eq(0);
+            expect(
+                await filestore.files.index.get(diagnostics.uploadId, {
+                    local: true,
+                    remote: false,
+                })
+            ).to.be.undefined;
+            expect(
+                [...((filestore as any).retainedChunkIds as Set<string>)].some(
+                    (id) => id.startsWith(`${diagnostics.uploadId}:`)
+                )
+            ).to.be.false;
+        });
+
+        it("pipelines persisted remote reads with bounded per-index lookups", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
             const fileId = await filestore.add(
@@ -464,6 +2037,7 @@ describe("index", () => {
             let sawChunkWaitFor = false;
             let indexedChunkGets = 0;
             let resolvedRemoteChunkGets = 0;
+            const batchReplicateValues: boolean[] = [];
             const resolvedChunks = new Set<string>();
             const retainedChunkId = `${fileId}:1`;
             const retainedWriterChunk = await filestore.files.index.get(
@@ -485,6 +2059,13 @@ describe("index", () => {
                 const queries = Array.isArray(request.query)
                     ? request.query
                     : [request.query];
+                if (queries.some((query: any) => Array.isArray(query?.or))) {
+                    const remote = (options as any)?.remote;
+                    if (remote === false) {
+                        return [];
+                    }
+                    batchReplicateValues.push(remote.replicate);
+                }
                 const isBulkChunkLookup = queries.some(
                     (query: any) =>
                         getQueryKey(query) === "parentId" &&
@@ -575,25 +2156,52 @@ describe("index", () => {
             }
 
             expect(parentIdSearches).to.eq(0);
-            expect(directChunkGets).to.be.greaterThan(1);
-            expect(maxInflightChunkGets).to.be.greaterThan(1);
-            const readAhead = filestoreReader.lastReadDiagnostics?.readAhead;
-            expect(readAhead).to.eq(2);
+            expect(directChunkGets).to.be.greaterThan(0);
+            expect(maxInflightChunkGets).to.be.greaterThan(0);
+            const readDiagnostics = filestoreReader.lastReadDiagnostics!;
+            const readAhead = readDiagnostics.readAhead;
+            expect(readDiagnostics.readAheadInitial).to.eq(2);
+            expect(readAhead).to.be.lessThanOrEqual(
+                readDiagnostics.readAheadLimit
+            );
+            expect(readDiagnostics.readAheadPeak).to.be.lessThanOrEqual(
+                readDiagnostics.readAheadLimit
+            );
+            expect(readDiagnostics.readAheadLimit).to.be.lessThanOrEqual(8);
             expect(readAhead).to.be.lessThanOrEqual(file!.chunkCount);
-            expect(filestoreReader.lastReadDiagnostics?.readAheadSource).to.eq(
-                "persisted-remote"
+            expect(readDiagnostics.readAheadSource).to.eq(
+                "persisted-remote-adaptive"
             );
             expect(
                 filestoreReader.lastReadDiagnostics?.initialLocalChunkCount
             ).to.be.lessThan(file!.chunkCount);
+            expect(readDiagnostics.chunkBatchQueryCount).to.eq(0);
+            expect(readDiagnostics.chunkBatchResultCount).to.eq(0);
             expect(
-                filestoreReader.lastReadDiagnostics?.chunkAttemptTimeoutMs
-            ).to.eq(5_000);
+                readDiagnostics.chunkPersistedRemoteBatchSkipCount
+            ).to.be.greaterThan(0);
+            expect(
+                readDiagnostics.chunkPersistedRemoteBatchSkippedIndexCount
+            ).to.eq(file!.chunkCount);
+            expect(readDiagnostics.maxRemoteChunkBatchSize).to.eq(0);
+            expect(readDiagnostics.maxConcurrentRemoteChunkBatches).to.eq(0);
+            expect(maxInflightChunkGets).to.be.lessThanOrEqual(
+                readDiagnostics.readAheadLimit
+            );
+            expect(readDiagnostics.chunkBatchResolverFallbackCount).to.eq(0);
+            expect(batchReplicateValues).to.have.length(0);
+            expect(readDiagnostics.peakKnownChunkCount).to.be.lessThanOrEqual(
+                readDiagnostics.readAheadPeak * 2
+            );
+            expect(readDiagnostics.finalKnownChunkCount).to.eq(0);
             expect(sawChunkWaitFor).to.be.false;
             expect(indexedChunkGets).to.eq(0);
-            expect(resolvedRemoteChunkGets).to.be.greaterThan(1);
-            expect(retainedBeforeIndexedReplication).to.be.true;
-            expect(maxInflightChunkGets).to.be.lessThanOrEqual(readAhead);
+            expect(resolvedRemoteChunkGets).to.be.greaterThan(0);
+            expect(
+                await (filestoreReader.files.log as any).keep(
+                    retainedWriterEntry
+                )
+            ).to.be.true;
             expect(
                 Object.keys(
                     filestoreReader.lastReadDiagnostics
@@ -608,6 +2216,643 @@ describe("index", () => {
             ).to.eq(streamedChunks.length);
             expect(streamedChunks.length).to.be.greaterThan(1);
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
+        });
+
+        it("retries partial hinted chunk batches once without a peer hint", async () => {
+            const writer = await peer.open(new Files());
+            const bytes = crypto.randomBytes(8 * 1e6) as Uint8Array;
+            const fileId = await writer.add("partial hinted batch", bytes);
+            const reader = await peer2.open<Files>(writer.address, {
+                args: { replicate: false },
+            });
+            await reader.files.log.waitForReplicator(peer.identity.publicKey);
+            const file = await reader.files.index.get(fileId);
+            expect(isLargeFileLike(file)).to.be.true;
+
+            const writerChunks = new Map<string, TinyFile>();
+            for (let index = 0; index < file!.chunkCount; index++) {
+                const chunk = await writer.files.index.get(
+                    `${fileId}:${index}`,
+                    {
+                        local: true,
+                        remote: false,
+                    }
+                );
+                writerChunks.set(chunk!.id, chunk as TinyFile);
+            }
+            const originalSearch = reader.files.index.search.bind(
+                reader.files.index
+            );
+            const originalHints = reader.getReadPeerHints.bind(reader);
+            let hintedBatches = 0;
+            let unhintedFallbacks = 0;
+            const replicateValues: boolean[] = [];
+            (reader as any).getReadPeerHints = async () => ["hinted-writer"];
+            (reader.files.index as any).search = async (
+                request: any,
+                options: any
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const idQueries = queries.find((query: any) =>
+                    Array.isArray(query?.or)
+                )?.or;
+                if (
+                    Array.isArray(idQueries) &&
+                    idQueries.every((query: any) => getQueryKey(query) === "id")
+                ) {
+                    const ids = idQueries.map((query: any) =>
+                        getQueryValue(query)
+                    );
+                    if (options.remote === false) {
+                        return [];
+                    }
+                    replicateValues.push(options.remote.replicate);
+                    if (options.remote.from) {
+                        hintedBatches += 1;
+                        await delay(30);
+                        return [writerChunks.get(ids[0])];
+                    }
+                    unhintedFallbacks += 1;
+                    return ids.map((id: string) => writerChunks.get(id));
+                }
+                return originalSearch(request as never, options as never);
+            };
+
+            let roundTrip: Uint8Array;
+            try {
+                roundTrip = await file!.getFile(reader, { as: "joined" });
+            } finally {
+                (reader.files.index as any).search = originalSearch;
+                (reader as any).getReadPeerHints = originalHints;
+            }
+
+            expect(equals(roundTrip!, bytes)).to.be.true;
+            expect(hintedBatches).to.be.greaterThan(0);
+            expect(unhintedFallbacks).to.eq(hintedBatches);
+            expect(replicateValues.every((value) => value === false)).to.be
+                .true;
+            expect(reader.lastReadDiagnostics?.chunkBatchFallbackCount).to.eq(
+                hintedBatches
+            );
+            expect(
+                reader.lastReadDiagnostics?.chunkBatchResolverFallbackCount
+            ).to.eq(0);
+            expect(reader.lastReadDiagnostics?.readAheadSource).to.eq(
+                "observer-adaptive"
+            );
+            expect(reader.lastReadDiagnostics?.readAheadPeak).to.be.greaterThan(
+                2
+            );
+            expect(
+                reader.lastReadDiagnostics?.peakKnownChunkCount
+            ).to.be.lessThanOrEqual(
+                reader.lastReadDiagnostics!.readAheadPeak * 2
+            );
+            expect(reader.lastReadDiagnostics?.finalKnownChunkCount).to.eq(0);
+            expect((reader as any).retainedChunkIds?.size ?? 0).to.eq(0);
+            expect((reader as any).retainedChunkEntryHeads?.size ?? 0).to.eq(0);
+            expect((reader as any).retainedEntryHeadsByFileId?.size ?? 0).to.eq(
+                0
+            );
+        });
+
+        it("falls back to indexed fields for legacy non-deterministic chunk ids", async () => {
+            const writer = await peer.open(new Files());
+            const fileId = "legacy-chunk-root";
+            const fileName = "legacy-chunk-root.bin";
+            const chunks = [new Uint8Array([1, 2]), new Uint8Array([3, 4])];
+            for (const [index, bytes] of chunks.entries()) {
+                await writer.files.put(
+                    new TinyFile({
+                        id: `legacy-chunk-${index}`,
+                        name: `${fileName}/${index}`,
+                        file: bytes,
+                        parentId: fileId,
+                        index,
+                    })
+                );
+            }
+            await writer.files.put(
+                new LargeFile({
+                    id: fileId,
+                    name: fileName,
+                    size: 4n,
+                    chunkCount: chunks.length,
+                    ready: true,
+                    finalHash: sha256Base64Sync(concat(chunks)),
+                })
+            );
+
+            const reader = await peer2.open<Files>(writer.address, {
+                args: { replicate: false },
+            });
+            await reader.files.log.waitForReplicator(peer.identity.publicKey);
+            const file = await reader.resolveById(fileId, {
+                timeout: 10_000,
+                replicate: false,
+            });
+            expect(isLargeFileLike(file)).to.be.true;
+            const roundTrip = await file!.getFile(reader, { as: "joined" });
+
+            expect(equals(roundTrip, concat(chunks))).to.be.true;
+            expect(
+                reader.lastReadDiagnostics?.chunkBatchResolverFallbackCount
+            ).to.eq(chunks.length);
+            expect(reader.lastReadDiagnostics?.chunkResolved?.[0]).to.eq(
+                "indexed-search"
+            );
+            expect(reader.lastReadDiagnostics?.chunkResolved?.[1]).to.eq(
+                "indexed-search"
+            );
+        });
+
+        it("retries stale hints for persisted legacy chunks and rereads them offline", async () => {
+            const writer = await peer.open(new Files());
+            const fileId = "persisted-legacy-chunk-root";
+            const fileName = "persisted-legacy-chunk-root.bin";
+            const chunks = [
+                new Uint8Array([1, 2, 3]),
+                new Uint8Array([4, 5, 6]),
+            ];
+            for (const [index, bytes] of chunks.entries()) {
+                await writer.files.put(
+                    new TinyFile({
+                        id: `persisted-legacy-chunk-${index}`,
+                        name: `${fileName}/${index}`,
+                        file: bytes,
+                        parentId: fileId,
+                        index,
+                    })
+                );
+            }
+            await writer.files.put(
+                new LargeFile({
+                    id: fileId,
+                    name: fileName,
+                    size: 6n,
+                    chunkCount: chunks.length,
+                    ready: true,
+                    finalHash: sha256Base64Sync(concat(chunks)),
+                })
+            );
+
+            const reader = await peer2.open<Files>(writer.address, {
+                args: { replicate: false },
+            });
+            // Exercise persisted reads without background full-log replication.
+            reader.persistChunkReads = true;
+            await reader.files.log.waitForReplicator(peer.identity.publicKey);
+            const file = await reader.resolveById(fileId, {
+                timeout: 10_000,
+                replicate: true,
+            });
+            expect(isLargeFileLike(file)).to.be.true;
+
+            const originalSearch = reader.files.index.search.bind(
+                reader.files.index
+            );
+            const originalHints = reader.getReadPeerHints.bind(reader);
+            let hintedFieldSearches = 0;
+            let unhintedPersistedFieldSearches = 0;
+            (reader as any).getReadPeerHints = async () => ["stale-peer"];
+            (reader.files.index as any).search = async (
+                request: any,
+                options: any
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const isChunkFieldSearch =
+                    queries.some(
+                        (query: any) => getQueryKey(query) === "parentId"
+                    ) &&
+                    queries.some((query: any) => getQueryKey(query) === "name");
+                if (options.remote?.from) {
+                    if (isChunkFieldSearch) {
+                        hintedFieldSearches += 1;
+                    }
+                    return [];
+                }
+                if (isChunkFieldSearch && options.remote?.replicate === true) {
+                    unhintedPersistedFieldSearches += 1;
+                }
+                return originalSearch(request as never, options as never);
+            };
+
+            let firstRead: Uint8Array;
+            try {
+                firstRead = await file!.getFile(reader, { as: "joined" });
+            } finally {
+                (reader.files.index as any).search = originalSearch;
+                (reader as any).getReadPeerHints = originalHints;
+            }
+
+            expect(equals(firstRead!, concat(chunks))).to.be.true;
+            expect(hintedFieldSearches).to.be.greaterThan(0);
+            expect(unhintedPersistedFieldSearches).to.eq(chunks.length);
+            expect(reader.lastReadDiagnostics?.chunkResolved?.[0]).to.eq(
+                "unhinted-persisted-indexed-search"
+            );
+            expect(reader.lastReadDiagnostics?.chunkResolved?.[1]).to.eq(
+                "unhinted-persisted-indexed-search"
+            );
+
+            await writer.close();
+            (reader as any).getReadPeerHints = async () => undefined;
+            let offlineRead: Uint8Array;
+            const offlineReadStartedAt = Date.now();
+            try {
+                offlineRead = await file!.getFile(reader, {
+                    as: "joined",
+                    timeout: 5_000,
+                });
+            } finally {
+                (reader as any).getReadPeerHints = originalHints;
+            }
+            expect(Date.now() - offlineReadStartedAt).to.be.lessThan(2_000);
+            expect(equals(offlineRead, concat(chunks))).to.be.true;
+            expect(
+                reader.lastReadDiagnostics?.chunkLocalIndexedBatchResultCount
+            ).to.eq(chunks.length);
+            expect(reader.lastReadDiagnostics?.readAheadSource).to.eq(
+                "persisted-local"
+            );
+        });
+
+        it("persists batched manifest-head reads for an offline local reread", async () => {
+            const writer = await peer.open(new Files());
+            const fileId = "persisted-manifest-head-batch";
+            const fileName = "persisted-manifest-head-batch.bin";
+            const chunks = [
+                new Uint8Array([1, 2]),
+                new Uint8Array([3, 4]),
+                new Uint8Array([5, 6]),
+            ];
+            const chunkEntryHeads: string[] = [];
+            for (const [index, bytes] of chunks.entries()) {
+                const result = await writer.files.put(
+                    new TinyFile({
+                        id: `${fileId}:${index}`,
+                        name: `${fileName}/${index}`,
+                        file: bytes,
+                        parentId: fileId,
+                        index,
+                    })
+                );
+                chunkEntryHeads[index] = result.entry.hash;
+            }
+            const expected = concat(chunks);
+            const manifest = new LargeFileWithChunkHeads({
+                id: fileId,
+                name: fileName,
+                size: BigInt(expected.byteLength),
+                chunkCount: chunks.length,
+                ready: true,
+                finalHash: sha256Base64Sync(expected),
+                chunkEntryHeads,
+            });
+            const reader = await peer2.open<Files>(writer.address, {
+                args: { replicate: false },
+            });
+            reader.persistChunkReads = true;
+            await reader.files.log.waitForReplicator(peer.identity.publicKey);
+
+            const originalGetMany = reader.files.log.log.getMany.bind(
+                reader.files.log.log
+            );
+            const originalIndexGet = reader.files.index.get.bind(
+                reader.files.index
+            );
+            const originalHints = reader.getReadPeerHints.bind(reader);
+            const batchCalls: Array<{ heads: string[]; options: any }> = [];
+            let perIndexChunkGets = 0;
+            (reader.files.log.log as any).getMany = async (
+                heads: string[],
+                options: any
+            ) => {
+                batchCalls.push({ heads: [...heads], options });
+                return originalGetMany(heads, options);
+            };
+            (reader.files.index as any).get = async (
+                id: unknown,
+                options: unknown
+            ) => {
+                if (typeof id === "string" && id.startsWith(`${fileId}:`)) {
+                    perIndexChunkGets += 1;
+                }
+                return originalIndexGet(id as never, options as never);
+            };
+
+            try {
+                expect(await reader.countLocalChunks(manifest)).to.eq(0);
+                expect(await reader.countLocalChunkBlocks(manifest)).to.eq(0);
+                const firstRead = await manifest.getFile(reader, {
+                    as: "joined",
+                    timeout: 10_000,
+                });
+                expect(equals(firstRead, expected)).to.be.true;
+                expect(
+                    reader.lastReadDiagnostics?.initialLocalChunkBlockCount
+                ).to.eq(0);
+                // Demand persistence stores exact entry blocks without joining
+                // the observer into Documents/index replication.
+                expect(await reader.countLocalChunks(manifest)).to.eq(0);
+                expect(await reader.countLocalChunkBlocks(manifest)).to.eq(
+                    chunks.length
+                );
+                expect(perIndexChunkGets).to.eq(0);
+                expect(
+                    batchCalls.filter((call) => call.options.remote === false)
+                        .length
+                ).to.be.greaterThan(0);
+                const remoteCalls = batchCalls.filter(
+                    (call) =>
+                        call.options.remote && call.options.remote !== false
+                );
+                expect(remoteCalls.length).to.be.greaterThan(0);
+                expect(
+                    remoteCalls.every(
+                        (call) =>
+                            call.heads.length <= 8 &&
+                            call.options.remote.replicate === true &&
+                            call.options.remote.timeout === 1_500 &&
+                            call.options.remote.signal instanceof AbortSignal
+                    )
+                ).to.be.true;
+                expect(
+                    chunkEntryHeads.every((head) =>
+                        (reader as any).retainedChunkEntryHeads.has(head)
+                    )
+                ).to.be.true;
+                expect(
+                    chunks.every((_, index) =>
+                        (reader as any).retainedChunkIds.has(
+                            `${fileId}:${index}`
+                        )
+                    )
+                ).to.be.true;
+
+                await writer.close();
+                (reader.files.log.log.entryIndex as any).cache.clear();
+                (reader as any).getReadPeerHints = async () => undefined;
+                batchCalls.length = 0;
+                const offlineRead = await manifest.getFile(reader, {
+                    as: "joined",
+                    timeout: 2_000,
+                });
+
+                expect(equals(offlineRead, expected)).to.be.true;
+                expect(perIndexChunkGets).to.eq(0);
+                expect(batchCalls.length).to.be.greaterThan(0);
+                expect(
+                    batchCalls.every((call) => call.options.remote === false)
+                ).to.be.true;
+                expect(
+                    reader.lastReadDiagnostics
+                        ?.chunkManifestHeadRemoteBatchQueryCount
+                ).to.eq(0);
+                expect(
+                    reader.lastReadDiagnostics
+                        ?.chunkManifestHeadLocalBatchAcceptedCount
+                ).to.eq(chunks.length);
+                expect(
+                    reader.lastReadDiagnostics
+                        ?.chunkManifestHeadRemoteBatchAcceptedCount
+                ).to.eq(0);
+                expect(
+                    reader.lastReadDiagnostics?.chunkBatchResolverFallbackCount
+                ).to.eq(0);
+                expect(reader.lastReadDiagnostics?.finalKnownChunkCount).to.eq(
+                    0
+                );
+                expect(await reader.countLocalChunks(manifest)).to.eq(0);
+                expect(await reader.countLocalChunkBlocks(manifest)).to.eq(
+                    chunks.length
+                );
+            } finally {
+                (reader.files.log.log as any).getMany = originalGetMany;
+                (reader.files.index as any).get = originalIndexGet;
+                (reader as any).getReadPeerHints = originalHints;
+            }
+        });
+
+        it("batch reads a fully local persisted file without peer hints", async () => {
+            const files = await peer.open(new Files());
+            const bytes = crypto.randomBytes(8 * 1e6) as Uint8Array;
+            const fileId = await files.add("offline persisted batch", bytes);
+            const file = await files.files.index.get(fileId);
+            const originalSearch = files.files.index.search.bind(
+                files.files.index
+            );
+            const originalHints = files.getReadPeerHints.bind(files);
+            const replicateValues: boolean[] = [];
+            (files as any).getReadPeerHints = async () => undefined;
+            (files.files.index as any).search = async (
+                request: any,
+                options: any
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                if (
+                    options.remote !== false &&
+                    queries.some((query: any) => Array.isArray(query?.or))
+                ) {
+                    replicateValues.push(options.remote.replicate);
+                }
+                return originalSearch(request as never, options as never);
+            };
+
+            let roundTrip: Uint8Array;
+            try {
+                roundTrip = await file!.getFile(files, { as: "joined" });
+            } finally {
+                (files.files.index as any).search = originalSearch;
+                (files as any).getReadPeerHints = originalHints;
+            }
+
+            expect(equals(roundTrip!, bytes)).to.be.true;
+            expect(replicateValues).to.have.length(0);
+            expect(files.lastReadDiagnostics?.chunkBatchResultCount).to.eq(
+                file!.chunkCount
+            );
+            expect(files.lastReadDiagnostics?.readAheadSource).to.eq(
+                "persisted-local"
+            );
+            expect(
+                files.lastReadDiagnostics?.chunkBatchResolverFallbackCount
+            ).to.eq(0);
+            expect(files.lastReadDiagnostics?.finalKnownChunkCount).to.eq(0);
+        });
+
+        it("reclassifies stale local counts before bounded per-index reads", async () => {
+            const writer = await peer.open(new Files());
+            const bytes = crypto.randomBytes(20 * 1e6) as Uint8Array;
+            const fileId = await writer.add("stale local chunk count", bytes);
+            const reader = await peer2.open<Files>(writer.address);
+            await reader.files.log.waitForReplicator(peer.identity.publicKey);
+            const file = await reader.files.index.get(fileId);
+            expect(isLargeFileLike(file)).to.be.true;
+            expect(file!.chunkCount).to.be.greaterThan(34);
+            stripChunkEntryHeads(file);
+
+            const writerChunks = new Map<string, TinyFile>();
+            await Promise.all(
+                Array.from({ length: file!.chunkCount }, async (_, index) => {
+                    const chunk = await writer.files.index.get(
+                        `${fileId}:${index}`,
+                        { local: true, remote: false }
+                    );
+                    writerChunks.set(chunk!.id, chunk as TinyFile);
+                })
+            );
+            const originalSearch = reader.files.index.search.bind(
+                reader.files.index
+            );
+            const originalGet = reader.files.index.get.bind(reader.files.index);
+            const originalCountLocalChunks =
+                reader.countLocalChunks.bind(reader);
+            let localBatchCalls = 0;
+            const remoteBatchSizes: number[] = [];
+            let activeRemoteBatches = 0;
+            let maxActiveRemoteBatches = 0;
+            let perIndexRemoteGets = 0;
+            let activePerIndexRemoteGets = 0;
+            let maxActivePerIndexRemoteGets = 0;
+            (reader as any).countLocalChunks = async (parent: LargeFile) =>
+                parent.id === fileId
+                    ? parent.chunkCount
+                    : originalCountLocalChunks(parent);
+            (reader.files.index as any).search = async (
+                request: any,
+                options: any
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                const idQueries = queries.find((query: any) =>
+                    Array.isArray(query?.or)
+                )?.or;
+                if (
+                    Array.isArray(idQueries) &&
+                    idQueries.every((query: any) => getQueryKey(query) === "id")
+                ) {
+                    const ids = idQueries.map((query: any) =>
+                        getQueryValue(query)
+                    );
+                    if (options.remote === false) {
+                        localBatchCalls += 1;
+                        if (localBatchCalls === 1) {
+                            return ids.map((id: string) =>
+                                writerChunks.get(id)
+                            );
+                        }
+                        if (localBatchCalls === 2) {
+                            // Simulate stale local rows/payloads after the
+                            // initial exact probe while still returning enough
+                            // objects to expose unbounded known-chunk caching.
+                            return ids
+                                .filter(
+                                    (_: string, index: number) => index !== 1
+                                )
+                                .map((id: string) => writerChunks.get(id));
+                        }
+                        return [];
+                    }
+                    remoteBatchSizes.push(ids.length);
+                    activeRemoteBatches += 1;
+                    maxActiveRemoteBatches = Math.max(
+                        maxActiveRemoteBatches,
+                        activeRemoteBatches
+                    );
+                    try {
+                        await delay(10);
+                        return ids.map((id: string) => writerChunks.get(id));
+                    } finally {
+                        activeRemoteBatches -= 1;
+                    }
+                }
+                return originalSearch(request as never, options as never);
+            };
+            (reader.files.index as any).get = async (
+                id: string,
+                options: any
+            ) => {
+                if (id.startsWith(`${fileId}:`)) {
+                    if (options.remote === false) {
+                        return undefined;
+                    }
+                    if (options.remote && options.remote !== false) {
+                        perIndexRemoteGets += 1;
+                        activePerIndexRemoteGets += 1;
+                        maxActivePerIndexRemoteGets = Math.max(
+                            maxActivePerIndexRemoteGets,
+                            activePerIndexRemoteGets
+                        );
+                        try {
+                            await delay(10);
+                            return writerChunks.get(id);
+                        } finally {
+                            activePerIndexRemoteGets -= 1;
+                        }
+                    }
+                }
+                return originalGet(id as never, options as never);
+            };
+
+            let roundTrip: Uint8Array;
+            try {
+                roundTrip = await file!.getFile(reader, { as: "joined" });
+            } finally {
+                (reader.files.index as any).search = originalSearch;
+                (reader.files.index as any).get = originalGet;
+                (reader as any).countLocalChunks = originalCountLocalChunks;
+            }
+
+            expect(equals(roundTrip!, bytes)).to.be.true;
+            // Initial verification plus the partial 32-id local window; after
+            // reclassification, persisted reads bypass batch prefetch entirely.
+            expect(localBatchCalls).to.eq(2);
+            expect(remoteBatchSizes).to.have.length(0);
+            expect(maxActiveRemoteBatches).to.eq(0);
+            expect(perIndexRemoteGets).to.be.greaterThan(0);
+            expect(maxActivePerIndexRemoteGets).to.be.greaterThan(0);
+            expect(reader.lastReadDiagnostics?.maxRemoteChunkBatchSize).to.eq(
+                0
+            );
+            expect(
+                reader.lastReadDiagnostics?.maxConcurrentRemoteChunkBatches
+            ).to.eq(0);
+            expect(
+                reader.lastReadDiagnostics
+                    ?.chunkBatchRemoteReclassificationCount
+            ).to.eq(1);
+            expect(reader.lastReadDiagnostics?.readAheadSource).to.eq(
+                "persisted-remote-adaptive"
+            );
+            expect(
+                reader.lastReadDiagnostics?.readAheadLimit
+            ).to.be.lessThanOrEqual(8);
+            expect(reader.lastReadDiagnostics?.readAhead).to.be.lessThanOrEqual(
+                8
+            );
+            expect(maxActivePerIndexRemoteGets).to.be.lessThanOrEqual(
+                reader.lastReadDiagnostics!.readAheadLimit
+            );
+            expect(
+                reader.lastReadDiagnostics?.chunkPersistedRemoteBatchSkipCount
+            ).to.be.greaterThan(0);
+            expect(
+                reader.lastReadDiagnostics?.chunkBatchResolverFallbackCount
+            ).to.eq(0);
+            expect(
+                reader.lastReadDiagnostics?.peakKnownChunkCount
+            ).to.be.lessThanOrEqual(
+                reader.lastReadDiagnostics!.readAheadLimit * 2
+            );
+            expect(reader.lastReadDiagnostics?.finalKnownChunkCount).to.eq(0);
         });
 
         it("bounds persisted chunk misses to exact lookups", async () => {
@@ -755,7 +3000,7 @@ describe("index", () => {
                     size: BigInt(512 * 1024 * 1024),
                     readChunks: async function* (chunkSize: number) {
                         observedChunkSize = chunkSize;
-                        yield new Uint8Array(0);
+                        yield new Uint8Array(chunkSize);
                     },
                 });
                 expect.fail("expected source size mismatch");
@@ -766,6 +3011,229 @@ describe("index", () => {
             }
 
             expect(observedChunkSize).to.eq(512 * 1024);
+        });
+
+        it("normalizes empty, oversized, and reusable source yields", async () => {
+            const filestore = await peer.open(new Files());
+            const expected = crypto.randomBytes(6 * 1024 * 1024) as Uint8Array;
+
+            const fileId = await filestore.addSource(
+                "normalized source chunks",
+                {
+                    size: BigInt(expected.byteLength),
+                    readChunks: async function* (chunkSize: number) {
+                        yield new Uint8Array(0);
+                        const oversizedEnd = chunkSize * 2 + 17;
+                        yield expected.subarray(0, oversizedEnd);
+                        const reusable = new Uint8Array(
+                            Math.max(1, Math.floor(chunkSize / 7))
+                        );
+                        for (
+                            let offset = oversizedEnd;
+                            offset < expected.byteLength;
+                            offset += reusable.byteLength
+                        ) {
+                            const end = Math.min(
+                                offset + reusable.byteLength,
+                                expected.byteLength
+                            );
+                            reusable.set(expected.subarray(offset, end), 0);
+                            yield reusable.subarray(0, end - offset);
+                        }
+                    },
+                }
+            );
+
+            const diagnostics = filestore.lastUploadDiagnostics!;
+            expect(diagnostics.chunkCount).to.eq(
+                Math.ceil(expected.byteLength / diagnostics.chunkSize)
+            );
+            for (let index = 0; index < diagnostics.chunkCount; index++) {
+                const chunk = (await filestore.files.index.get(
+                    `${fileId}:${index}`,
+                    { local: true, remote: false }
+                )) as TinyFile;
+                expect(chunk.file.byteLength).to.eq(
+                    index === diagnostics.chunkCount - 1
+                        ? expected.byteLength % diagnostics.chunkSize ||
+                              diagnostics.chunkSize
+                        : diagnostics.chunkSize
+                );
+            }
+            const file = await filestore.files.index.get(fileId, {
+                local: true,
+                remote: false,
+            });
+            expect(
+                equals(
+                    await file!.getFile(filestore, { as: "joined" }),
+                    expected
+                )
+            ).to.be.true;
+        });
+
+        it("rejects a declared-size overrun before enqueuing its first chunk", async () => {
+            const filestore = await peer.open(new Files());
+            const declaredSize = 6 * 1024 * 1024;
+
+            await expect(
+                filestore.addSource("overrun source", {
+                    size: BigInt(declaredSize),
+                    readChunks: async function* () {
+                        yield new Uint8Array(declaredSize + 1);
+                    },
+                })
+            ).rejects.toThrow("Source size changed during upload");
+
+            expect(
+                filestore.lastUploadDiagnostics?.maxConcurrentChunkPutBytes
+            ).to.eq(0);
+        });
+
+        it("withholds the final normalized chunk until the source finishes", async () => {
+            const filestore = await peer.open(new Files());
+            const expected = crypto.randomBytes(6 * 1024 * 1024) as Uint8Array;
+            let markWaiting!: () => void;
+            const waiting = new Promise<void>((resolve) => {
+                markWaiting = resolve;
+            });
+            let finishSource!: () => void;
+            const finish = new Promise<void>((resolve) => {
+                finishSource = resolve;
+            });
+            const upload = filestore.addSource("withheld final chunk", {
+                size: BigInt(expected.byteLength),
+                readChunks: () => {
+                    let nextCall = 0;
+                    return {
+                        [Symbol.asyncIterator]() {
+                            return this;
+                        },
+                        async next() {
+                            nextCall += 1;
+                            if (nextCall === 1) {
+                                return {
+                                    done: false as const,
+                                    value: expected,
+                                };
+                            }
+                            markWaiting();
+                            await finish;
+                            return {
+                                done: true as const,
+                                value: undefined,
+                            };
+                        },
+                    };
+                },
+            });
+
+            await waiting;
+            const diagnostics = filestore.lastUploadDiagnostics!;
+            try {
+                await waitForResolved(async () => {
+                    expect(
+                        await filestore.countLocalChunks({
+                            id: diagnostics.uploadId,
+                        } as any)
+                    ).to.eq(diagnostics.chunkCount - 1);
+                });
+            } finally {
+                finishSource();
+            }
+            const fileId = await upload;
+            expect(
+                await filestore.countLocalChunks({ id: fileId } as any)
+            ).to.eq(diagnostics.chunkCount);
+        });
+
+        it("cancels a blocked source iterator after a queued put fails", async () => {
+            const filestore = await peer.open(new Files());
+            const originalPut = filestore.files.put.bind(filestore.files);
+            let iteratorReturned = false;
+
+            (filestore.files as any).put = async (
+                value: any,
+                ...args: any[]
+            ) => {
+                if (value instanceof TinyFile && value.parentId != null) {
+                    await delay(10);
+                    throw new Error("early queued put failure");
+                }
+                return (originalPut as any)(value, ...args);
+            };
+
+            try {
+                await expect(
+                    filestore.addSource("blocked source", {
+                        size: 6n * 1024n * 1024n,
+                        readChunks: (chunkSize: number) => {
+                            let nextCalls = 0;
+                            return {
+                                [Symbol.asyncIterator]() {
+                                    return this;
+                                },
+                                next() {
+                                    nextCalls += 1;
+                                    if (nextCalls === 1) {
+                                        return Promise.resolve({
+                                            done: false as const,
+                                            value: new Uint8Array(chunkSize),
+                                        });
+                                    }
+                                    return new Promise<never>(() => {});
+                                },
+                                return() {
+                                    iteratorReturned = true;
+                                    return Promise.resolve({
+                                        done: true as const,
+                                        value: undefined,
+                                    });
+                                },
+                            };
+                        },
+                    })
+                ).rejects.toThrow("early queued put failure");
+            } finally {
+                (filestore.files as any).put = originalPut;
+            }
+
+            expect(iteratorReturned).to.be.true;
+            const diagnostics = filestore.lastUploadDiagnostics!;
+            expect(
+                await filestore.countLocalChunks({
+                    id: diagnostics.uploadId,
+                } as any)
+            ).to.eq(0);
+        });
+
+        it("releases every attempted chunk after an oversized source stream", async () => {
+            const filestore = await peer.open(new Files());
+            const declaredSize = 6 * 1e6;
+
+            await expect(
+                filestore.addSource("oversized source", {
+                    size: BigInt(declaredSize),
+                    readChunks: async function* (chunkSize: number) {
+                        const expectedChunks = Math.ceil(
+                            declaredSize / chunkSize
+                        );
+                        for (let index = 0; index <= expectedChunks; index++) {
+                            yield new Uint8Array(chunkSize);
+                        }
+                    },
+                })
+            ).rejects.toThrow("Source size changed during upload");
+
+            const uploadId = filestore.lastUploadDiagnostics!.uploadId;
+            expect(
+                [
+                    ...((filestore as any).retainedChunkIds as Set<string>),
+                ].filter((id) => id.startsWith(`${uploadId}:`))
+            ).toHaveLength(0);
+            expect(
+                await filestore.countLocalChunks({ id: uploadId } as any)
+            ).to.eq(0);
         });
 
         it("uses indexed chunk search when direct chunk lookup misses", async () => {
@@ -811,6 +3279,15 @@ describe("index", () => {
                 const queries = Array.isArray(request.query)
                     ? request.query
                     : [request.query];
+                if (queries.some((query: any) => Array.isArray(query?.or))) {
+                    const results = await originalSearch(
+                        request as never,
+                        options as never
+                    );
+                    return results.filter(
+                        (candidate) => candidate.id !== missingDirectChunkId
+                    );
+                }
                 const hasParentId = queries.some(
                     (query: any) =>
                         getQueryKey(query) === "parentId" &&
@@ -823,6 +3300,11 @@ describe("index", () => {
                     );
                 });
                 if (hasParentId && hasChunkName) {
+                    if ((options as any)?.remote === false) {
+                        // This test targets the direct-get -> indexed-search
+                        // fallback, so suppress the earlier local legacy probe.
+                        return [];
+                    }
                     indexedChunkSearches++;
                 }
 
@@ -894,6 +3376,15 @@ describe("index", () => {
                 const queries = Array.isArray(request.query)
                     ? request.query
                     : [request.query];
+                if (queries.some((query: any) => Array.isArray(query?.or))) {
+                    const results = await originalSearch(
+                        request as never,
+                        options as never
+                    );
+                    return results.filter(
+                        (candidate) => candidate.id !== missingDirectChunkId
+                    );
+                }
                 const hasParentId = queries.some(
                     (query: any) =>
                         getQueryKey(query) === "parentId" &&
@@ -999,6 +3490,15 @@ describe("index", () => {
                 const queries = Array.isArray(request.query)
                     ? request.query
                     : [request.query];
+                if (queries.some((query: any) => Array.isArray(query?.or))) {
+                    const results = await originalSearch(
+                        request as never,
+                        options as never
+                    );
+                    return results.filter(
+                        (candidate) => candidate.id !== delayedChunkId
+                    );
+                }
                 const hasParentId = queries.some(
                     (query: any) =>
                         getQueryKey(query) === "parentId" &&
@@ -1176,6 +3676,14 @@ describe("index", () => {
                 const queries = Array.isArray(request.query)
                     ? request.query
                     : [request.query];
+                if (
+                    queries.some((query: any) => Array.isArray(query?.or)) ||
+                    queries.some(
+                        (query: any) => getQueryKey(query) === "parentId"
+                    )
+                ) {
+                    return [];
+                }
                 const hasRootId = queries.some(
                     (query: any) =>
                         getQueryKey(query) === "id" &&
@@ -1237,8 +3745,109 @@ describe("index", () => {
                 Object.values(
                     filestore.lastReadDiagnostics?.chunkResolved ?? {}
                 )
-            ).to.deep.eq(chunks.map(() => "manifest-head-get"));
+            ).to.deep.eq(chunks.map(() => "cached"));
+            expect(
+                Object.values(
+                    filestore.lastReadDiagnostics
+                        ?.chunkManifestHeadBatchResolved ?? {}
+                )
+            ).to.deep.eq(chunkEntryHeads);
             expect(equals(concat(streamedChunks), expected)).to.be.true;
+        });
+
+        it("does not retain manifest heads while resolving observer chunks", async () => {
+            const files = await peer.open(new Files());
+            const fileId = "observer-manifest-heads";
+            const fileName = "observer-manifest-heads.bin";
+            const chunks = [new Uint8Array([1, 2]), new Uint8Array([3, 4])];
+            const chunkEntryHeads: string[] = [];
+            for (const [index, bytes] of chunks.entries()) {
+                const result = await files.files.put(
+                    new TinyFile({
+                        id: `${fileId}:${index}`,
+                        name: `${fileName}/${index}`,
+                        file: bytes,
+                        parentId: fileId,
+                        index,
+                    })
+                );
+                chunkEntryHeads[index] = result.entry.hash;
+            }
+            const manifest = new LargeFileWithChunkHeads({
+                id: fileId,
+                name: fileName,
+                size: 4n,
+                chunkCount: chunks.length,
+                ready: true,
+                finalHash: sha256Base64Sync(concat(chunks)),
+                chunkEntryHeads,
+            });
+            const originalSearch = files.files.index.search.bind(
+                files.files.index
+            );
+            const originalGet = files.files.index.get.bind(files.files.index);
+            const originalLogGet = files.files.log.log.get.bind(
+                files.files.log.log
+            );
+            const logSignals: AbortSignal[] = [];
+            files.persistChunkReads = false;
+            (files as any).retainedChunkIds = new Set();
+            (files as any).retainedChunkEntryHeads = new Set();
+            (files as any).retainedEntryHeadsByFileId = new Map();
+            (files.files.index as any).search = async (
+                request: any,
+                options: any
+            ) => {
+                const queries = Array.isArray(request.query)
+                    ? request.query
+                    : [request.query];
+                if (
+                    queries.some((query: any) => Array.isArray(query?.or)) ||
+                    queries.some(
+                        (query: any) => getQueryKey(query) === "parentId"
+                    )
+                ) {
+                    expect(options.signal).to.be.instanceOf(AbortSignal);
+                    return [];
+                }
+                return originalSearch(request as never, options as never);
+            };
+            (files.files.index as any).get = async (
+                id: string,
+                options: any
+            ) => {
+                if (id.startsWith(`${fileId}:`)) {
+                    expect(options.signal).to.be.instanceOf(AbortSignal);
+                    return undefined;
+                }
+                return originalGet(id as never, options as never);
+            };
+            (files.files.log.log as any).get = async (
+                hash: string,
+                options: any
+            ) => {
+                if (chunkEntryHeads.includes(hash)) {
+                    logSignals.push(options.remote.signal);
+                }
+                return originalLogGet(hash as never, options as never);
+            };
+
+            let roundTrip: Uint8Array;
+            try {
+                roundTrip = await manifest.getFile(files, { as: "joined" });
+            } finally {
+                (files.files.index as any).search = originalSearch;
+                (files.files.index as any).get = originalGet;
+                (files.files.log.log as any).get = originalLogGet;
+            }
+
+            expect(equals(roundTrip!, concat(chunks))).to.be.true;
+            expect(logSignals).to.have.length(chunks.length);
+            expect(logSignals.every((signal) => signal instanceof AbortSignal))
+                .to.be.true;
+            expect((files as any).retainedChunkIds.size).to.eq(0);
+            expect((files as any).retainedChunkEntryHeads.size).to.eq(0);
+            expect((files as any).retainedEntryHeadsByFileId.size).to.eq(0);
         });
 
         it("falls back per chunk when ready manifest chunk heads are missing", async () => {
@@ -1427,6 +4036,9 @@ describe("index", () => {
             const originalLogGet = filestore.files.log.log.get.bind(
                 filestore.files.log.log
             );
+            const originalLogGetMany = filestore.files.log.log.getMany.bind(
+                filestore.files.log.log
+            );
             let firstHeadMissed = false;
             let firstHeadGets = 0;
 
@@ -1437,6 +4049,9 @@ describe("index", () => {
                 const queries = Array.isArray(request.query)
                     ? request.query
                     : [request.query];
+                if (queries.some((query: any) => Array.isArray(query?.or))) {
+                    return [];
+                }
                 const hasRootId = queries.some(
                     (query: any) =>
                         getQueryKey(query) === "id" &&
@@ -1486,6 +4101,18 @@ describe("index", () => {
                 }
                 return originalLogGet(hash as never, options as never);
             };
+            (filestore.files.log.log as any).getMany = async (
+                hashes: string[],
+                options: unknown
+            ) => {
+                const entries = await originalLogGetMany(
+                    hashes,
+                    options as never
+                );
+                return entries.map((entry, index) =>
+                    hashes[index] === chunkEntryHeads[0] ? undefined : entry
+                );
+            };
 
             const streamedChunks: Uint8Array[] = [];
 
@@ -1503,6 +4130,7 @@ describe("index", () => {
                 (filestore.files.index as any).search = originalSearch;
                 (filestore.files.index as any).get = originalGet;
                 (filestore.files.log.log as any).get = originalLogGet;
+                (filestore.files.log.log as any).getMany = originalLogGetMany;
             }
 
             expect(firstHeadGets).to.be.greaterThan(1);
@@ -1513,7 +4141,7 @@ describe("index", () => {
                 Object.values(
                     filestore.lastReadDiagnostics?.chunkResolved ?? {}
                 )
-            ).to.deep.eq(chunks.map(() => "manifest-head-get"));
+            ).to.deep.eq(["manifest-head-get", "cached", "cached"]);
             expect(equals(concat(streamedChunks), expected)).to.be.true;
         });
 
@@ -2026,6 +4654,15 @@ describe("index", () => {
                 const queries = Array.isArray(request.query)
                     ? request.query
                     : [request.query];
+                if (queries.some((query: any) => Array.isArray(query?.or))) {
+                    const results = await originalSearch(
+                        request as never,
+                        options as never
+                    );
+                    return results.filter(
+                        (candidate) => candidate.id !== delayedChunkId
+                    );
+                }
                 const hasParentId = queries.some(
                     (query: any) =>
                         getQueryKey(query) === "parentId" &&
@@ -2149,6 +4786,15 @@ describe("index", () => {
                 const queries = Array.isArray(request.query)
                     ? request.query
                     : [request.query];
+                if (queries.some((query: any) => Array.isArray(query?.or))) {
+                    const results = await originalSearch(
+                        request as never,
+                        options as never
+                    );
+                    return results.filter(
+                        (candidate) => candidate.id !== missingDirectChunkId
+                    );
+                }
                 const hasParentId = queries.some(
                     (query: any) =>
                         getQueryKey(query) === "parentId" &&
@@ -2277,6 +4923,15 @@ describe("index", () => {
                 const queries = Array.isArray(request.query)
                     ? request.query
                     : [request.query];
+                if (queries.some((query: any) => Array.isArray(query?.or))) {
+                    const results = await originalSearch(
+                        request as never,
+                        options as never
+                    );
+                    return results.filter(
+                        (candidate) => candidate.id !== delayedChunkId
+                    );
+                }
                 const hasParentId = queries.some(
                     (query: any) =>
                         getQueryKey(query) === "parentId" &&
@@ -2389,6 +5044,15 @@ describe("index", () => {
                 const queries = Array.isArray(request.query)
                     ? request.query
                     : [request.query];
+                if (queries.some((query: any) => Array.isArray(query?.or))) {
+                    const results = await originalSearch(
+                        request as never,
+                        options as never
+                    );
+                    return results.filter(
+                        (candidate) => candidate.id !== missingDirectChunkId
+                    );
+                }
                 const hasParentId = queries.some(
                     (query: any) =>
                         getQueryKey(query) === "parentId" &&
@@ -2401,6 +5065,9 @@ describe("index", () => {
                 );
 
                 if (hasParentId && hasChunkName) {
+                    if ((options as any)?.remote === false) {
+                        return [];
+                    }
                     preciseChunkSearches++;
                     return missingDirectChunk ? [missingDirectChunk] : [];
                 }
@@ -2433,7 +5100,7 @@ describe("index", () => {
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
 
-        it("waits for all chunk documents before streaming observer downloads", async () => {
+        it("falls back per-index after partial observer chunk batches", async () => {
             const filestore = await peer.open(new Files());
             const largeFile = crypto.randomBytes(12 * 1e6) as Uint8Array;
             const fileId = await filestore.add(
@@ -2513,7 +5180,11 @@ describe("index", () => {
 
             expect(fetchSearchCalls).to.be.greaterThan(0);
             expect(partialFetches).to.eq(2);
-            expect(directChunkGets).to.eq(0);
+            expect(directChunkGets).to.be.greaterThan(0);
+            expect(
+                filestoreReader.lastReadDiagnostics
+                    ?.chunkBatchResolverFallbackCount
+            ).to.be.greaterThan(0);
             expect(streamedChunks.length).to.be.greaterThan(1);
             expect(equals(concat(streamedChunks), largeFile)).to.be.true;
         });
@@ -2721,6 +5392,15 @@ describe("index", () => {
                 const queries = Array.isArray(request.query)
                     ? request.query
                     : [request.query];
+                if (queries.some((query: any) => Array.isArray(query?.or))) {
+                    const results = await originalSearch(
+                        request as never,
+                        options as never
+                    );
+                    return results.filter(
+                        (candidate) => candidate.id !== transientChunkId
+                    );
+                }
                 const isTransientChunkSearch =
                     queries.some(
                         (query: any) =>

--- a/packages/file-share/library/src/__tests__/manifest.test.ts
+++ b/packages/file-share/library/src/__tests__/manifest.test.ts
@@ -20,12 +20,32 @@ const syncedDependencies = [
     "@peerbit/trusted-network",
 ] as const;
 
+const isMajorCompatibleCaretRange = (range: string) =>
+    /^\^(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*)){0,2}$/.test(range);
+
 describe("package manifest", () => {
     it("keeps published peerbit dependency ranges major-compatible", () => {
         for (const dependency of syncedDependencies) {
             const version = libraryPackageJson.dependencies?.[dependency];
             expect(version).toBeDefined();
-            expect(version).toMatch(/^\^\d+$/);
+            expect(isMajorCompatibleCaretRange(version!)).toBe(true);
+        }
+    });
+
+    it("rejects dependency ranges that can cross the next major", () => {
+        for (const range of [
+            "*",
+            "latest",
+            ">=5",
+            ">=5 <7",
+            "^5 || ^6",
+            "~5.3.0",
+            "5.3.0",
+        ]) {
+            expect(isMajorCompatibleCaretRange(range)).toBe(false);
+        }
+        for (const range of ["^5", "^5.3", "^5.3.0", "^13.1.0"]) {
+            expect(isMajorCompatibleCaretRange(range)).toBe(true);
         }
     });
 });

--- a/packages/file-share/library/src/__tests__/read-performance.test.ts
+++ b/packages/file-share/library/src/__tests__/read-performance.test.ts
@@ -1,0 +1,2025 @@
+import { describe, expect, it, vi } from "vitest";
+import { deserialize, serialize } from "@dao-xyz/borsh";
+import { PutOperation } from "@peerbit/document";
+import { concat } from "uint8arrays";
+import { AbstractFile, Files, LargeFile, TinyFile } from "../index.js";
+import {
+    adaptRemotePersistedReadAhead,
+    getRemotePersistedReadAheadLimit,
+} from "../read-scheduling.js";
+
+const createLookupSignal = (onWait?: () => void) => {
+    let closed = false;
+    const controller = new AbortController();
+    return {
+        get isClosed() {
+            return closed;
+        },
+        get abortSignal() {
+            return controller.signal;
+        },
+        snapshot: () => 0,
+        throwIfClosed: () => {
+            if (closed) {
+                throw new Error("File read cancelled");
+            }
+        },
+        waitForChangeAfter: async () => {
+            onWait?.();
+            return true;
+        },
+        close: () => {
+            closed = true;
+            controller.abort();
+        },
+    };
+};
+
+const resolveSingleChunk = (
+    file: LargeFile,
+    files: Files,
+    signal: ReturnType<typeof createLookupSignal>,
+    debug: Record<string, any>
+) =>
+    (file as any).resolveChunk(files, 0, new Map(), {}, signal, {
+        timeout: 30_000,
+        debug,
+        persist: files.persistChunkReads,
+    }) as Promise<TinyFile>;
+
+const withHead = <T extends object>(value: T, head: string) => {
+    Object.defineProperty(value, "__context", {
+        configurable: true,
+        value: { head },
+    });
+    return value;
+};
+
+const createPutEntry = (file: TinyFile | LargeFile, hash: string) => ({
+    hash,
+    getPayloadValue: async () =>
+        new PutOperation({
+            data: serialize(file),
+        }),
+});
+
+const createStreamHarness = (size: bigint, chunks: Uint8Array[]) => {
+    const files = new Files();
+    files.persistChunkReads = false;
+    const file = new LargeFile({
+        id: "stream-size-file",
+        name: "stream-size-file.bin",
+        size,
+        chunkCount: chunks.length,
+        ready: true,
+    });
+    const chunkFiles = chunks.map(
+        (bytes, index) =>
+            new TinyFile({
+                id: `${file.id}:${index}`,
+                name: `${file.name}/${index}`,
+                file: bytes,
+                parentId: file.id,
+                index,
+            })
+    );
+    (files as any).getReadPeerHints = async () => undefined;
+    (files.files.index as any).search = async () => [];
+    (file as any).waitUntilReady = async () => file;
+    (file as any).resolveChunk = async (_files: Files, index: number) =>
+        chunkFiles[index];
+    return { file, files };
+};
+
+const createPersistedManifestStreamHarness = (chunks: Uint8Array[]) => {
+    const files = new Files();
+    const file = new LargeFile({
+        id: "persisted-manifest-stream",
+        name: "persisted-manifest-stream.bin",
+        size: BigInt(chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0)),
+        chunkCount: chunks.length,
+        ready: true,
+    });
+    const chunkFiles = chunks.map(
+        (bytes, index) =>
+            new TinyFile({
+                id: `${file.id}:${index}`,
+                name: `${file.name}/${index}`,
+                file: bytes,
+                parentId: file.id,
+                index,
+            })
+    );
+    const heads = chunkFiles.map((_, index) => `chunk-head-${index}`);
+    const entriesByHead = new Map(
+        heads.map((head, index) => [
+            head,
+            createPutEntry(chunkFiles[index]!, head),
+        ])
+    );
+    const fallbackIndices = new Set<number>();
+    const perIndexGets: number[] = [];
+
+    (file as any).chunkEntryHeads = heads;
+    (files as any).countLocalChunks = async () => 0;
+    (files as any).getReadPeerHints = async () => ["writer-peer"];
+    Object.defineProperty(files.files.index, "valueEncoding", {
+        configurable: true,
+        value: {
+            decoder: (bytes: Uint8Array) => deserialize(bytes, AbstractFile),
+        },
+    });
+    (files.files.index as any).get = async (id: string) => {
+        const prefix = `${file.id}:`;
+        if (!id.startsWith(prefix)) {
+            throw new Error(`unexpected index get: ${id}`);
+        }
+        const index = Number(id.slice(prefix.length));
+        perIndexGets.push(index);
+        if (!fallbackIndices.has(index)) {
+            throw new Error(`unexpected per-index fallback: ${index}`);
+        }
+        return chunkFiles[index];
+    };
+    (files.files.index as any).search = async () => {
+        throw new Error("unexpected indexed fallback");
+    };
+    (files.files.log.log as any).get = async () => {
+        throw new Error("unexpected single manifest-head fallback");
+    };
+
+    return {
+        entriesByHead,
+        fallbackIndices,
+        file,
+        files,
+        heads,
+        chunkFiles,
+        perIndexGets,
+    };
+};
+
+describe("large-file read scheduling", () => {
+    it("rejects a short stream even when no final hash is declared", async () => {
+        const { file, files } = createStreamHarness(3n, [
+            new Uint8Array([1, 2]),
+        ]);
+        const iterator = file.streamFile(files)[Symbol.asyncIterator]();
+
+        expect((await iterator.next()).value).toEqual(new Uint8Array([1, 2]));
+        await expect(iterator.next()).rejects.toThrow(
+            "Expected 3 bytes, got 2"
+        );
+    });
+
+    it("rejects an oversized chunk before yielding it", async () => {
+        const { file, files } = createStreamHarness(1n, [
+            new Uint8Array([1, 2]),
+        ]);
+        const iterator = file.streamFile(files)[Symbol.asyncIterator]();
+
+        await expect(iterator.next()).rejects.toThrow("Expected 1 bytes");
+    });
+
+    it("rejects a positive-size manifest with zero chunks", async () => {
+        const { file, files } = createStreamHarness(1n, []);
+        const iterator = file.streamFile(files)[Symbol.asyncIterator]();
+
+        await expect(iterator.next()).rejects.toThrow(
+            "Expected 1 bytes, got 0"
+        );
+    });
+
+    it("keeps concurrent write diagnostics scoped to their own streams", async () => {
+        const files = new Files();
+        files.persistChunkReads = false;
+        (files as any).getReadPeerHints = async () => undefined;
+        (files.files.index as any).search = async () => [];
+
+        const fileA = new LargeFile({
+            id: "concurrent-write-a",
+            name: "concurrent-write-a.bin",
+            size: 1n,
+            chunkCount: 1,
+            ready: true,
+        });
+        const fileB = new LargeFile({
+            id: "concurrent-write-b",
+            name: "concurrent-write-b.bin",
+            size: 1n,
+            chunkCount: 1,
+            ready: true,
+        });
+        const chunkA = new TinyFile({
+            id: `${fileA.id}:0`,
+            name: `${fileA.name}/0`,
+            file: new Uint8Array([1]),
+            parentId: fileA.id,
+            index: 0,
+        });
+        const chunkB = new TinyFile({
+            id: `${fileB.id}:0`,
+            name: `${fileB.name}/0`,
+            file: new Uint8Array([2]),
+            parentId: fileB.id,
+            index: 0,
+        });
+        let markAResolving: () => void = () => {};
+        let releaseA: () => void = () => {};
+        const aResolving = new Promise<void>((resolve) => {
+            markAResolving = resolve;
+        });
+        const aReleased = new Promise<void>((resolve) => {
+            releaseA = resolve;
+        });
+        (fileA as any).waitUntilReady = async () => fileA;
+        (fileB as any).waitUntilReady = async () => fileB;
+        (fileA as any).resolveChunk = async () => {
+            markAResolving();
+            await aReleased;
+            return chunkA;
+        };
+        (fileB as any).resolveChunk = async () => chunkB;
+
+        const writableA = {
+            write: vi.fn(async () => {}),
+            close: vi.fn(async () => {}),
+        };
+        const writableB = {
+            write: vi.fn(async () => {}),
+            close: vi.fn(async () => {}),
+        };
+
+        const writingA = fileA.writeFile(files, writableA);
+        await aResolving;
+        const diagnosticsA = files.lastReadDiagnostics!;
+
+        await fileB.writeFile(files, writableB);
+        const diagnosticsB = files.lastReadDiagnostics!;
+        expect(diagnosticsB).not.toBe(diagnosticsA);
+
+        releaseA();
+        await writingA;
+
+        expect(diagnosticsA.fileId).toBe(fileA.id);
+        expect(diagnosticsA.chunkWriteStartedAt[0]).toEqual(expect.any(Number));
+        expect(diagnosticsA.chunkWriteFinishedAt[0]).toEqual(
+            expect.any(Number)
+        );
+        expect(diagnosticsB.fileId).toBe(fileB.id);
+        expect(diagnosticsB.chunkWriteStartedAt[0]).toEqual(expect.any(Number));
+        expect(diagnosticsB.chunkWriteFinishedAt[0]).toEqual(
+            expect.any(Number)
+        );
+        expect(files.lastReadDiagnostics).toBe(diagnosticsB);
+        expect(writableA.write).toHaveBeenCalledOnce();
+        expect(writableB.write).toHaveBeenCalledOnce();
+    });
+
+    it("does not append TinyFile sink timings to prior large-file diagnostics", async () => {
+        const { file, files } = createStreamHarness(1n, [new Uint8Array([1])]);
+        await file.getFile(files, { as: "joined" });
+        const largeDiagnostics = files.lastReadDiagnostics!;
+        expect(largeDiagnostics.chunkWriteStartedAt).toEqual({});
+        expect(largeDiagnostics.chunkWriteFinishedAt).toEqual({});
+
+        const tiny = new TinyFile({
+            name: "tiny-followup.bin",
+            file: new Uint8Array([2]),
+        });
+        const writes: Uint8Array[] = [];
+        await tiny.writeFile(files, {
+            write: (chunk) => {
+                writes.push(chunk);
+            },
+        });
+
+        expect(writes).toEqual([new Uint8Array([2])]);
+        expect(files.lastReadDiagnostics).toBe(largeDiagnostics);
+        expect(largeDiagnostics.chunkWriteStartedAt).toEqual({});
+        expect(largeDiagnostics.chunkWriteFinishedAt).toEqual({});
+    });
+
+    it("keeps single-write diagnostics benchmark-compatible", async () => {
+        const { file, files } = createStreamHarness(1n, [new Uint8Array([1])]);
+
+        await file.writeFile(files, {
+            write: async () => {},
+            close: async () => {},
+        });
+
+        expect(files.lastReadDiagnostics).toMatchObject({
+            fileId: file.id,
+            fileName: file.name,
+            startedAt: expect.any(Number),
+            finishedAt: expect.any(Number),
+            chunkMaterializeStartedAt: { 0: expect.any(Number) },
+            chunkMaterializeFinishedAt: { 0: expect.any(Number) },
+            chunkHashStartedAt: { 0: expect.any(Number) },
+            chunkHashFinishedAt: { 0: expect.any(Number) },
+            chunkWriteStartedAt: { 0: expect.any(Number) },
+            chunkWriteFinishedAt: { 0: expect.any(Number) },
+        });
+    });
+
+    it("wakes on matching document events and removes its listener", async () => {
+        const files = new Files();
+        const signal = files.createFileChangeSignal(
+            (file) => file.id === "upload:0"
+        );
+        const waiting = signal.waitForChangeAfter(signal.snapshot(), 10_000);
+
+        files.files.events.dispatchEvent(
+            new CustomEvent("change", {
+                detail: {
+                    added: [
+                        new TinyFile({
+                            id: "upload:0",
+                            name: "chunk-0",
+                            file: new Uint8Array([1]),
+                            parentId: "upload",
+                            index: 0,
+                        }),
+                    ],
+                    removed: [],
+                },
+            })
+        );
+
+        expect(await waiting).toBe(true);
+        signal.close();
+        expect((files as any).activeFileChangeSignals.size).toBe(0);
+    });
+
+    it("bounds, grows, and backs off persisted remote read-ahead", () => {
+        expect(getRemotePersistedReadAheadLimit(512 * 1024 * 512, 512)).toBe(8);
+        expect(getRemotePersistedReadAheadLimit(2 * 1024 * 1024 * 10, 10)).toBe(
+            2
+        );
+        expect(getRemotePersistedReadAheadLimit(5 * 1024 * 1024 * 10, 10)).toBe(
+            1
+        );
+
+        expect(
+            adaptRemotePersistedReadAhead(2, 8, {
+                demandWaitMs: 25,
+                attempts: 1,
+            })
+        ).toBe(3);
+        expect(
+            adaptRemotePersistedReadAhead(6, 8, {
+                demandWaitMs: 100,
+                attempts: 2,
+            })
+        ).toBe(3);
+    });
+
+    it("starts complete persisted manifest reads at the bounded memory-derived limit", async () => {
+        const chunks = Array.from(
+            { length: 9 },
+            (_, index) => new Uint8Array([index])
+        );
+        const { entriesByHead, file, files, perIndexGets } =
+            createPersistedManifestStreamHarness(chunks);
+        const getMany = vi.fn(
+            async (requestedHeads: string[], options: any): Promise<any[]> => {
+                if (options.remote === false) {
+                    return requestedHeads.map(() => undefined);
+                }
+                return requestedHeads.map((head) => entriesByHead.get(head));
+            }
+        );
+        (files.files.log.log as any).getMany = getMany;
+
+        const roundTrip = await file.getFile(files, { as: "joined" });
+
+        expect(roundTrip).toEqual(concat(chunks));
+        expect(perIndexGets).toEqual([]);
+        expect(getMany).toHaveBeenCalledTimes(4);
+        expect(getMany.mock.calls.every(([heads]) => heads.length <= 8)).toBe(
+            true
+        );
+        const diagnostics = files.lastReadDiagnostics!;
+        expect(diagnostics.readAheadInitial).toBe(8);
+        expect(diagnostics.readAheadLimit).toBe(8);
+        expect(diagnostics.readAheadPeak).toBe(8);
+        expect(diagnostics.maxInFlightChunks).toBe(8);
+        expect(diagnostics.maxManifestHeadBatchSize).toBe(8);
+        expect(diagnostics.chunkManifestHeadBatchAcceptedCount).toBe(9);
+    });
+
+    it("prefetches aligned persisted manifest heads through one bounded local and remote phase", async () => {
+        const { entriesByHead, file, files, heads, perIndexGets } =
+            createPersistedManifestStreamHarness([
+                new Uint8Array([1, 2]),
+                new Uint8Array([3, 4]),
+            ]);
+        const getMany = vi.fn(
+            async (requestedHeads: string[], options: any): Promise<any[]> => {
+                if (options.remote === false) {
+                    return requestedHeads.map((head) =>
+                        head === heads[0] ? entriesByHead.get(head) : undefined
+                    );
+                }
+                return requestedHeads.map((head) => entriesByHead.get(head));
+            }
+        );
+        (files.files.log.log as any).getMany = getMany;
+
+        const roundTrip = await file.getFile(files, { as: "joined" });
+
+        expect(roundTrip).toEqual(new Uint8Array([1, 2, 3, 4]));
+        expect(perIndexGets).toEqual([]);
+        expect(getMany).toHaveBeenCalledTimes(2);
+        const [localHeads, localOptions] = getMany.mock.calls[0]!;
+        const [remoteHeads, remoteOptions] = getMany.mock.calls[1]!;
+        expect(localHeads).toEqual(heads);
+        expect(localOptions.remote).toBe(false);
+        expect(remoteHeads).toEqual([heads[1]]);
+        expect(remoteOptions.remote).toMatchObject({
+            timeout: 1_500,
+            replicate: true,
+            from: ["writer-peer"],
+        });
+        expect(remoteOptions.remote.signal).toBeInstanceOf(AbortSignal);
+        expect(
+            Math.max(...getMany.mock.calls.map(([batch]) => batch.length))
+        ).toBeLessThanOrEqual(8);
+
+        const diagnostics = files.lastReadDiagnostics!;
+        expect(diagnostics.chunkManifestHeadBatchQueryCount).toBe(1);
+        expect(diagnostics.chunkManifestHeadLocalBatchQueryCount).toBe(1);
+        expect(diagnostics.chunkManifestHeadRemoteBatchQueryCount).toBe(1);
+        expect(diagnostics.chunkManifestHeadBatchRequestedIndexCount).toBe(2);
+        expect(diagnostics.chunkManifestHeadLocalBatchAcceptedCount).toBe(1);
+        expect(diagnostics.chunkManifestHeadRemoteBatchAcceptedCount).toBe(1);
+        expect(diagnostics.chunkManifestHeadBatchAcceptedCount).toBe(2);
+        expect(diagnostics.chunkManifestHeadBatchMissingCount).toBe(0);
+        expect(diagnostics.chunkManifestHeadBatchInvalidCount).toBe(0);
+        expect(diagnostics.chunkManifestHeadBatchPartialCount).toBe(0);
+        expect(diagnostics.chunkManifestHeadBatchErrorCount).toBe(0);
+        expect(diagnostics.chunkManifestHeadBatchDisabled).toBe(false);
+        expect(diagnostics.maxManifestHeadBatchSize).toBeLessThanOrEqual(8);
+        expect(diagnostics.maxConcurrentManifestHeadBatches).toBe(1);
+        expect(diagnostics.chunkBatchResolverFallbackCount).toBe(0);
+        expect(diagnostics.finalKnownChunkCount).toBe(0);
+        expect((files as any).retainedChunkEntryHeads).toEqual(new Set(heads));
+    });
+
+    it("uses aligned entry-index batches when public log getMany is unavailable", async () => {
+        const { entriesByHead, file, files, heads, perIndexGets } =
+            createPersistedManifestStreamHarness([
+                new Uint8Array([1]),
+                new Uint8Array([2]),
+            ]);
+        const entryIndexGetMany = vi.fn(
+            async (requestedHeads: string[], options: any): Promise<any[]> => {
+                if (options.remote === false) {
+                    return requestedHeads.map((head) =>
+                        head === heads[0] ? entriesByHead.get(head) : undefined
+                    );
+                }
+                return requestedHeads.map((head) => entriesByHead.get(head));
+            }
+        );
+        const log = files.files.log.log as any;
+        Object.defineProperty(log, "getMany", {
+            configurable: true,
+            value: undefined,
+        });
+        Object.defineProperty(log, "entryIndex", {
+            configurable: true,
+            value: { getMany: entryIndexGetMany },
+        });
+
+        const roundTrip = await file.getFile(files, { as: "joined" });
+
+        expect(roundTrip).toEqual(new Uint8Array([1, 2]));
+        expect(perIndexGets).toEqual([]);
+        expect(entryIndexGetMany).toHaveBeenCalledTimes(2);
+        const [localHeads, localOptions] = entryIndexGetMany.mock.calls[0]!;
+        const [remoteHeads, remoteOptions] = entryIndexGetMany.mock.calls[1]!;
+        expect(localHeads).toEqual(heads);
+        expect(localOptions).toMatchObject({
+            type: "full",
+            ignoreMissing: true,
+            remote: false,
+        });
+        expect(remoteHeads).toEqual([heads[1]]);
+        expect(remoteOptions).toMatchObject({
+            type: "full",
+            ignoreMissing: true,
+            remote: {
+                timeout: 1_500,
+                replicate: true,
+                from: ["writer-peer"],
+            },
+        });
+        expect(remoteOptions.remote.signal).toBeInstanceOf(AbortSignal);
+        expect(
+            files.lastReadDiagnostics?.chunkManifestHeadBatchAcceptedCount
+        ).toBe(2);
+    });
+
+    it("uses bounded aligned per-head gets when neither batch API is available", async () => {
+        const { entriesByHead, file, files, heads, perIndexGets } =
+            createPersistedManifestStreamHarness([
+                new Uint8Array([1]),
+                new Uint8Array([2]),
+            ]);
+        const log = files.files.log.log as any;
+        Object.defineProperty(log, "getMany", {
+            configurable: true,
+            value: undefined,
+        });
+        Object.defineProperty(log, "entryIndex", {
+            configurable: true,
+            value: {},
+        });
+        let activeGets = 0;
+        let maxActiveGets = 0;
+        const get = vi.fn(async (head: string, options: any): Promise<any> => {
+            activeGets += 1;
+            maxActiveGets = Math.max(maxActiveGets, activeGets);
+            try {
+                await Promise.resolve();
+                if (options.remote === false && head !== heads[0]) {
+                    return undefined;
+                }
+                return entriesByHead.get(head);
+            } finally {
+                activeGets -= 1;
+            }
+        });
+        log.get = get;
+
+        const roundTrip = await file.getFile(files, { as: "joined" });
+
+        expect(roundTrip).toEqual(new Uint8Array([1, 2]));
+        expect(perIndexGets).toEqual([]);
+        expect(get).toHaveBeenCalledTimes(3);
+        expect(get.mock.calls.map(([head]) => head)).toEqual([
+            heads[0],
+            heads[1],
+            heads[1],
+        ]);
+        expect(get.mock.calls[0]![1].remote).toBe(false);
+        expect(get.mock.calls[1]![1].remote).toBe(false);
+        expect(get.mock.calls[2]![1].remote).toMatchObject({
+            timeout: 1_500,
+            replicate: true,
+            from: ["writer-peer"],
+        });
+        expect(get.mock.calls[2]![1].remote.signal).toBeInstanceOf(AbortSignal);
+        expect(maxActiveGets).toBeLessThanOrEqual(8);
+    });
+
+    it("falls back only for missing persisted manifest-head batch results", async () => {
+        const {
+            entriesByHead,
+            fallbackIndices,
+            file,
+            files,
+            heads,
+            perIndexGets,
+        } = createPersistedManifestStreamHarness([
+            new Uint8Array([1]),
+            new Uint8Array([2]),
+        ]);
+        fallbackIndices.add(1);
+        const getMany = vi.fn(
+            async (requestedHeads: string[], options: any): Promise<any[]> => {
+                if (options.remote === false) {
+                    return requestedHeads.map(() => undefined);
+                }
+                return requestedHeads.map((head) =>
+                    head === heads[0] ? entriesByHead.get(head) : undefined
+                );
+            }
+        );
+        (files.files.log.log as any).getMany = getMany;
+
+        const roundTrip = await file.getFile(files, { as: "joined" });
+
+        expect(roundTrip).toEqual(new Uint8Array([1, 2]));
+        expect(perIndexGets).toEqual([1]);
+        expect(getMany).toHaveBeenCalledTimes(2);
+        expect(getMany.mock.calls[1]![0]).toEqual(heads);
+        const diagnostics = files.lastReadDiagnostics!;
+        expect(diagnostics.chunkManifestHeadBatchAcceptedCount).toBe(1);
+        expect(diagnostics.chunkManifestHeadLocalBatchAcceptedCount).toBe(0);
+        expect(diagnostics.chunkManifestHeadRemoteBatchAcceptedCount).toBe(1);
+        expect(diagnostics.chunkManifestHeadBatchMissingCount).toBe(1);
+        expect(diagnostics.chunkManifestHeadBatchPartialCount).toBe(1);
+        expect(diagnostics.chunkManifestHeadBatchDisabled).toBe(false);
+        expect((files as any).retainedChunkEntryHeads).toEqual(
+            new Set([heads[0]])
+        );
+    });
+
+    for (const mode of ["error", "zero-accepted"] as const) {
+        it(`disables later persisted manifest-head probes after a ${mode} batch`, async () => {
+            const {
+                entriesByHead,
+                fallbackIndices,
+                file,
+                files,
+                heads,
+                perIndexGets,
+            } = createPersistedManifestStreamHarness([
+                new Uint8Array([1]),
+                new Uint8Array([2]),
+                new Uint8Array([3]),
+                new Uint8Array([4]),
+                new Uint8Array([5]),
+                new Uint8Array([6]),
+                new Uint8Array([7]),
+                new Uint8Array([8]),
+                new Uint8Array([9]),
+                new Uint8Array([10]),
+            ]);
+            for (let index = 0; index < 10; index++) {
+                fallbackIndices.add(index);
+            }
+            const getMany = vi.fn(
+                async (
+                    requestedHeads: string[],
+                    options: any
+                ): Promise<any[]> => {
+                    if (options.remote === false) {
+                        return requestedHeads.map((head) =>
+                            mode === "error" && head === heads[0]
+                                ? entriesByHead.get(head)
+                                : undefined
+                        );
+                    }
+                    if (mode === "error") {
+                        throw new Error("speculative manifest-head failure");
+                    }
+                    return requestedHeads.map(() => undefined);
+                }
+            );
+            (files.files.log.log as any).getMany = getMany;
+
+            const roundTrip = await file.getFile(files, { as: "joined" });
+
+            expect(roundTrip).toEqual(
+                new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+            );
+            expect(perIndexGets).toEqual(
+                mode === "error"
+                    ? [1, 2, 3, 4, 5, 6, 7, 8, 9]
+                    : [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            );
+            expect(getMany).toHaveBeenCalledTimes(2);
+            expect(getMany.mock.calls[0]![0]).toEqual(heads.slice(0, 8));
+            expect(getMany.mock.calls[0]![1].remote).toBe(false);
+            expect(getMany.mock.calls[1]![0]).toEqual(
+                mode === "error" ? heads.slice(1, 8) : heads.slice(0, 8)
+            );
+            expect(getMany.mock.calls[1]![1].remote.replicate).toBe(true);
+
+            const diagnostics = files.lastReadDiagnostics!;
+            expect(diagnostics.chunkManifestHeadBatchQueryCount).toBe(1);
+            expect(diagnostics.chunkManifestHeadLocalBatchQueryCount).toBe(1);
+            expect(diagnostics.chunkManifestHeadRemoteBatchQueryCount).toBe(1);
+            expect(diagnostics.chunkManifestHeadBatchDisabled).toBe(true);
+            expect(diagnostics.chunkManifestHeadBatchDisabledReason).toBe(mode);
+            expect(diagnostics.chunkManifestHeadBatchDisabledSkipCount).toBe(1);
+            expect(
+                diagnostics.chunkManifestHeadBatchDisabledSkippedIndexCount
+            ).toBe(2);
+            expect(diagnostics.chunkManifestHeadBatchErrorCount).toBe(
+                mode === "error" ? 1 : 0
+            );
+            expect(diagnostics.chunkManifestHeadBatchAcceptedCount).toBe(
+                mode === "error" ? 1 : 0
+            );
+            expect(diagnostics.chunkManifestHeadLocalBatchAcceptedCount).toBe(
+                mode === "error" ? 1 : 0
+            );
+            expect(diagnostics.chunkManifestHeadRemoteBatchAcceptedCount).toBe(
+                0
+            );
+            expect(diagnostics.prefetchedChunkCount).toBe(
+                mode === "error" ? 1 : 0
+            );
+            expect(diagnostics.chunkManifestHeadBatchMissingCount).toBe(
+                mode === "zero-accepted" ? 8 : 0
+            );
+        });
+    }
+
+    it("rejects invalid parent and index entries before per-index fallback", async () => {
+        const {
+            entriesByHead,
+            fallbackIndices,
+            file,
+            files,
+            heads,
+            perIndexGets,
+        } = createPersistedManifestStreamHarness([
+            new Uint8Array([1]),
+            new Uint8Array([2]),
+            new Uint8Array([3]),
+            new Uint8Array([4]),
+        ]);
+        fallbackIndices.add(0);
+        fallbackIndices.add(2);
+        const invalidParent = new TinyFile({
+            id: `${file.id}:0`,
+            name: `${file.name}/0`,
+            file: new Uint8Array([9]),
+            parentId: "different-parent",
+            index: 0,
+        });
+        const invalidIndex = new TinyFile({
+            id: `${file.id}:2`,
+            name: `${file.name}/2`,
+            file: new Uint8Array([9]),
+            parentId: file.id,
+            index: 99,
+        });
+        const invalidEntries = new Map([
+            [heads[0], createPutEntry(invalidParent, heads[0]!)],
+            [heads[2], createPutEntry(invalidIndex, heads[2]!)],
+        ]);
+        const getMany = vi.fn(
+            async (requestedHeads: string[], options: any): Promise<any[]> => {
+                expect(options.remote).toBe(false);
+                return requestedHeads.map(
+                    (head) =>
+                        invalidEntries.get(head) ?? entriesByHead.get(head)
+                );
+            }
+        );
+        (files.files.log.log as any).getMany = getMany;
+
+        const roundTrip = await file.getFile(files, { as: "joined" });
+
+        expect(roundTrip).toEqual(new Uint8Array([1, 2, 3, 4]));
+        expect(perIndexGets).toEqual([0, 2]);
+        expect(
+            getMany.mock.calls.every(([, options]) => options.remote === false)
+        ).toBe(true);
+        const diagnostics = files.lastReadDiagnostics!;
+        expect(diagnostics.chunkManifestHeadBatchAcceptedCount).toBe(2);
+        expect(diagnostics.chunkManifestHeadBatchInvalidCount).toBe(2);
+        expect(diagnostics.chunkManifestHeadBatchPartialCount).toBe(1);
+        expect(diagnostics.chunkManifestHeadBatchDisabled).toBe(false);
+    });
+
+    it("aborts a pending remote manifest-head batch and releases listeners when the stream closes", async () => {
+        const { entriesByHead, file, files, heads, perIndexGets } =
+            createPersistedManifestStreamHarness([
+                new Uint8Array([1]),
+                new Uint8Array([2]),
+                new Uint8Array([3]),
+                new Uint8Array([4]),
+                new Uint8Array([5]),
+                new Uint8Array([6]),
+                new Uint8Array([7]),
+                new Uint8Array([8]),
+                new Uint8Array([9]),
+                new Uint8Array([10]),
+            ]);
+        let remoteSignal: AbortSignal | undefined;
+        let remoteAborted = false;
+        let markRemoteStarted!: () => void;
+        const remoteStarted = new Promise<void>((resolve) => {
+            markRemoteStarted = resolve;
+        });
+        const getMany = vi.fn(
+            async (requestedHeads: string[], options: any): Promise<any[]> => {
+                if (options.remote === false) {
+                    if (requestedHeads.includes(heads[0]!)) {
+                        return requestedHeads.map((head) =>
+                            entriesByHead.get(head)
+                        );
+                    }
+                    return requestedHeads.map(() => undefined);
+                }
+
+                remoteSignal = options.remote.signal;
+                markRemoteStarted();
+                return await new Promise<any[]>((_, reject) => {
+                    const abort = () => {
+                        remoteAborted = true;
+                        reject(
+                            remoteSignal?.reason ??
+                                new Error("manifest-head batch aborted")
+                        );
+                    };
+                    if (remoteSignal?.aborted) {
+                        abort();
+                    } else {
+                        remoteSignal?.addEventListener("abort", abort, {
+                            once: true,
+                        });
+                    }
+                });
+            }
+        );
+        (files.files.log.log as any).getMany = getMany;
+
+        const iterator = file.streamFile(files)[Symbol.asyncIterator]();
+        try {
+            const first = await iterator.next();
+            expect(first).toEqual({ done: false, value: new Uint8Array([1]) });
+            await Promise.race([
+                remoteStarted,
+                new Promise((_, reject) =>
+                    setTimeout(
+                        () =>
+                            reject(
+                                new Error("remote head batch did not start")
+                            ),
+                        1_000
+                    )
+                ),
+            ]);
+
+            const returnStartedAt = Date.now();
+            await iterator.return?.();
+            expect(Date.now() - returnStartedAt).toBeLessThan(500);
+            expect(remoteSignal).toBeInstanceOf(AbortSignal);
+            expect(remoteSignal?.aborted).toBe(true);
+            expect(remoteAborted).toBe(true);
+            expect((files as any).activeFileChangeSignals.size).toBe(0);
+            expect(perIndexGets).toEqual([]);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            expect(files.lastReadDiagnostics?.activeManifestHeadBatches).toBe(
+                0
+            );
+            expect(files.lastReadDiagnostics?.finalKnownChunkCount).toBe(0);
+        } finally {
+            await iterator.return?.();
+        }
+    });
+
+    it("caps slow fallbacks to one lookup-round budget and rotates strategy", async () => {
+        let now = 10_000;
+        const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+        const files = new Files();
+        const file = new LargeFile({
+            id: "round-budget",
+            name: "round-budget.bin",
+            size: 512n * 1024n,
+            chunkCount: 1,
+            ready: true,
+        });
+        (file as any).chunkEntryHeads = ["round-budget-head"];
+        const chunk = new TinyFile({
+            id: `${file.id}:0`,
+            name: `${file.name}/0`,
+            file: new Uint8Array([1]),
+            parentId: file.id,
+            index: 0,
+        });
+        const operations: string[] = [];
+        let waits = 0;
+        (files as any).getReadPeerHints = async () => ["writer"];
+        (files.files.log.log as any).get = async (
+            _head: string,
+            options: { remote: { timeout: number } }
+        ) => {
+            operations.push(`manifest:${options.remote.timeout}`);
+            now += options.remote.timeout;
+            return undefined;
+        };
+        (files.files.index as any).get = async (
+            _id: string,
+            options: { remote: false | { timeout: number } }
+        ) => {
+            if (options.remote === false) {
+                return undefined;
+            }
+            operations.push(`direct:${options.remote.timeout}`);
+            now += 25;
+            return chunk;
+        };
+        (files.files.index as any).search = async () => {
+            throw new Error("indexed fallback should not run");
+        };
+        const signal = createLookupSignal(() => {
+            waits += 1;
+        });
+        const debug: Record<string, any> = {};
+
+        try {
+            expect(await resolveSingleChunk(file, files, signal, debug)).toBe(
+                chunk
+            );
+        } finally {
+            nowSpy.mockRestore();
+        }
+
+        expect(operations).toEqual(["manifest:5000", "direct:5000"]);
+        expect(waits).toBe(1);
+        expect(debug.chunkAttempts[0]).toBe(2);
+        expect(now - 10_000).toBe(5_025);
+    });
+
+    it("rechecks local state after a slow round before another remote lookup", async () => {
+        let now = 20_000;
+        const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+        const files = new Files();
+        const file = new LargeFile({
+            id: "round-event",
+            name: "round-event.bin",
+            size: 512n * 1024n,
+            chunkCount: 1,
+            ready: true,
+        });
+        (file as any).chunkEntryHeads = ["round-event-head"];
+        const chunk = new TinyFile({
+            id: `${file.id}:0`,
+            name: `${file.name}/0`,
+            file: new Uint8Array([2]),
+            parentId: file.id,
+            index: 0,
+        });
+        let localAvailable = false;
+        let remoteCalls = 0;
+        (files as any).getReadPeerHints = async () => ["writer"];
+        (files.files.log.log as any).get = async (
+            _head: string,
+            options: { remote: { timeout: number } }
+        ) => {
+            remoteCalls += 1;
+            now += options.remote.timeout;
+            return undefined;
+        };
+        (files.files.index as any).get = async (
+            _id: string,
+            options: { remote: false | { timeout: number } }
+        ) => {
+            if (options.remote === false) {
+                return localAvailable ? chunk : undefined;
+            }
+            throw new Error("remote get should not run after local recovery");
+        };
+        const signal = createLookupSignal(() => {
+            localAvailable = true;
+        });
+        const debug: Record<string, any> = {};
+
+        try {
+            expect(await resolveSingleChunk(file, files, signal, debug)).toBe(
+                chunk
+            );
+        } finally {
+            nowSpy.mockRestore();
+        }
+
+        expect(remoteCalls).toBe(1);
+        expect(debug.chunkAttempts[0]).toBe(2);
+        expect(debug.chunkResolved[0]).toBe("local");
+    });
+
+    it("rotates from a slow deterministic miss to legacy indexed fields", async () => {
+        let now = 30_000;
+        const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+        const files = new Files();
+        const file = new LargeFile({
+            id: "legacy-round",
+            name: "legacy-round.bin",
+            size: 512n * 1024n,
+            chunkCount: 1,
+            ready: true,
+        });
+        const chunk = new TinyFile({
+            id: "legacy-random-id",
+            name: `${file.name}/0`,
+            file: new Uint8Array([3]),
+            parentId: file.id,
+            index: 0,
+        });
+        const operations: string[] = [];
+        (files as any).getReadPeerHints = async () => ["writer"];
+        (files.files.log.log as any).get = async () => {
+            throw new Error("a headless legacy file must not fetch a head");
+        };
+        (files.files.index as any).get = async (
+            _id: string,
+            options: { remote: false | { timeout: number } }
+        ) => {
+            if (options.remote === false) {
+                return undefined;
+            }
+            operations.push(`direct:${options.remote.timeout}`);
+            now += options.remote.timeout;
+            return undefined;
+        };
+        (files.files.index as any).search = async (
+            _request: unknown,
+            options: { remote: { timeout: number; from?: string[] } }
+        ) => {
+            operations.push(
+                `indexed:${options.remote.from ? "hinted" : "unhinted"}:${options.remote.timeout}`
+            );
+            now += 25;
+            return [chunk];
+        };
+        const signal = createLookupSignal();
+        const debug: Record<string, any> = {};
+
+        try {
+            expect(await resolveSingleChunk(file, files, signal, debug)).toBe(
+                chunk
+            );
+        } finally {
+            nowSpy.mockRestore();
+        }
+
+        expect(operations).toEqual(["direct:5000", "indexed:hinted:5000"]);
+        expect(debug.chunkAttempts[0]).toBe(2);
+        expect(debug.chunkResolved[0]).toBe("indexed-search");
+    });
+
+    it("propagates cancellation without starting the next fallback", async () => {
+        const files = new Files();
+        const file = new LargeFile({
+            id: "cancel-round",
+            name: "cancel-round.bin",
+            size: 512n * 1024n,
+            chunkCount: 1,
+            ready: true,
+        });
+        (file as any).chunkEntryHeads = ["cancel-round-head"];
+        const signal = createLookupSignal();
+        let directCalls = 0;
+        (files as any).getReadPeerHints = async () => ["writer"];
+        (files.files.index as any).get = async (
+            _id: string,
+            options: { remote: false | object }
+        ) => {
+            if (options.remote === false) {
+                return undefined;
+            }
+            directCalls += 1;
+            return undefined;
+        };
+        (files.files.log.log as any).get = async () => {
+            signal.close();
+            return undefined;
+        };
+
+        await expect(
+            resolveSingleChunk(file, files, signal, {})
+        ).rejects.toThrow("File read cancelled");
+        expect(directCalls).toBe(0);
+    });
+
+    it("checks cancellation before classifying a rejected abort error", async () => {
+        const files = new Files();
+        const file = new LargeFile({
+            id: "cancelled-abort-round",
+            name: "cancelled-abort-round.bin",
+            size: 512n * 1024n,
+            chunkCount: 1,
+            ready: true,
+        });
+        (file as any).chunkEntryHeads = ["cancelled-abort-head"];
+        const signal = createLookupSignal();
+        const lifecycle: string[] = [];
+        const originalThrowIfClosed = signal.throwIfClosed;
+        signal.throwIfClosed = () => {
+            lifecycle.push("throwIfClosed");
+            originalThrowIfClosed();
+        };
+        const abortError = new Error("lookup aborted");
+        Object.defineProperty(abortError, "name", {
+            get: () => {
+                lifecycle.push("classify");
+                return "AbortError";
+            },
+        });
+        let directCalls = 0;
+        (files as any).getReadPeerHints = async () => ["writer"];
+        (files.files.index as any).get = async (
+            _id: string,
+            options: { remote: false | object }
+        ) => {
+            if (options.remote === false) {
+                return undefined;
+            }
+            directCalls += 1;
+            return undefined;
+        };
+        (files.files.log.log as any).get = async () => {
+            lifecycle.length = 0;
+            signal.close();
+            throw abortError;
+        };
+
+        await expect(
+            resolveSingleChunk(file, files, signal, {})
+        ).rejects.toThrow("File read cancelled");
+        expect(lifecycle).toEqual(["throwIfClosed"]);
+        expect(directCalls).toBe(0);
+    });
+
+    it.each([
+        [
+            "nested aggregate",
+            new AggregateError(
+                [
+                    Object.assign(new Error("delivery failed"), {
+                        name: "DeliveryError",
+                    }),
+                    Object.assign(new Error("fanout channel closed"), {
+                        name: "AbortError",
+                    }),
+                ],
+                "All promises were rejected"
+            ),
+        ],
+        [
+            "empty aggregate",
+            new AggregateError([], "All promises were rejected"),
+        ],
+        [
+            "timeout",
+            Object.assign(new Error("request timed out"), {
+                name: "TimeoutError",
+            }),
+        ],
+        [
+            "not found name",
+            Object.assign(new Error("entry not found"), {
+                name: "NotFoundError",
+            }),
+        ],
+        [
+            "not found code",
+            Object.assign(new Error("entry not found"), {
+                code: "ERR_NOT_FOUND",
+            }),
+        ],
+    ])("retries a %s remote lookup failure", async (_label, retryableError) => {
+        const files = new Files();
+        const file = new LargeFile({
+            id: "aggregate-retry-round",
+            name: "aggregate-retry-round.bin",
+            size: 1n,
+            chunkCount: 1,
+            ready: true,
+        });
+        const chunk = new TinyFile({
+            id: `${file.id}:0`,
+            name: `${file.name}/0`,
+            file: new Uint8Array([7]),
+            parentId: file.id,
+            index: 0,
+        });
+        let indexedSearchCalls = 0;
+        (files as any).getReadPeerHints = async () => ["writer"];
+        (files.files.index as any).get = async (
+            _id: string,
+            options: { remote: false | object }
+        ) => {
+            if (options.remote === false) {
+                return undefined;
+            }
+            throw retryableError;
+        };
+        (files.files.index as any).search = async () => {
+            indexedSearchCalls += 1;
+            return [chunk];
+        };
+
+        await expect(
+            resolveSingleChunk(file, files, createLookupSignal(), {})
+        ).resolves.toBe(chunk);
+        expect(indexedSearchCalls).toBe(1);
+    });
+
+    it("does not retry a mixed aggregate containing a validation failure", async () => {
+        const files = new Files();
+        const file = new LargeFile({
+            id: "mixed-aggregate-round",
+            name: "mixed-aggregate-round.bin",
+            size: 1n,
+            chunkCount: 1,
+            ready: true,
+        });
+        const mixed = new AggregateError(
+            [
+                Object.assign(new Error("request timed out"), {
+                    name: "TimeoutError",
+                }),
+                new Error("invalid signed chunk payload"),
+            ],
+            "All promises were rejected"
+        );
+        const indexedSearch = vi.fn(async () => []);
+        (files as any).getReadPeerHints = async () => ["writer"];
+        (files.files.index as any).get = async (
+            _id: string,
+            options: { remote: false | object }
+        ) => {
+            if (options.remote === false) {
+                return undefined;
+            }
+            throw mixed;
+        };
+        (files.files.index as any).search = indexedSearch;
+
+        await expect(
+            resolveSingleChunk(file, files, createLookupSignal(), {})
+        ).rejects.toBe(mixed);
+        expect(indexedSearch).not.toHaveBeenCalled();
+    });
+
+    it("shares one deadline between pending-manifest search and direct get", async () => {
+        const startedAt = 40_000;
+        vi.useFakeTimers({ now: startedAt });
+        const files = new Files();
+        const pending = new LargeFile({
+            id: "pending-deadline",
+            name: "pending-deadline.bin",
+            size: 512n * 1024n,
+            chunkCount: 1,
+            ready: false,
+        });
+        const ready = new LargeFile({
+            id: pending.id,
+            name: pending.name,
+            size: pending.size,
+            chunkCount: pending.chunkCount,
+            ready: true,
+        });
+        (ready as any).chunkEntryHeads = ["pending-deadline-head"];
+        const operations: Array<{ operation: string; timeout: number }> = [];
+        const signal = createLookupSignal();
+        (files as any).getReadPeerHints = async () => ["writer"];
+        (files.files.index as any).search = async (
+            _request: unknown,
+            options: { remote: false | { timeout: number } }
+        ) => {
+            if (options.remote === false) {
+                return [];
+            }
+            operations.push({
+                operation: "search",
+                timeout: options.remote.timeout,
+            });
+            vi.advanceTimersByTime(4_000);
+            return [];
+        };
+        (files.files.index as any).get = async (
+            _id: string,
+            options: { remote: { timeout: number } }
+        ) => {
+            operations.push({
+                operation: "get",
+                timeout: options.remote.timeout,
+            });
+            return ready;
+        };
+
+        const diagnostics = { waitUntilReadyAttempts: 0 };
+        try {
+            expect(
+                await (pending as any).waitUntilReadyWithSignal(
+                    files,
+                    signal,
+                    {
+                        timeout: 30_000,
+                        persist: true,
+                    },
+                    diagnostics
+                )
+            ).toBe(ready);
+        } finally {
+            vi.useRealTimers();
+        }
+
+        expect(operations).toEqual([
+            { operation: "search", timeout: 5_000 },
+            { operation: "get", timeout: 1_000 },
+        ]);
+        expect(diagnostics.waitUntilReadyAttempts).toBe(1);
+    });
+
+    it("releases only the retained state associated with a deleted file", () => {
+        const files = new Files();
+        files.retainChunkRead("deleted:0");
+        files.retainChunkRead("kept:0");
+        files.retainChunkEntryHead("deleted-head", "deleted");
+        files.retainChunkEntryHead("kept-head", "kept");
+
+        files.releaseLargeFileRetention({ id: "deleted", chunkCount: 1 });
+
+        expect((files as any).retainedChunkIds).toEqual(new Set(["kept:0"]));
+        expect((files as any).retainedChunkEntryHeads).toEqual(
+            new Set(["kept-head"])
+        );
+    });
+
+    it("tracks huge claimed files in constant space and releases only seen ids", () => {
+        const files = new Files();
+        class GuardedSet extends Set<string> {
+            addCalls = 0;
+            deleteCalls = 0;
+
+            add(value: string) {
+                this.addCalls += 1;
+                if (this.addCalls > 2) {
+                    throw new Error("retention expanded claimed chunkCount");
+                }
+                return super.add(value);
+            }
+
+            delete(value: string) {
+                this.deleteCalls += 1;
+                if (this.deleteCalls > 2) {
+                    throw new Error("release looped over claimed chunkCount");
+                }
+                return super.delete(value);
+            }
+        }
+        const retainedIds = new GuardedSet();
+        (files as any).retainedChunkIds = retainedIds;
+        const file = new LargeFile({
+            id: "untrusted-huge",
+            name: "untrusted-huge.bin",
+            size: 1n,
+            chunkCount: 0xffffffff,
+            ready: true,
+        });
+
+        files.retainFileRead(file);
+        expect(retainedIds.addCalls).toBe(0);
+        expect((files as any).retainedLargeFileChunkCounts.get(file.id)).toBe(
+            file.chunkCount
+        );
+
+        files.retainChunkRead(`${file.id}:0`, file.id);
+        files.retainChunkRead("legacy-actual-id", file.id);
+        files.releaseLargeFileRetention(file);
+
+        expect(retainedIds.addCalls).toBe(2);
+        expect(retainedIds.deleteCalls).toBe(2);
+        expect(retainedIds.size).toBe(0);
+        expect((files as any).retainedLargeFileChunkCounts.size).toBe(0);
+        expect((files as any).retainedChunkIdsByFileId.size).toBe(0);
+    });
+
+    it("keeps TinyFile.delete as a no-op compatibility API", async () => {
+        const files = new Files();
+        const file = new TinyFile({
+            id: "retained-tiny-root",
+            name: "retained-tiny-root.bin",
+            file: new Uint8Array([1]),
+        });
+        files.retainChunkEntryHead("retained-tiny-head", file.id);
+
+        await file.delete();
+
+        expect((files as any).retainedChunkEntryHeads).toEqual(
+            new Set(["retained-tiny-head"])
+        );
+    });
+
+    it("commits a tiny root deletion before releasing its retention", async () => {
+        const files = new Files();
+        const file = new TinyFile({
+            id: "transactional-tiny-root",
+            name: "transactional-tiny-root.bin",
+            file: new Uint8Array([1]),
+        });
+        files.retainChunkEntryHead("transactional-tiny-head", file.id, file.id);
+        (files.files.index as any).get = async () => file;
+        let deleteCommitted = false;
+        (files.files as any).del = async () => {
+            expect((files as any).retainedChunkEntryHeads).toContain(
+                "transactional-tiny-head"
+            );
+            deleteCommitted = true;
+        };
+
+        await files.removeById(file.id);
+
+        expect(deleteCommitted).toBe(true);
+        expect((files as any).retainedChunkEntryHeads.size).toBe(0);
+    });
+
+    it("rejects an unknown remote deletion when no read peer is available", async () => {
+        const files = new Files();
+        (files.files.index as any).get = async () => undefined;
+        (files as any).getReadPeerHints = async () => undefined;
+
+        await expect(files.removeById("unknown-remote-root")).rejects.toThrow(
+            "no remote read peers are available"
+        );
+    });
+
+    it("propagates incomplete exact remote deletion confirmation", async () => {
+        const files = new Files();
+        (files.files.index as any).get = async () => undefined;
+        (files as any).getReadPeerHints = async () => ["writer-peer"];
+        (files.files.index as any).search = async (
+            _request: unknown,
+            options: any
+        ) => {
+            expect(options.remote.throwOnMissing).toBe(true);
+            throw new Error("missing selected peer response");
+        };
+
+        await expect(
+            files.removeById("unconfirmed-remote-root")
+        ).rejects.toThrow("missing selected peer response");
+    });
+
+    it("accepts an all-peer exact miss as an already-absent deletion", async () => {
+        const files = new Files();
+        (files.files.index as any).get = async () => undefined;
+        (files as any).getReadPeerHints = async () => ["writer-peer"];
+        (files.files.index as any).search = async () => [];
+
+        await expect(
+            files.removeById("confirmed-absent-remote-root")
+        ).resolves.toBeUndefined();
+    });
+
+    it("rejects when a confirmed remote root is not materialized locally", async () => {
+        const files = new Files();
+        const remoteRoot = new TinyFile({
+            id: "unmaterialized-remote-root",
+            name: "unmaterialized-remote-root.bin",
+            file: new Uint8Array([1]),
+        });
+        (files.files.index as any).get = async () => undefined;
+        (files as any).getReadPeerHints = async () => ["writer-peer"];
+        (files.files.index as any).search = async () => [remoteRoot];
+
+        await expect(files.removeById(remoteRoot.id)).rejects.toThrow(
+            "Failed to materialize current remote file"
+        );
+    });
+
+    it("preserves root retention when the target deletion fails", async () => {
+        const files = new Files();
+        const file = new LargeFile({
+            id: "failed-root-transaction",
+            name: "failed-root-transaction.bin",
+            size: 1n,
+            chunkCount: 1,
+            ready: true,
+        });
+        files.retainFileRead(file);
+        files.retainChunkRead(`${file.id}:0`, file.id);
+        files.retainChunkEntryHead("failed-root-head", file.id, file.id);
+        (files.files.index as any).get = async () => file;
+        (files.files as any).del = async () => {
+            throw new Error("root delete failed");
+        };
+        const fetchChunks = vi.spyOn(file, "fetchChunks").mockResolvedValue([]);
+
+        await expect(files.removeById(file.id)).rejects.toThrow(
+            "root delete failed"
+        );
+
+        expect(fetchChunks).not.toHaveBeenCalled();
+        expect((files as any).retainedLargeFileChunkCounts.get(file.id)).toBe(
+            1
+        );
+        expect((files as any).retainedChunkIds).toContain(`${file.id}:0`);
+        expect((files as any).retainedChunkEntryHeads).toContain(
+            "failed-root-head"
+        );
+    });
+
+    it("finishes cleanup when a rejected root deletion committed locally", async () => {
+        const files = new Files();
+        const file = withHead(
+            new LargeFile({
+                id: "postcommit-root-transaction",
+                name: "postcommit-root-transaction.bin",
+                size: 1n,
+                chunkCount: 1,
+                ready: true,
+            }),
+            "postcommit-root-head"
+        );
+        let current: LargeFile | undefined = file;
+        (files.files.index as any).get = async () => current;
+        (files.files as any).del = async () => {
+            current = undefined;
+            throw new Error("delivery failed after local delete");
+        };
+        vi.spyOn(file, "fetchChunks").mockResolvedValue([]);
+        files.retainFileRead(file);
+        files.retainChunkRead(`${file.id}:0`, file.id);
+        files.retainChunkEntryHead("postcommit-root-head", file.id, file.id);
+
+        await files.removeById(file.id);
+
+        expect((files as any).retainedLargeFileChunkCounts.size).toBe(0);
+        expect((files as any).retainedChunkIds.size).toBe(0);
+        expect((files as any).retainedChunkEntryHeads.size).toBe(0);
+    });
+
+    it("does not clean a concurrent replacement after a rejected deletion", async () => {
+        const files = new Files();
+        const target = withHead(
+            new LargeFile({
+                id: "replaced-root-transaction",
+                name: "old-root.bin",
+                size: 1n,
+                chunkCount: 1,
+                ready: true,
+            }),
+            "old-root-head"
+        );
+        const replacement = withHead(
+            new LargeFile({
+                id: target.id,
+                name: "replacement-root.bin",
+                size: 2n,
+                chunkCount: 2,
+                ready: true,
+            }),
+            "replacement-root-head"
+        );
+        let current: LargeFile = target;
+        (files.files.index as any).get = async () => current;
+        (files.files as any).del = async () => {
+            current = replacement;
+            throw new Error("delivery failed while replacement won");
+        };
+        const fetchChunks = vi
+            .spyOn(target, "fetchChunks")
+            .mockResolvedValue([]);
+        files.retainFileRead(target);
+        files.retainChunkRead(`${target.id}:0`, target.id);
+        files.retainChunkEntryHead("old-root-head", target.id, target.id);
+
+        await expect(files.removeById(target.id)).rejects.toThrow(
+            "delivery failed while replacement won"
+        );
+
+        expect(fetchChunks).not.toHaveBeenCalled();
+        expect((files as any).retainedLargeFileChunkCounts.get(target.id)).toBe(
+            1
+        );
+        expect((files as any).retainedChunkIds).toContain(`${target.id}:0`);
+        expect((files as any).retainedChunkEntryHeads).toContain(
+            "old-root-head"
+        );
+    });
+
+    it("allows a current hash to acquire new ownership after release", () => {
+        const files = new Files();
+        files.retainChunkEntryHead("released-head", "first", "first:0");
+
+        files.releaseChunkRetention("first", "first:0", "released-head");
+        files.retainChunkEntryHead("released-head", "second", "second:0");
+
+        expect((files as any).retainedChunkEntryHeads).toContain(
+            "released-head"
+        );
+        expect(
+            (files as any).retainedChunkEntryHeadOwners
+                .get("released-head")
+                .has("second")
+        ).toBe(true);
+    });
+
+    it("validates retained heads against the current local document head", async () => {
+        const files = new Files();
+        const currentByDocument = new Map<string, string | Error>([
+            ["current-doc", "current-head"],
+            ["stale-doc", "replacement-head"],
+            ["unknown-doc", new Error("local index unavailable")],
+        ]);
+        (files.files.index as any).get = async (documentId: string) => {
+            const result = currentByDocument.get(documentId);
+            if (result instanceof Error) {
+                throw result;
+            }
+            return result ? { __context: { head: result } } : undefined;
+        };
+        files.retainChunkEntryHead(
+            "current-head",
+            "current-group",
+            "current-doc"
+        );
+        files.retainChunkEntryHead("stale-head", "stale-group", "stale-doc");
+        // A legacy unscoped retain must not override a known stale document.
+        files.retainChunkEntryHead("stale-head");
+        files.retainChunkEntryHead(
+            "unknown-head",
+            "unknown-group",
+            "unknown-doc"
+        );
+
+        expect(
+            await (files as any).shouldKeepFileEntry({ hash: "current-head" })
+        ).toBe(true);
+        expect(
+            await (files as any).shouldKeepFileEntry({ hash: "unknown-head" })
+        ).toBe(true);
+        expect(
+            await (files as any).shouldKeepFileEntry({ hash: "stale-head" })
+        ).toBe(false);
+        expect((files as any).retainedChunkEntryHeads).not.toContain(
+            "stale-head"
+        );
+        expect((files as any).unscopedRetainedChunkEntryHeads).not.toContain(
+            "stale-head"
+        );
+    });
+
+    it("rebuilds child retention when a current child is evaluated before its parent", async () => {
+        const files = new Files();
+        const parent = withHead(
+            new LargeFile({
+                id: "child-first-parent",
+                name: "child-first-parent.bin",
+                size: 1n,
+                chunkCount: 1,
+                ready: true,
+            }),
+            "child-first-parent-head"
+        );
+        const child = withHead(
+            new TinyFile({
+                id: `${parent.id}:0`,
+                name: `${parent.name}/0`,
+                file: new Uint8Array([1]),
+                parentId: parent.id,
+                index: 0,
+            }),
+            "child-first-head"
+        );
+        (files.files.index as any).get = async (id: string) =>
+            id === child.id ? child : id === parent.id ? parent : undefined;
+        Object.defineProperty(files.files.index, "valueEncoding", {
+            configurable: true,
+            value: { decoder: () => child },
+        });
+
+        expect(
+            await (files as any).shouldKeepFileEntry(
+                createPutEntry(child, "child-first-head")
+            )
+        ).toBe(true);
+        expect((files as any).retainedLargeFileChunkCounts.get(parent.id)).toBe(
+            1
+        );
+        expect((files as any).retainedChunkIds).toContain(child.id);
+        expect((files as any).retainedChunkEntryHeads).toContain(
+            "child-first-head"
+        );
+    });
+
+    it("invalidates retained children after their parent is deleted or replaced", async () => {
+        for (const replacement of [
+            undefined,
+            new LargeFile({
+                id: "invalidated-parent",
+                name: "replacement-name.bin",
+                size: 1n,
+                chunkCount: 1,
+                ready: true,
+            }),
+        ]) {
+            const files = new Files();
+            const parent = new LargeFile({
+                id: "invalidated-parent",
+                name: "original-name.bin",
+                size: 1n,
+                chunkCount: 1,
+                ready: true,
+            });
+            const child = withHead(
+                new TinyFile({
+                    id: `${parent.id}:0`,
+                    name: `${parent.name}/0`,
+                    file: new Uint8Array([1]),
+                    parentId: parent.id,
+                    index: 0,
+                }),
+                "invalidated-child-head"
+            );
+            let currentParent: LargeFile | undefined = parent;
+            (files.files.index as any).get = async (id: string) =>
+                id === child.id
+                    ? child
+                    : id === parent.id
+                      ? currentParent
+                      : undefined;
+            Object.defineProperty(files.files.index, "valueEncoding", {
+                configurable: true,
+                value: { decoder: () => child },
+            });
+            const entry = createPutEntry(child, "invalidated-child-head");
+            expect(await (files as any).shouldKeepFileEntry(entry)).toBe(true);
+
+            currentParent = replacement;
+
+            expect(await (files as any).shouldKeepFileEntry(entry)).toBe(false);
+            expect(
+                (files as any).retainedLargeFileChunkCounts.has(parent.id)
+            ).toBe(false);
+            expect((files as any).retainedChunkIds).not.toContain(child.id);
+            expect((files as any).retainedChunkEntryHeads).not.toContain(
+                "invalidated-child-head"
+            );
+        }
+    });
+
+    it("rebuilds retention for a current legacy non-deterministic chunk id", async () => {
+        const files = new Files();
+        const parent = new LargeFile({
+            id: "legacy-parent",
+            name: "legacy-parent.bin",
+            size: 1n,
+            chunkCount: 1,
+            ready: true,
+        });
+        const child = withHead(
+            new TinyFile({
+                id: "legacy-random-chunk-id",
+                name: `${parent.name}/0`,
+                file: new Uint8Array([1]),
+                parentId: parent.id,
+                index: 0,
+            }),
+            "legacy-child-head"
+        );
+        (files.files.index as any).get = async (id: string) =>
+            id === child.id ? child : id === parent.id ? parent : undefined;
+        Object.defineProperty(files.files.index, "valueEncoding", {
+            configurable: true,
+            value: { decoder: () => child },
+        });
+
+        expect(
+            await (files as any).shouldKeepFileEntry(
+                createPutEntry(child, "legacy-child-head")
+            )
+        ).toBe(true);
+        expect((files as any).retainedChunkIds).toContain(child.id);
+        expect(
+            (files as any).retainedEntryHeadsByDocumentId.get(child.id)
+        ).toEqual(new Set(["legacy-child-head"]));
+    });
+
+    it("keeps shared and foreign-owned heads when another file releases", () => {
+        const files = new Files();
+        files.retainChunkEntryHead("shared-head", "first-file", "first-file:0");
+        files.retainChunkEntryHead(
+            "shared-head",
+            "second-file",
+            "second-file:0"
+        );
+        files.retainChunkEntryHead(
+            "foreign-head",
+            "foreign-file",
+            "foreign-file:0"
+        );
+
+        files.releaseLargeFileRetention({
+            id: "first-file",
+            chunkCount: 0xffffffff,
+            chunkEntryHeads: ["shared-head", "foreign-head"],
+        });
+
+        expect((files as any).retainedChunkEntryHeads).toContain("shared-head");
+        expect((files as any).retainedChunkEntryHeads).toContain(
+            "foreign-head"
+        );
+        expect(
+            (files as any).retainedChunkEntryHeadOwners
+                .get("shared-head")
+                .has("second-file")
+        ).toBe(true);
+
+        files.releaseLargeFileRetention({
+            id: "second-file",
+            chunkCount: 0xffffffff,
+        });
+        expect((files as any).retainedChunkEntryHeads).not.toContain(
+            "shared-head"
+        );
+        expect((files as any).retainedChunkEntryHeads).toContain(
+            "foreign-head"
+        );
+    });
+
+    it("releases only the deleted child document within its retained group", async () => {
+        const files = new Files();
+        const parent = new LargeFile({
+            id: "direct-child-parent",
+            name: "direct-child-parent.bin",
+            size: 2n,
+            chunkCount: 2,
+            ready: true,
+        });
+        const first = new TinyFile({
+            id: `${parent.id}:0`,
+            name: `${parent.name}/0`,
+            file: new Uint8Array([1]),
+            parentId: parent.id,
+            index: 0,
+        });
+        const second = new TinyFile({
+            id: `${parent.id}:1`,
+            name: `${parent.name}/1`,
+            file: new Uint8Array([2]),
+            parentId: parent.id,
+            index: 1,
+        });
+        Object.defineProperty(first, "__context", {
+            value: { head: "first-child-head" },
+        });
+        files.retainFileRead(parent);
+        files.retainChunkRead(first.id, parent.id);
+        files.retainChunkRead(second.id, parent.id);
+        files.retainChunkEntryHead("first-child-head", parent.id, first.id);
+        files.retainChunkEntryHead("second-child-head", parent.id, second.id);
+
+        (files.files.index as any).get = async () => first;
+        (files.files as any).del = async () => undefined;
+        await files.removeById(first.id);
+
+        expect((files as any).retainedLargeFileChunkCounts.get(parent.id)).toBe(
+            2
+        );
+        expect((files as any).retainedChunkIds).toEqual(new Set([second.id]));
+        expect((files as any).retainedChunkEntryHeads).toEqual(
+            new Set(["second-child-head"])
+        );
+    });
+
+    it("retires the pending root head without releasing its ready replacement", () => {
+        const files = new Files();
+        const root = new LargeFile({
+            id: "pending-ready-root",
+            name: "pending-ready-root.bin",
+            size: 1n,
+            chunkCount: 1,
+            ready: false,
+        });
+        files.retainChunkEntryHead("pending-root-head", root.id, root.id);
+        files.retainChunkEntryHead("ready-root-head", root.id, root.id);
+
+        (files as any).retireAuthoredFileEntry(root, "pending-root-head");
+
+        expect((files as any).retainedChunkEntryHeads).toEqual(
+            new Set(["ready-root-head"])
+        );
+    });
+
+    it("does not release retention from the public LargeFile.delete cleanup API", async () => {
+        const files = new Files();
+        const file = new LargeFile({
+            id: "failed-delete",
+            name: "failed-delete.bin",
+            size: 1n,
+            chunkCount: 0xffffffff,
+            ready: true,
+        });
+        files.retainFileRead(file);
+        files.retainChunkRead("failed-delete-legacy", file.id);
+        files.retainChunkEntryHead("failed-delete-head", file.id);
+        file.fetchChunks = async () => {
+            throw new Error("fetch failed");
+        };
+
+        await expect(file.delete(files)).rejects.toThrow("fetch failed");
+
+        expect((files as any).retainedLargeFileChunkCounts.get(file.id)).toBe(
+            file.chunkCount
+        );
+        expect((files as any).retainedChunkIds).toContain(
+            "failed-delete-legacy"
+        );
+        expect((files as any).retainedChunkEntryHeads).toContain(
+            "failed-delete-head"
+        );
+    });
+
+    it("preserves root retention until orphan cleanup retry succeeds", async () => {
+        const files = new Files();
+        const file = new LargeFile({
+            id: "failed-orphan-cleanup",
+            name: "failed-orphan-cleanup.bin",
+            size: 1n,
+            chunkCount: 0xffffffff,
+            ready: true,
+        });
+        files.retainFileRead(file);
+        files.retainChunkRead("failed-orphan-cleanup-legacy", file.id);
+        files.retainChunkEntryHead("failed-orphan-cleanup-head", file.id);
+        (files.files.index as any).get = async () => file;
+        let rootDeleted = false;
+        (files.files as any).del = async () => {
+            rootDeleted = true;
+        };
+        const fetchChunks = vi
+            .spyOn(file, "fetchChunks")
+            .mockImplementation(async () => {
+                expect(rootDeleted).toBe(true);
+                throw new Error("fetch failed");
+            });
+
+        await expect(files.removeById(file.id)).rejects.toThrow("fetch failed");
+
+        expect(rootDeleted).toBe(true);
+        expect((files as any).retainedLargeFileChunkCounts.get(file.id)).toBe(
+            file.chunkCount
+        );
+        expect((files as any).retainedChunkIds).toContain(
+            "failed-orphan-cleanup-legacy"
+        );
+        expect((files as any).retainedChunkEntryHeads).toContain(
+            "failed-orphan-cleanup-head"
+        );
+        expect((files as any).pendingLargeFileDeletions.has(file.id)).toBe(
+            true
+        );
+
+        fetchChunks.mockResolvedValue([]);
+        await files.removeById(file.id);
+
+        expect((files as any).retainedLargeFileChunkCounts.size).toBe(0);
+        expect((files as any).retainedChunkIds.size).toBe(0);
+        expect((files as any).retainedChunkEntryHeads.size).toBe(0);
+        expect((files as any).retainedEntryHeadsByFileId.size).toBe(0);
+        expect((files as any).pendingLargeFileDeletions.size).toBe(0);
+    });
+
+    it("releases failed-upload retention even when chunk deletion rejects", async () => {
+        const files = new Files();
+        const chunk = withHead(
+            new TinyFile({
+                id: "failed:0",
+                name: "failed/0",
+                file: new Uint8Array([1]),
+                parentId: "failed",
+                index: 0,
+            }),
+            "failed-head"
+        );
+        files.retainChunkRead(chunk.id);
+        files.retainChunkEntryHead("failed-head", "failed", chunk.id);
+
+        const originalGet = files.files.index.get.bind(files.files.index);
+        const originalLogGet = files.files.log.log.get.bind(
+            files.files.log.log
+        );
+        const originalDelete = files.files.del.bind(files.files);
+        (files.files.index as any).get = async () => chunk;
+        (files.files.log.log as any).get = async () => ({});
+        (files.files as any).del = async () => {
+            throw new Error("delete failed");
+        };
+
+        try {
+            await expect(
+                (files as any).cleanupChunkedUpload("failed", 1, [
+                    "failed-head",
+                ])
+            ).rejects.toThrow("delete failed");
+        } finally {
+            (files.files.index as any).get = originalGet;
+            (files.files.log.log as any).get = originalLogGet;
+            (files.files as any).del = originalDelete;
+        }
+
+        expect((files as any).retainedChunkIds.size).toBe(0);
+        expect((files as any).retainedChunkEntryHeads.size).toBe(0);
+    });
+
+    it("releases exact failed-upload heads while preserving unknown id retention", async () => {
+        const files = new Files();
+        files.retainChunkRead("failed-search:0");
+        files.retainChunkEntryHead(
+            "failed-search-head",
+            "failed-search",
+            "failed-search:0"
+        );
+        const originalGet = files.files.index.get.bind(files.files.index);
+        (files.files.index as any).get = async () => {
+            throw new Error("lookup failed");
+        };
+
+        try {
+            await expect(
+                (files as any).cleanupChunkedUpload("failed-search", 1, [
+                    "failed-search-head",
+                ])
+            ).rejects.toThrow("lookup failed");
+        } finally {
+            (files.files.index as any).get = originalGet;
+        }
+
+        expect((files as any).retainedChunkIds).toContain("failed-search:0");
+        expect((files as any).retainedChunkEntryHeads.size).toBe(0);
+    });
+});

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -5,8 +5,11 @@ import {
     SearchRequest,
     StringMatch,
     StringMatchMethod,
+    Or,
     IsNull,
     isPutOperation,
+    isDeleteOperation,
+    type DocumentsChange,
     type Operation,
 } from "@peerbit/document";
 import {
@@ -21,8 +24,11 @@ import { sha256Sync } from "@peerbit/crypto";
 import { TrustedNetwork } from "@peerbit/trusted-network";
 import { ReplicationOptions, SharedLog } from "@peerbit/shared-log";
 import { SHA256 } from "@stablelib/sha256";
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+import {
+    adaptRemotePersistedReadAhead,
+    getRemotePersistedReadAheadLimit,
+    REMOTE_PERSISTED_READ_AHEAD_MIN,
+} from "./read-scheduling.js";
 
 type RuntimeOpenProfileSample = {
     label: string;
@@ -165,28 +171,89 @@ const getErrorMessage = (error: unknown) =>
             ? (error as { message: string }).message
             : String(error);
 
-const isRetryableChunkLookupError = (error: unknown) => {
+const getErrorCode = (error: unknown) =>
+    typeof (error as { code?: unknown })?.code === "string"
+        ? (error as { code: string }).code
+        : undefined;
+
+const getContainedErrors = (error: unknown): unknown[] => {
+    const errors = (error as { errors?: unknown })?.errors;
+    if (Array.isArray(errors)) {
+        return errors;
+    }
+    if (
+        errors != null &&
+        typeof errors !== "string" &&
+        typeof (errors as { [Symbol.iterator]?: unknown })[Symbol.iterator] ===
+            "function"
+    ) {
+        try {
+            return Array.from(errors as Iterable<unknown>);
+        } catch {
+            return [];
+        }
+    }
+    return [];
+};
+
+const isRetryableChunkLookupError = (
+    error: unknown,
+    seen = new Set<unknown>()
+): boolean => {
+    if (seen.has(error)) {
+        return false;
+    }
+    seen.add(error);
     const name = getErrorName(error);
     const message = getErrorMessage(error);
-    return (
+    const code = getErrorCode(error);
+    const containedErrors = getContainedErrors(error);
+    if (
         name === "AbortError" ||
         name === "DeliveryError" ||
+        name === "TimeoutError" ||
+        name === "NotFoundError" ||
         name === "StreamStateError" ||
+        code === "ERR_NOT_FOUND" ||
+        (containedErrors.length === 0 &&
+            name === "AggregateError" &&
+            message.includes("All promises were rejected")) ||
         message.includes("fanout channel closed") ||
         message.includes("Failed to resolve block") ||
         message.includes("Failed to load entry from head") ||
         message.includes("Message did not have any valid receivers") ||
         message.includes("delivery acknowledges from all nodes")
+    ) {
+        return true;
+    }
+
+    return (
+        containedErrors.length > 0 &&
+        containedErrors.every((contained) =>
+            isRetryableChunkLookupError(contained, new Set(seen))
+        )
     );
 };
 
-const shouldRetryChunkLookupWithoutHints = (error: unknown) => {
+const shouldRetryChunkLookupWithoutHints = (
+    error: unknown,
+    seen = new Set<unknown>()
+): boolean => {
+    if (seen.has(error)) {
+        return false;
+    }
+    seen.add(error);
     const name = getErrorName(error);
     const message = getErrorMessage(error);
-    return (
+    if (
         name === "DeliveryError" ||
         message.includes("delivery acknowledges from all nodes") ||
         message.includes("Message did not have any valid receivers")
+    ) {
+        return true;
+    }
+    return getContainedErrors(error).some((contained) =>
+        shouldRetryChunkLookupWithoutHints(contained, new Set(seen))
     );
 };
 
@@ -195,14 +262,36 @@ type FileReadOptions = {
     progress?: (progress: number) => any;
 };
 
+type FileReadDiagnostics = Record<string, any>;
+
+type FileReadDiagnosticsContext = {
+    diagnostics?: FileReadDiagnostics;
+};
+
+const FILE_READ_DIAGNOSTICS_CONTEXT = Symbol("file-read-diagnostics-context");
+
+type InternalFileReadOptions = FileReadOptions & {
+    [FILE_READ_DIAGNOSTICS_CONTEXT]?: FileReadDiagnosticsContext;
+};
+
+type EffectiveFileReadOptions = FileReadOptions & {
+    persist: boolean;
+};
+
 type ChunkReadContext = {
     lastReadPeerHints?: string[];
     localChunkEntryHeads?: Map<string, string>;
     localChunkEntryHeadsScan?: Promise<Map<string, string>>;
+    fileChangeSignals?: Set<FileChangeSignal>;
 };
 
 export interface ReReadableChunkSource {
     size: bigint;
+    /**
+     * Yield Uint8Array data in any convenient geometry. Empty yields are
+     * ignored; large-file uploads coalesce and split all other yields into the
+     * requested chunk size while preserving byte order.
+     */
     readChunks(chunkSize: number): AsyncIterable<Uint8Array>;
 }
 
@@ -245,10 +334,22 @@ export abstract class AbstractFile {
         writable: ChunkWritable,
         properties?: FileReadOptions
     ) {
+        const internalProperties = properties as
+            | InternalFileReadOptions
+            | undefined;
+        const diagnosticsContext =
+            internalProperties?.[FILE_READ_DIAGNOSTICS_CONTEXT] ?? {};
+        const streamProperties: InternalFileReadOptions = {
+            ...properties,
+            [FILE_READ_DIAGNOSTICS_CONTEXT]: diagnosticsContext,
+        };
         let chunkIndex = 0;
         try {
-            for await (const chunk of this.streamFile(files, properties)) {
-                const debug = files.lastReadDiagnostics;
+            for await (const chunk of this.streamFile(
+                files,
+                streamProperties
+            )) {
+                const debug = diagnosticsContext.diagnostics;
                 if (debug) {
                     (debug.chunkWriteStartedAt ||= {})[chunkIndex] = Date.now();
                 }
@@ -297,16 +398,137 @@ export class IndexableFile {
     }
 }
 
+type FileChangePredicate = (file: AbstractFile) => boolean;
+
+class FileReadCancelledError extends Error {
+    constructor() {
+        super("File read cancelled");
+        this.name = "FileReadCancelledError";
+    }
+}
+
+/**
+ * A race-free, one-shot-friendly view of relevant Documents changes.
+ *
+ * The listener is installed before a lookup attempt starts. Callers snapshot
+ * the version before querying and then wait only if no matching change arrived
+ * in the meantime. The timeout remains necessary for observer reads because a
+ * non-replicating remote result does not produce a local Documents event.
+ */
+class FileChangeSignal {
+    private version = 0;
+    private closed = false;
+    private abortController = new AbortController();
+    private waiters = new Set<(changed: boolean) => void>();
+    private readonly listener = (
+        event: CustomEvent<DocumentsChange<AbstractFile, IndexableFile>>
+    ) => {
+        if (
+            ![...event.detail.added, ...event.detail.removed].some(
+                this.predicate
+            )
+        ) {
+            return;
+        }
+
+        this.version += 1;
+        for (const finish of [...this.waiters]) {
+            finish(true);
+        }
+    };
+
+    constructor(
+        private readonly events: Documents<
+            AbstractFile,
+            IndexableFile
+        >["events"],
+        private readonly predicate: FileChangePredicate,
+        private readonly onClose?: () => void
+    ) {
+        this.events.addEventListener("change", this.listener);
+    }
+
+    snapshot() {
+        return this.version;
+    }
+
+    get isClosed() {
+        return this.closed;
+    }
+
+    get abortSignal() {
+        return this.abortController.signal;
+    }
+
+    throwIfClosed() {
+        if (this.closed) {
+            throw new FileReadCancelledError();
+        }
+    }
+
+    waitForChangeAfter(version: number, timeoutMs: number): Promise<boolean> {
+        if (this.closed || this.version !== version) {
+            return Promise.resolve(!this.closed);
+        }
+        if (timeoutMs <= 0) {
+            return Promise.resolve(false);
+        }
+
+        return new Promise<boolean>((resolve) => {
+            let timer: ReturnType<typeof setTimeout> | undefined;
+            let settled = false;
+            const finish = (changed: boolean) => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                if (timer) {
+                    clearTimeout(timer);
+                }
+                this.waiters.delete(finish);
+                resolve(changed);
+            };
+
+            this.waiters.add(finish);
+            timer = setTimeout(() => finish(false), timeoutMs);
+
+            // Keep this check even though JavaScript runs synchronously here:
+            // alternate EventTarget implementations may dispatch re-entrantly
+            // while a listener is being registered.
+            if (this.closed) {
+                finish(false);
+            } else if (this.version !== version) {
+                finish(true);
+            }
+        });
+    }
+
+    close() {
+        if (this.closed) {
+            return;
+        }
+        this.closed = true;
+        this.abortController.abort(new FileReadCancelledError());
+        this.events.removeEventListener("change", this.listener);
+        for (const finish of [...this.waiters]) {
+            finish(false);
+        }
+        this.onClose?.();
+    }
+}
+
 const TINY_FILE_SIZE_LIMIT = 5 * 1e6; // 6mb
 const LARGE_FILE_SEGMENT_SIZE = TINY_FILE_SIZE_LIMIT / 10;
 const LARGE_FILE_TARGET_CHUNK_COUNT = 256;
 const CHUNK_SIZE_GRANULARITY = 64 * 1024;
 const MAX_LARGE_FILE_SEGMENT_SIZE = 512 * 1024;
 const LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS = 5 * 60 * 1000;
+const LARGE_FILE_CHUNK_BATCH_SPECULATIVE_TIMEOUT_MS = 1_500;
 const LARGE_FILE_PERSISTED_READ_AHEAD = 32;
-const LARGE_FILE_REMOTE_PERSISTED_READ_AHEAD = 2;
 const LARGE_FILE_OBSERVER_READ_AHEAD = 2;
-const LARGE_FILE_OBSERVER_PREFETCH_TIMEOUT_MS = 5_000;
+const LARGE_FILE_CHANGE_WAIT_FALLBACK_MS = 250;
+const LARGE_FILE_CHUNK_PUT_CONCURRENCY = 4;
+const LARGE_FILE_CHUNK_PUT_BYTE_LIMIT = 2 * 1024 * 1024;
 const LARGE_FILE_MIN_CHUNK_ATTEMPT_TIMEOUT_MS = 5_000;
 const LARGE_FILE_MAX_CHUNK_ATTEMPT_TIMEOUT_MS = 45_000;
 const LARGE_FILE_REMOTE_CHUNK_TIMEOUT_OVERHEAD_MS = 5_000;
@@ -344,6 +566,109 @@ const getChunkCount = (
     size: number | bigint,
     chunkSize = LARGE_FILE_SEGMENT_SIZE
 ) => Math.ceil(Number(size) / chunkSize);
+
+type InFlightWork = {
+    bytes: number;
+    promise: Promise<void>;
+};
+
+class BoundedAsyncWorkQueue {
+    private inFlight = new Set<InFlightWork>();
+    private inFlightBytes = 0;
+    private failed = false;
+    private failure: unknown;
+    private rejectFailureSignal!: (error: unknown) => void;
+    readonly failureSignal: Promise<never>;
+    peakCount = 0;
+    peakBytes = 0;
+
+    constructor(
+        readonly countLimit: number,
+        readonly byteLimit: number
+    ) {
+        this.failureSignal = new Promise<never>((_resolve, reject) => {
+            this.rejectFailureSignal = reject;
+        });
+        void this.failureSignal.catch(() => undefined);
+    }
+
+    private hasCapacity(bytes: number) {
+        return (
+            this.inFlight.size < this.countLimit &&
+            (this.inFlightBytes === 0 ||
+                this.inFlightBytes + bytes <= this.byteLimit)
+        );
+    }
+
+    throwIfFailed() {
+        if (this.failed) {
+            throw this.failure;
+        }
+    }
+
+    private async waitForCapacity(bytes: number) {
+        while (!this.hasCapacity(bytes)) {
+            this.throwIfFailed();
+            await Promise.race(
+                [...this.inFlight].map((work) =>
+                    work.promise.catch(() => undefined)
+                )
+            );
+        }
+        this.throwIfFailed();
+    }
+
+    async enqueue(bytes: number, task: () => Promise<void>) {
+        await this.waitForCapacity(bytes);
+        const work = {
+            bytes,
+            promise: Promise.resolve(),
+        } as InFlightWork;
+        this.inFlight.add(work);
+        this.inFlightBytes += bytes;
+        this.peakCount = Math.max(this.peakCount, this.inFlight.size);
+        this.peakBytes = Math.max(this.peakBytes, this.inFlightBytes);
+
+        let taskPromise: Promise<void>;
+        try {
+            // Invoke synchronously after reserving capacity so callers can copy
+            // reusable source buffers inside the reservation.
+            taskPromise = Promise.resolve(task());
+        } catch (error) {
+            taskPromise = Promise.reject(error);
+        }
+        work.promise = taskPromise
+            .catch((error) => {
+                if (!this.failed) {
+                    this.failed = true;
+                    this.failure = error;
+                    this.rejectFailureSignal(error);
+                }
+                throw error;
+            })
+            .finally(() => {
+                this.inFlight.delete(work);
+                this.inFlightBytes -= bytes;
+            });
+        // Callers intentionally do not await individual tasks. Attach a
+        // handler now while preserving the stored rejection for drain().
+        void work.promise.catch(() => undefined);
+    }
+
+    async settle() {
+        while (this.inFlight.size > 0) {
+            await Promise.allSettled(
+                [...this.inFlight].map((work) => work.promise)
+            );
+        }
+    }
+
+    async drain() {
+        await this.settle();
+        this.throwIfFailed();
+    }
+}
+
 const getChunkByteLength = (
     size: number | bigint,
     chunkCount: number,
@@ -354,18 +679,16 @@ const getChunkByteLength = (
     const start = index * estimatedChunkSize;
     return Math.max(0, Math.min(estimatedChunkSize, total - start));
 };
-const getChunkLookupAttemptTimeout = (
-    size: number | bigint,
-    chunkCount: number,
-    index: number,
+const getRemotePayloadAttemptTimeout = (
+    payloadBytes: number,
     totalTimeout: number
 ) => {
-    const chunkBytes = getChunkByteLength(size, chunkCount, index);
     const scaledTimeout =
-        chunkBytes > LARGE_FILE_REMOTE_CHUNK_TIMEOUT_SCALE_MIN_BYTES
+        payloadBytes > LARGE_FILE_REMOTE_CHUNK_TIMEOUT_SCALE_MIN_BYTES
             ? LARGE_FILE_REMOTE_CHUNK_TIMEOUT_OVERHEAD_MS +
               Math.ceil(
-                  (chunkBytes / LARGE_FILE_REMOTE_CHUNK_MIN_BYTES_PER_SECOND) *
+                  (payloadBytes /
+                      LARGE_FILE_REMOTE_CHUNK_MIN_BYTES_PER_SECOND) *
                       1000
               )
             : LARGE_FILE_MIN_CHUNK_ATTEMPT_TIMEOUT_MS;
@@ -377,6 +700,16 @@ const getChunkLookupAttemptTimeout = (
         )
     );
 };
+const getChunkLookupAttemptTimeout = (
+    size: number | bigint,
+    chunkCount: number,
+    index: number,
+    totalTimeout: number
+) =>
+    getRemotePayloadAttemptTimeout(
+        getChunkByteLength(size, chunkCount, index),
+        totalTimeout
+    );
 const getChunkId = (parentId: string, index: number) => `${parentId}:${index}`;
 const createUploadId = () => toBase64URL(randomBytes(16));
 const getEntryHash = (entry: unknown) =>
@@ -526,10 +859,16 @@ export class TinyFile extends AbstractFile {
         yield this.file;
     }
 
-    async delete(): Promise<void> {
-        // Do nothing, since no releated files where created
-    }
+    async delete(): Promise<void> {}
 }
+
+const isLargeFileChunk = (
+    value: unknown
+): value is TinyFile & { parentId: string; index: number } =>
+    value instanceof TinyFile && value.parentId != null && value.index != null;
+
+const getRetentionOwnerId = (file: AbstractFile) =>
+    isLargeFileChunk(file) ? file.parentId : file.id;
 
 @variant(1) // for versioning purposes
 export class LargeFile extends AbstractFile {
@@ -595,12 +934,24 @@ export class LargeFile extends AbstractFile {
                 }
             }
         };
+        const changeSignal = files.createFileChangeSignal(
+            (file) =>
+                file instanceof TinyFile &&
+                file.parentId === this.id &&
+                file.index != null
+        );
 
-        while (chunks.size < this.chunkCount && Date.now() < deadline) {
-            const before = chunks.size;
-            const remoteFrom = await files.getReadPeerHints();
-            recordChunks(
-                await files.files.index.search(
+        try {
+            while (
+                !changeSignal.isClosed &&
+                chunks.size < this.chunkCount &&
+                Date.now() < deadline
+            ) {
+                const changeVersion = changeSignal.snapshot();
+                const before = chunks.size;
+                const remoteFrom = await files.getReadPeerHints();
+                changeSignal.throwIfClosed();
+                const results = await files.files.index.search(
                     new SearchRequest({
                         query: new StringMatch({
                             key: "parentId",
@@ -610,6 +961,7 @@ export class LargeFile extends AbstractFile {
                     }),
                     {
                         local: true,
+                        signal: changeSignal.abortSignal,
                         remote: {
                             timeout: queryTimeout,
                             throwOnMissing: false,
@@ -620,17 +972,29 @@ export class LargeFile extends AbstractFile {
                             from: remoteFrom,
                         },
                     } as any
-                )
-            );
+                );
+                changeSignal.throwIfClosed();
+                recordChunks(results);
 
-            if (chunks.size === before && chunks.size < this.chunkCount) {
-                await sleep(250);
+                if (chunks.size === before && chunks.size < this.chunkCount) {
+                    await changeSignal.waitForChangeAfter(
+                        changeVersion,
+                        Math.min(
+                            LARGE_FILE_CHANGE_WAIT_FALLBACK_MS,
+                            Math.max(0, deadline - Date.now())
+                        )
+                    );
+                    changeSignal.throwIfClosed();
+                }
             }
-        }
 
-        return [...chunks.values()].sort(
-            (a, b) => (a.index || 0) - (b.index || 0)
-        );
+            changeSignal.throwIfClosed();
+            return [...chunks.values()].sort(
+                (a, b) => (a.index || 0) - (b.index || 0)
+            );
+        } finally {
+            changeSignal.close();
+        }
     }
     async delete(files: Files) {
         await Promise.all(
@@ -643,9 +1007,11 @@ export class LargeFile extends AbstractFile {
         index: number,
         knownChunks: Map<number, TinyFile>,
         readContext: ChunkReadContext,
-        properties?: {
+        changeSignal: FileChangeSignal,
+        properties: {
             timeout?: number;
             debug?: Record<string, any>;
+            persist: boolean;
         }
     ): Promise<TinyFile> {
         const totalTimeout =
@@ -661,28 +1027,33 @@ export class LargeFile extends AbstractFile {
             properties.debug.chunkAttemptTimeoutMs = attemptTimeout;
         }
         const chunkId = getChunkId(this.id, index);
-        if (files.persistChunkReads) {
-            files.retainChunkRead(chunkId);
+        if (properties.persist) {
+            files.retainChunkRead(chunkId, this.id);
         }
         let hintedDeliveryFailures = 0;
         let directMisses = 0;
         let retryableFailures = 0;
         let nextNonReplicatingReadAfterFailures = 3;
         let skipManifestHeadForChunk = false;
+        let triedUnhintedPersistedFields = false;
         const materializeLocalChunk = async (
             resolvedBy: string
         ): Promise<TinyFile | undefined> => {
             const chunk = await files.files.index.get(chunkId, {
                 local: true,
                 remote: false,
+                signal: changeSignal.abortSignal,
             });
+            changeSignal.throwIfClosed();
             if (
                 chunk instanceof TinyFile &&
                 chunk.parentId === this.id &&
                 chunk.index === index
             ) {
                 knownChunks.set(index, chunk);
-                files.retainResolvedChunk(chunk);
+                if (properties.persist) {
+                    files.retainResolvedChunk(chunk, properties.persist);
+                }
                 properties?.debug &&
                     ((properties.debug.chunkResolved ||= {})[index] =
                         resolvedBy);
@@ -690,7 +1061,8 @@ export class LargeFile extends AbstractFile {
             }
         };
         const resolveChunkByIndexedFields = async (
-            remoteFrom: string[] | undefined
+            remoteFrom: string[] | undefined,
+            timeout: number
         ): Promise<TinyFile | undefined> => {
             properties?.debug &&
                 ((properties.debug.chunkIndexedSearches ||= {})[index] =
@@ -716,15 +1088,21 @@ export class LargeFile extends AbstractFile {
                 }),
                 {
                     local: true,
+                    signal: changeSignal.abortSignal,
                     remote: {
-                        timeout: attemptTimeout,
+                        timeout,
+                        // Legacy chunk ids are resolved by parent/name. Once a
+                        // persisted local row materializes, do not keep waiting
+                        // on an unavailable writer during offline rereads.
+                        strategy: "fallback" as any,
                         throwOnMissing: false,
                         retryMissingResponses: false,
-                        replicate: files.persistChunkReads,
+                        replicate: properties.persist,
                         from: remoteFrom,
                     },
                 } as any
             );
+            changeSignal.throwIfClosed();
             const chunk = (chunks as unknown[]).find(
                 (candidate): candidate is TinyFile =>
                     candidate instanceof TinyFile &&
@@ -733,7 +1111,9 @@ export class LargeFile extends AbstractFile {
             );
             if (chunk) {
                 knownChunks.set(index, chunk);
-                files.retainResolvedChunk(chunk);
+                if (properties.persist) {
+                    files.retainResolvedChunk(chunk, properties.persist);
+                }
                 properties?.debug &&
                     ((properties.debug.chunkResolved ||= {})[index] =
                         "indexed-search");
@@ -741,7 +1121,8 @@ export class LargeFile extends AbstractFile {
             }
         };
         const resolveChunkByResolvedFields = async (
-            remoteFrom: string[] | undefined
+            remoteFrom: string[] | undefined,
+            timeout: number
         ): Promise<TinyFile | undefined> => {
             properties?.debug &&
                 ((properties.debug.chunkResolvedSearches ||= {})[index] =
@@ -767,8 +1148,9 @@ export class LargeFile extends AbstractFile {
                 }),
                 {
                     local: false,
+                    signal: changeSignal.abortSignal,
                     remote: {
-                        timeout: attemptTimeout,
+                        timeout,
                         throwOnMissing: false,
                         retryMissingResponses: false,
                         replicate: false,
@@ -776,6 +1158,7 @@ export class LargeFile extends AbstractFile {
                     },
                 } as any
             );
+            changeSignal.throwIfClosed();
             const chunk = (chunks as unknown[]).find(
                 (candidate): candidate is TinyFile =>
                     candidate instanceof TinyFile &&
@@ -784,7 +1167,9 @@ export class LargeFile extends AbstractFile {
             );
             if (chunk) {
                 knownChunks.set(index, chunk);
-                files.retainResolvedChunk(chunk);
+                if (properties.persist) {
+                    files.retainResolvedChunk(chunk, properties.persist);
+                }
                 properties?.debug &&
                     ((properties.debug.chunkResolved ||= {})[index] =
                         "resolved-search");
@@ -793,12 +1178,14 @@ export class LargeFile extends AbstractFile {
         };
         const resolveChunkByDirectGet = async (
             remoteFrom: string[] | undefined,
-            replicate: boolean
+            replicate: boolean,
+            timeout: number
         ): Promise<TinyFile | undefined> => {
             const chunk = await files.files.index.get(chunkId, {
                 local: true,
+                signal: changeSignal.abortSignal,
                 remote: {
-                    timeout: attemptTimeout,
+                    timeout,
                     // Exact chunk reads must still ask the hinted remote when
                     // a local indexed row exists but its payload blocks are no
                     // longer materializable locally.
@@ -809,6 +1196,7 @@ export class LargeFile extends AbstractFile {
                     from: remoteFrom,
                 },
             });
+            changeSignal.throwIfClosed();
 
             if (
                 chunk instanceof TinyFile &&
@@ -816,7 +1204,9 @@ export class LargeFile extends AbstractFile {
                 chunk.index === index
             ) {
                 knownChunks.set(index, chunk);
-                files.retainResolvedChunk(chunk);
+                if (properties.persist) {
+                    files.retainResolvedChunk(chunk, properties.persist);
+                }
                 properties?.debug &&
                     ((properties.debug.chunkResolved ||= {})[index] = replicate
                         ? "remote-get"
@@ -825,7 +1215,8 @@ export class LargeFile extends AbstractFile {
             }
         };
         const resolveChunkByManifestEntryHead = async (
-            remoteFrom: string[] | undefined
+            remoteFrom: string[] | undefined,
+            timeout: number
         ): Promise<TinyFile | undefined> => {
             if (skipManifestHeadForChunk) {
                 return;
@@ -836,24 +1227,23 @@ export class LargeFile extends AbstractFile {
             if (typeof head !== "string") {
                 return;
             }
-            files.retainChunkEntryHead(head);
             properties?.debug &&
                 ((properties.debug.chunkManifestHeads ||= {})[index] = head);
 
             const entry = await files.files.log.log.get(head, {
                 remote: {
-                    timeout: attemptTimeout,
+                    timeout,
                     throwOnMissing: false,
                     retryMissingResponses: false,
-                    replicate: files.persistChunkReads,
+                    replicate: properties.persist,
                     from: remoteFrom,
+                    signal: changeSignal.abortSignal,
                 } as any,
             });
+            changeSignal.throwIfClosed();
             if (!entry) {
                 properties?.debug &&
-                    ((properties.debug.chunkManifestHeadMisses ||= {})[
-                        index
-                    ] =
+                    ((properties.debug.chunkManifestHeadMisses ||= {})[index] =
                         ((properties.debug.chunkManifestHeadMisses ||= {})[
                             index
                         ] ?? 0) + 1);
@@ -861,6 +1251,7 @@ export class LargeFile extends AbstractFile {
             }
 
             const operation = await entry.getPayloadValue();
+            changeSignal.throwIfClosed();
             if (!isPutOperation(operation)) {
                 return;
             }
@@ -872,8 +1263,13 @@ export class LargeFile extends AbstractFile {
                 chunk.parentId === this.id &&
                 chunk.index === index
             ) {
+                if (properties.persist) {
+                    files.retainChunkEntryHead(head, this.id, chunk.id);
+                }
                 knownChunks.set(index, chunk);
-                files.retainResolvedChunk(chunk);
+                if (properties.persist) {
+                    files.retainResolvedChunk(chunk, properties.persist);
+                }
                 properties?.debug &&
                     ((properties.debug.chunkResolved ||= {})[index] =
                         "manifest-head-get");
@@ -881,16 +1277,44 @@ export class LargeFile extends AbstractFile {
             }
         };
         const resolveChunkWithoutPersisting = async (
-            remoteFrom: string[] | undefined
+            remoteFrom: string[] | undefined,
+            timeout: number
         ): Promise<TinyFile | undefined> => {
             properties?.debug &&
                 ((properties.debug.chunkNonReplicatingGets ||= {})[index] =
                     ((properties.debug.chunkNonReplicatingGets ||= {})[index] ??
                         0) + 1);
-            return resolveChunkByDirectGet(remoteFrom, false);
+            return resolveChunkByDirectGet(remoteFrom, false, timeout);
         };
 
-        while (Date.now() < deadline) {
+        type LookupStrategy =
+            | "manifest-head"
+            | "deterministic-id"
+            | "indexed-fields"
+            | "unhinted-indexed-fields";
+        // Every remote primitive can consume its full timeout. Keep one shared
+        // deadline per lookup round so fallbacks cannot multiply a transient
+        // five-second stall into 20-30 seconds. The cursor resumes at the next
+        // strategy after a budget-consuming call, preserving legacy/indexed
+        // recovery without letting one slow route monopolize every retry.
+        const lookupStrategies: LookupStrategy[] = [
+            "manifest-head",
+            "deterministic-id",
+            "indexed-fields",
+            "unhinted-indexed-fields",
+        ];
+        let nextLookupStrategyIndex = 0;
+        const getRemainingRoundTimeout = (roundDeadline: number) => {
+            const remaining = Math.min(deadline, roundDeadline) - Date.now();
+            return remaining > 0 ? Math.max(1, Math.floor(remaining)) : 0;
+        };
+
+        while (!changeSignal.isClosed && Date.now() < deadline) {
+            const changeVersion = changeSignal.snapshot();
+            const roundDeadline = Math.min(
+                deadline,
+                Date.now() + attemptTimeout
+            );
             properties?.debug &&
                 ((properties.debug.chunkAttempts ||= {})[index] =
                     ((properties.debug.chunkAttempts ||= {})[index] ?? 0) + 1);
@@ -906,6 +1330,7 @@ export class LargeFile extends AbstractFile {
                     return localChunk;
                 }
             } catch (error) {
+                changeSignal.throwIfClosed();
                 skipManifestHeadForChunk = true;
                 if (!isRetryableChunkLookupError(error)) {
                     properties?.debug &&
@@ -922,6 +1347,7 @@ export class LargeFile extends AbstractFile {
                         getErrorMessage(error));
             }
             const candidateReadPeerHints = await files.getReadPeerHints();
+            changeSignal.throwIfClosed();
             if (candidateReadPeerHints) {
                 readContext.lastReadPeerHints = candidateReadPeerHints;
             }
@@ -936,90 +1362,174 @@ export class LargeFile extends AbstractFile {
                     remoteFrom ?? null;
             }
 
-            try {
-                const chunk = await resolveChunkByManifestEntryHead(remoteFrom);
-                if (chunk) {
-                    return chunk;
+            for (
+                let attemptedStrategies = 0;
+                attemptedStrategies < lookupStrategies.length;
+                attemptedStrategies++
+            ) {
+                const remainingRoundTimeout =
+                    getRemainingRoundTimeout(roundDeadline);
+                if (remainingRoundTimeout <= 0) {
+                    break;
                 }
-            } catch (error) {
-                if (!isRetryableChunkLookupError(error)) {
-                    properties?.debug &&
-                        (properties.debug.chunkFailure = {
-                            index,
-                            type: "non-retryable-manifest-head-get",
-                            message: getErrorMessage(error),
-                        });
-                    throw error;
-                }
-                if (remoteFrom && shouldRetryChunkLookupWithoutHints(error)) {
-                    hintedDeliveryFailures += 1;
-                }
-                retryableFailures += 1;
-                properties?.debug &&
-                    ((properties.debug.chunkRetryableManifestHeadGetErrors ||=
-                        {})[index] = getErrorMessage(error));
-            }
+                const strategy =
+                    lookupStrategies[
+                        nextLookupStrategyIndex % lookupStrategies.length
+                    ];
+                nextLookupStrategyIndex =
+                    (nextLookupStrategyIndex + 1) % lookupStrategies.length;
 
-            try {
-                const chunk = await resolveChunkByDirectGet(
-                    remoteFrom,
-                    files.persistChunkReads
-                );
-                if (chunk instanceof TinyFile) {
-                    return chunk;
+                if (
+                    strategy === "unhinted-indexed-fields" &&
+                    (!properties.persist ||
+                        !remoteFrom ||
+                        triedUnhintedPersistedFields)
+                ) {
+                    continue;
                 }
-                properties?.debug &&
-                    ((properties.debug.chunkGetMisses ||= {})[index] =
-                        ((properties.debug.chunkGetMisses ||= {})[index] ?? 0) +
-                        1);
-                directMisses += 1;
-            } catch (error) {
-                if (!isRetryableChunkLookupError(error)) {
-                    properties?.debug &&
-                        (properties.debug.chunkFailure = {
-                            index,
-                            type: "non-retryable",
-                            message: getErrorMessage(error),
-                        });
-                    throw error;
-                }
-                if (remoteFrom && shouldRetryChunkLookupWithoutHints(error)) {
-                    hintedDeliveryFailures += 1;
-                }
-                retryableFailures += 1;
-                properties?.debug &&
-                    ((properties.debug.chunkRetryableErrors ||= {})[index] =
-                        getErrorMessage(error));
-            }
 
-            try {
-                const chunk = await resolveChunkByIndexedFields(remoteFrom);
-                if (chunk) {
-                    return chunk;
+                if (strategy === "manifest-head") {
+                    try {
+                        const chunk = await resolveChunkByManifestEntryHead(
+                            remoteFrom,
+                            remainingRoundTimeout
+                        );
+                        if (chunk) {
+                            return chunk;
+                        }
+                    } catch (error) {
+                        changeSignal.throwIfClosed();
+                        if (!isRetryableChunkLookupError(error)) {
+                            properties?.debug &&
+                                (properties.debug.chunkFailure = {
+                                    index,
+                                    type: "non-retryable-manifest-head-get",
+                                    message: getErrorMessage(error),
+                                });
+                            throw error;
+                        }
+                        if (
+                            remoteFrom &&
+                            shouldRetryChunkLookupWithoutHints(error)
+                        ) {
+                            hintedDeliveryFailures += 1;
+                        }
+                        retryableFailures += 1;
+                        properties?.debug &&
+                            ((properties.debug.chunkRetryableManifestHeadGetErrors ||=
+                                {})[index] = getErrorMessage(error));
+                    }
+                    continue;
                 }
-            } catch (error) {
-                if (!isRetryableChunkLookupError(error)) {
-                    properties?.debug &&
-                        (properties.debug.chunkFailure = {
-                            index,
-                            type: "non-retryable-indexed-search",
-                            message: getErrorMessage(error),
-                        });
-                    throw error;
+
+                if (strategy === "deterministic-id") {
+                    try {
+                        const chunk = await resolveChunkByDirectGet(
+                            remoteFrom,
+                            properties.persist,
+                            remainingRoundTimeout
+                        );
+                        if (chunk instanceof TinyFile) {
+                            return chunk;
+                        }
+                        properties?.debug &&
+                            ((properties.debug.chunkGetMisses ||= {})[index] =
+                                ((properties.debug.chunkGetMisses ||= {})[
+                                    index
+                                ] ?? 0) + 1);
+                        directMisses += 1;
+                    } catch (error) {
+                        changeSignal.throwIfClosed();
+                        if (!isRetryableChunkLookupError(error)) {
+                            properties?.debug &&
+                                (properties.debug.chunkFailure = {
+                                    index,
+                                    type: "non-retryable",
+                                    message: getErrorMessage(error),
+                                });
+                            throw error;
+                        }
+                        if (
+                            remoteFrom &&
+                            shouldRetryChunkLookupWithoutHints(error)
+                        ) {
+                            hintedDeliveryFailures += 1;
+                        }
+                        retryableFailures += 1;
+                        properties?.debug &&
+                            ((properties.debug.chunkRetryableErrors ||= {})[
+                                index
+                            ] = getErrorMessage(error));
+                    }
+                    continue;
                 }
-                if (remoteFrom && shouldRetryChunkLookupWithoutHints(error)) {
-                    hintedDeliveryFailures += 1;
+
+                if (strategy === "indexed-fields") {
+                    try {
+                        const chunk = await resolveChunkByIndexedFields(
+                            remoteFrom,
+                            remainingRoundTimeout
+                        );
+                        if (chunk) {
+                            return chunk;
+                        }
+                    } catch (error) {
+                        changeSignal.throwIfClosed();
+                        if (!isRetryableChunkLookupError(error)) {
+                            properties?.debug &&
+                                (properties.debug.chunkFailure = {
+                                    index,
+                                    type: "non-retryable-indexed-search",
+                                    message: getErrorMessage(error),
+                                });
+                            throw error;
+                        }
+                        if (
+                            remoteFrom &&
+                            shouldRetryChunkLookupWithoutHints(error)
+                        ) {
+                            hintedDeliveryFailures += 1;
+                        }
+                        retryableFailures += 1;
+                        properties?.debug &&
+                            ((properties.debug.chunkRetryableSearchErrors ||=
+                                {})[index] = getErrorMessage(error));
+                    }
+                    continue;
                 }
-                retryableFailures += 1;
+
+                triedUnhintedPersistedFields = true;
                 properties?.debug &&
-                    ((properties.debug.chunkRetryableSearchErrors ||= {})[
+                    ((properties.debug.chunkUnhintedPersistedSearches ||= {})[
                         index
-                    ] = getErrorMessage(error));
+                    ] = true);
+                try {
+                    const chunk = await resolveChunkByIndexedFields(
+                        undefined,
+                        remainingRoundTimeout
+                    );
+                    if (chunk) {
+                        properties?.debug &&
+                            ((properties.debug.chunkResolved ||= {})[index] =
+                                "unhinted-persisted-indexed-search");
+                        return chunk;
+                    }
+                } catch (error) {
+                    changeSignal.throwIfClosed();
+                    if (!isRetryableChunkLookupError(error)) {
+                        throw error;
+                    }
+                    retryableFailures += 1;
+                    properties?.debug &&
+                        ((properties.debug.chunkRetryableUnhintedPersistedSearchErrors ||=
+                            {})[index] = getErrorMessage(error));
+                }
             }
 
             if (
                 directMisses + retryableFailures >=
-                nextNonReplicatingReadAfterFailures
+                    nextNonReplicatingReadAfterFailures &&
+                getRemainingRoundTimeout(roundDeadline) > 0
             ) {
                 // A miss is not evidence that a peer hint is stale. Keep using
                 // the known writer/replicator hint for direct reads unless a
@@ -1028,17 +1538,28 @@ export class LargeFile extends AbstractFile {
                     remoteFrom ??
                     readContext.lastReadPeerHints ??
                     (await files.getReadPeerHints());
+                changeSignal.throwIfClosed();
                 const remoteSources = sourceHints
                     ? [undefined, sourceHints]
                     : [undefined];
+                let attemptedNonReplicatingLookup = false;
                 for (const sourceFrom of remoteSources) {
+                    const remainingRoundTimeout =
+                        getRemainingRoundTimeout(roundDeadline);
+                    if (remainingRoundTimeout <= 0) {
+                        break;
+                    }
+                    attemptedNonReplicatingLookup = true;
                     try {
-                        const chunk =
-                            await resolveChunkWithoutPersisting(sourceFrom);
+                        const chunk = await resolveChunkWithoutPersisting(
+                            sourceFrom,
+                            remainingRoundTimeout
+                        );
                         if (chunk) {
                             return chunk;
                         }
                     } catch (error) {
+                        changeSignal.throwIfClosed();
                         if (!isRetryableChunkLookupError(error)) {
                             properties?.debug &&
                                 (properties.debug.chunkFailure = {
@@ -1061,13 +1582,22 @@ export class LargeFile extends AbstractFile {
                     }
                 }
                 for (const sourceFrom of remoteSources) {
+                    const remainingRoundTimeout =
+                        getRemainingRoundTimeout(roundDeadline);
+                    if (remainingRoundTimeout <= 0) {
+                        break;
+                    }
+                    attemptedNonReplicatingLookup = true;
                     try {
-                        const chunk =
-                            await resolveChunkByResolvedFields(sourceFrom);
+                        const chunk = await resolveChunkByResolvedFields(
+                            sourceFrom,
+                            remainingRoundTimeout
+                        );
                         if (chunk) {
                             return chunk;
                         }
                     } catch (error) {
+                        changeSignal.throwIfClosed();
                         if (!isRetryableChunkLookupError(error)) {
                             properties?.debug &&
                                 (properties.debug.chunkFailure = {
@@ -1089,12 +1619,22 @@ export class LargeFile extends AbstractFile {
                                 {})[index] = getErrorMessage(error));
                     }
                 }
-                nextNonReplicatingReadAfterFailures *= 2;
+                if (attemptedNonReplicatingLookup) {
+                    nextNonReplicatingReadAfterFailures *= 2;
+                }
             }
 
-            await sleep(250);
+            await changeSignal.waitForChangeAfter(
+                changeVersion,
+                Math.min(
+                    LARGE_FILE_CHANGE_WAIT_FALLBACK_MS,
+                    Math.max(0, deadline - Date.now())
+                )
+            );
+            changeSignal.throwIfClosed();
         }
 
+        changeSignal.throwIfClosed();
         throw new Error(
             `Failed to resolve chunk ${index + 1}/${this.chunkCount} for file ${this.id}`
         );
@@ -1102,23 +1642,44 @@ export class LargeFile extends AbstractFile {
 
     private async waitUntilReady(
         files: Files,
-        properties?: FileReadOptions
+        properties: EffectiveFileReadOptions,
+        debug: FileReadDiagnostics
     ): Promise<LargeFile> {
         if (this.ready) {
             return this;
         }
 
+        const changeSignal = files.createFileChangeSignal(
+            (file) => file.id === this.id
+        );
+        try {
+            return await this.waitUntilReadyWithSignal(
+                files,
+                changeSignal,
+                properties,
+                debug
+            );
+        } finally {
+            changeSignal.close();
+        }
+    }
+
+    private async waitUntilReadyWithSignal(
+        files: Files,
+        changeSignal: FileChangeSignal,
+        properties: EffectiveFileReadOptions,
+        debug: FileReadDiagnostics
+    ): Promise<LargeFile> {
         const totalTimeout =
             properties?.timeout ?? LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS;
         const deadline = Date.now() + totalTimeout;
         const attemptTimeout = Math.min(totalTimeout, 5_000);
 
-        while (Date.now() < deadline) {
-            const debug = files.lastReadDiagnostics;
-            if (debug) {
-                debug.waitUntilReadyAttempts += 1;
-            }
+        while (!changeSignal.isClosed && Date.now() < deadline) {
+            const changeVersion = changeSignal.snapshot();
+            debug.waitUntilReadyAttempts += 1;
             const remoteFrom = await files.getReadPeerHints();
+            changeSignal.throwIfClosed();
             const request = new SearchRequest({
                 query: new StringMatch({
                     key: "id",
@@ -1149,7 +1710,9 @@ export class LargeFile extends AbstractFile {
             const localMatches = await files.files.index.search(request, {
                 local: true,
                 remote: false,
+                signal: changeSignal.abortSignal,
             } as any);
+            changeSignal.throwIfClosed();
             const localLatest = pickLatest(localMatches);
             const thisCandidate = toReadableLargeFile(this) ?? this;
             const localCandidate = toReadableLargeFile(localLatest);
@@ -1176,23 +1739,37 @@ export class LargeFile extends AbstractFile {
                 }
                 return localReady;
             }
+            const attemptDeadline = Math.min(
+                deadline,
+                Date.now() + attemptTimeout
+            );
+            const getRemainingAttemptTimeout = () => {
+                const remaining = attemptDeadline - Date.now();
+                return remaining > 0 ? Math.max(1, Math.floor(remaining)) : 0;
+            };
             let remoteMatches: AbstractFile[] = [];
-            try {
-                remoteMatches = await files.files.index.search(request, {
-                    local: false,
-                    remote: {
-                        timeout: attemptTimeout,
-                        throwOnMissing: false,
-                        retryMissingResponses: true,
-                        replicate: files.persistChunkReads,
-                        from: remoteFrom,
-                    },
-                } as any);
-            } catch (error) {
-                if (debug) {
-                    (debug.readyRemoteSearchErrors ||= []).push(
-                        getErrorMessage(error)
-                    );
+            const remoteSearchTimeout = getRemainingAttemptTimeout();
+            if (remoteSearchTimeout > 0) {
+                try {
+                    remoteMatches = await files.files.index.search(request, {
+                        local: false,
+                        signal: changeSignal.abortSignal,
+                        remote: {
+                            timeout: remoteSearchTimeout,
+                            throwOnMissing: false,
+                            retryMissingResponses: true,
+                            replicate: properties.persist,
+                            from: remoteFrom,
+                        },
+                    } as any);
+                    changeSignal.throwIfClosed();
+                } catch (error) {
+                    changeSignal.throwIfClosed();
+                    if (debug) {
+                        (debug.readyRemoteSearchErrors ||= []).push(
+                            getErrorMessage(error)
+                        );
+                    }
                 }
             }
             const remoteLatest = pickLatest(remoteMatches);
@@ -1207,45 +1784,54 @@ export class LargeFile extends AbstractFile {
                 }
                 return remoteReady;
             }
-            try {
-                const directRemote = await files.files.index.get(this.id, {
-                    local: false,
-                    remote: {
-                        timeout: attemptTimeout,
-                        strategy: "always" as any,
-                        throwOnMissing: false,
-                        retryMissingResponses: true,
-                        replicate: files.persistChunkReads,
-                        from: remoteFrom,
-                    },
-                });
-                let directReady = toReadableLargeFile(directRemote);
-                let directReadySource = "ready-manifest-get";
-                if (debug?.lastReadyProbe && isLargeFileLike(directRemote)) {
-                    debug.lastReadyProbe.ready = directRemote.ready;
-                }
-                if (debug?.lastReadyProbe && directReady) {
-                    debug.lastReadyProbe.ready = directReady.ready;
-                }
-                if (directReady?.ready) {
-                    if (debug) {
-                        debug.waitUntilReadyResolvedBy = directReadySource;
+            const directGetTimeout = getRemainingAttemptTimeout();
+            if (directGetTimeout > 0) {
+                try {
+                    const directRemote = await files.files.index.get(this.id, {
+                        local: false,
+                        signal: changeSignal.abortSignal,
+                        remote: {
+                            timeout: directGetTimeout,
+                            strategy: "always" as any,
+                            throwOnMissing: false,
+                            retryMissingResponses: true,
+                            replicate: properties.persist,
+                            from: remoteFrom,
+                        },
+                    });
+                    changeSignal.throwIfClosed();
+                    const directReady = toReadableLargeFile(directRemote);
+                    const directReadySource = "ready-manifest-get";
+                    if (
+                        debug?.lastReadyProbe &&
+                        isLargeFileLike(directRemote)
+                    ) {
+                        debug.lastReadyProbe.ready = directRemote.ready;
                     }
-                    return directReady;
-                }
-                if (
-                    directReady &&
-                    (!remoteReady ||
-                        hasChunkEntryHeads(directReady) ||
-                        !hasChunkEntryHeads(remoteReady))
-                ) {
-                    remoteReady = directReady;
-                }
-            } catch (error) {
-                if (debug) {
-                    (debug.readyRemoteGetErrors ||= []).push(
-                        getErrorMessage(error)
-                    );
+                    if (debug?.lastReadyProbe && directReady) {
+                        debug.lastReadyProbe.ready = directReady.ready;
+                    }
+                    if (directReady?.ready) {
+                        if (debug) {
+                            debug.waitUntilReadyResolvedBy = directReadySource;
+                        }
+                        return directReady;
+                    }
+                    if (
+                        directReady &&
+                        (!remoteReady ||
+                            hasChunkEntryHeads(directReady) ||
+                            !hasChunkEntryHeads(remoteReady))
+                    ) {
+                        remoteReady = directReady;
+                    }
+                } catch (error) {
+                    changeSignal.throwIfClosed();
+                    if (debug) {
+                        (debug.readyRemoteGetErrors ||= []).push(
+                            getErrorMessage(error)
+                        );
+                    }
                 }
             }
             const countCandidate =
@@ -1258,6 +1844,7 @@ export class LargeFile extends AbstractFile {
             const localChunkCount = await files
                 .countLocalChunks(countCandidate)
                 .catch(() => 0);
+            changeSignal.throwIfClosed();
             if (debug?.lastReadyProbe) {
                 debug.lastReadyProbe.localChunkCount = localChunkCount;
             }
@@ -1267,9 +1854,17 @@ export class LargeFile extends AbstractFile {
                 }
                 return countCandidate;
             }
-            await sleep(250);
+            await changeSignal.waitForChangeAfter(
+                changeVersion,
+                Math.min(
+                    LARGE_FILE_CHANGE_WAIT_FALLBACK_MS,
+                    Math.max(0, deadline - Date.now())
+                )
+            );
+            changeSignal.throwIfClosed();
         }
 
+        changeSignal.throwIfClosed();
         throw new Error(
             `File ${this.id} is still uploading after waiting ${Math.round(
                 totalTimeout / 1000
@@ -1281,18 +1876,82 @@ export class LargeFile extends AbstractFile {
         files: Files,
         properties?: FileReadOptions
     ): AsyncIterable<Uint8Array> {
+        // Keep one immutable read policy for the entire stream. Role changes can
+        // update the program default concurrently, but must not switch an
+        // in-flight read between persisted and non-persisted scheduling paths.
+        const persistChunkReads = files.persistChunkReads;
+        const effectiveProperties: EffectiveFileReadOptions = {
+            ...properties,
+            persist: persistChunkReads,
+        };
         const debug = {
             fileId: this.id,
             fileName: this.name,
-            persistChunkReads: files.persistChunkReads,
+            persistChunkReads,
+            programPersistChunkReads: persistChunkReads,
             startedAt: Date.now(),
             waitUntilReadyAttempts: 0,
             waitUntilReadyResolvedAt: null as number | null,
             waitUntilReadyResolvedReady: null as boolean | null,
             waitUntilReadyResolvedBy: null as string | null,
             prefetchedChunkCount: 0,
+            chunkBatchQueryCount: 0,
+            chunkBatchResultCount: 0,
+            chunkBatchFallbackCount: 0,
+            chunkBatchFallbackResultCount: 0,
+            chunkBatchResolverFallbackCount: 0,
+            chunkPersistedRemoteBatchSkipCount: 0,
+            chunkPersistedRemoteBatchSkippedIndexCount: 0,
+            chunkManifestHeadBatchQueryCount: 0,
+            chunkManifestHeadLocalBatchQueryCount: 0,
+            chunkManifestHeadRemoteBatchQueryCount: 0,
+            chunkManifestHeadBatchRequestedIndexCount: 0,
+            chunkManifestHeadBatchAcceptedCount: 0,
+            chunkManifestHeadLocalBatchAcceptedCount: 0,
+            chunkManifestHeadRemoteBatchAcceptedCount: 0,
+            chunkManifestHeadBatchMissingCount: 0,
+            chunkManifestHeadBatchInvalidCount: 0,
+            chunkManifestHeadBatchInvalidErrors: [] as {
+                index: number;
+                message: string;
+            }[],
+            chunkManifestHeadBatchPartialCount: 0,
+            chunkManifestHeadBatchErrorCount: 0,
+            chunkManifestHeadBatchErrors: [] as string[],
+            chunkManifestHeadBatchDisabled: false,
+            chunkManifestHeadBatchDisabledReason: null as string | null,
+            chunkManifestHeadBatchDisabledSkipCount: 0,
+            chunkManifestHeadBatchDisabledSkippedIndexCount: 0,
+            chunkManifestHeadBatchAttemptTimeoutMs: 0,
+            maxManifestHeadBatchSize: 0,
+            activeManifestHeadBatches: 0,
+            maxConcurrentManifestHeadBatches: 0,
+            chunkManifestHeadBatchResolved: {} as Record<number, string>,
+            chunkBatchAttemptTimeoutMs: 0,
+            chunkBatchRemoteReclassificationCount: 0,
+            chunkLocalIndexedBatchQueryCount: 0,
+            chunkLocalIndexedBatchResultCount: 0,
+            chunkBatchErrorCount: 0,
+            chunkBatchErrors: [] as string[],
+            maxRemoteChunkBatchSize: 0,
+            activeRemoteChunkBatches: 0,
+            maxConcurrentRemoteChunkBatches: 0,
+            peakKnownChunkCount: 0,
+            finalKnownChunkCount: null as number | null,
             readAhead: 0,
+            readAheadInitial: 0,
+            readAheadLimit: 0,
+            readAheadPeak: 0,
+            maxInFlightChunks: 0,
+            readAheadChanges: [] as {
+                index: number;
+                from: number;
+                to: number;
+                demandWaitMs: number;
+                attempts: number;
+            }[],
             initialLocalChunkCount: null as number | null,
+            initialLocalChunkBlockCount: null as number | null,
             readAheadSource: null as string | null,
             initialReadPeerHints: null as string[] | null,
             chunkAttemptTimeoutMs: 0,
@@ -1314,46 +1973,722 @@ export class LargeFile extends AbstractFile {
                 message: string;
             } | null,
         };
+        const diagnosticsContext = (
+            properties as InternalFileReadOptions | undefined
+        )?.[FILE_READ_DIAGNOSTICS_CONTEXT];
+        if (diagnosticsContext) {
+            diagnosticsContext.diagnostics = debug;
+        }
         files.lastReadDiagnostics = debug;
-        if (files.persistChunkReads) {
+        if (persistChunkReads) {
             files.retainFileRead(this);
         }
-        const resolvedFile = await this.waitUntilReady(files, properties);
+        const resolvedFile = await this.waitUntilReady(
+            files,
+            effectiveProperties,
+            debug
+        );
         debug.waitUntilReadyResolvedAt = Date.now();
         debug.waitUntilReadyResolvedReady = resolvedFile.ready;
-        if (files.persistChunkReads) {
+        if (persistChunkReads) {
             files.retainFileRead(resolvedFile);
         }
 
         properties?.progress?.(0);
 
-        let processed = 0;
+        let processed = 0n;
         const hasher = resolvedFile.finalHash ? new SHA256() : undefined;
         const knownChunks = new Map<number, TinyFile>();
-        const readContext: ChunkReadContext = {};
-        if (files.persistChunkReads) {
-            const initialReadPeerHints = await files.getReadPeerHints();
-            if (initialReadPeerHints) {
-                readContext.lastReadPeerHints = initialReadPeerHints;
-                debug.initialReadPeerHints = initialReadPeerHints;
+        const readContext: ChunkReadContext = {
+            fileChangeSignals: new Set(),
+        };
+        const initialReadPeerHints = await files.getReadPeerHints();
+        if (initialReadPeerHints) {
+            readContext.lastReadPeerHints = initialReadPeerHints;
+            debug.initialReadPeerHints = initialReadPeerHints;
+        }
+        if (persistChunkReads) {
+            const [initialLocalChunkCount, initialLocalChunkBlockCount] =
+                await Promise.all([
+                    files.countLocalChunks(resolvedFile).catch(() => null),
+                    files.countLocalChunkBlocks(resolvedFile).catch(() => null),
+                ]);
+            debug.initialLocalChunkCount = initialLocalChunkCount;
+            debug.initialLocalChunkBlockCount =
+                initialLocalChunkBlockCount ?? null;
+        }
+        const remoteReadAheadLimit = getRemotePersistedReadAheadLimit(
+            resolvedFile.size,
+            resolvedFile.chunkCount
+        );
+        const localReadAheadLimit = Math.min(
+            resolvedFile.chunkCount,
+            LARGE_FILE_PERSISTED_READ_AHEAD
+        );
+        const manifestChunkEntryHeads = (
+            resolvedFile as { chunkEntryHeads?: unknown }
+        ).chunkEntryHeads;
+        const hasCompleteChunkEntryHeads =
+            Array.isArray(manifestChunkEntryHeads) &&
+            manifestChunkEntryHeads.length === resolvedFile.chunkCount &&
+            manifestChunkEntryHeads.every(
+                (head: unknown) => typeof head === "string"
+            );
+        let isRemotePersistedRead =
+            persistChunkReads &&
+            (debug.initialLocalChunkCount == null ||
+                debug.initialLocalChunkCount < resolvedFile.chunkCount);
+        let isAdaptiveRemoteRead = !persistChunkReads || isRemotePersistedRead;
+        let readAheadLimit = isAdaptiveRemoteRead
+            ? remoteReadAheadLimit
+            : localReadAheadLimit;
+        // A count can be stale when local index rows outlive their payloads.
+        // Probe a small exact batch before granting the 32-chunk local window.
+        let localReadAheadVerified =
+            !persistChunkReads || isRemotePersistedRead;
+        let usesLegacyLocalChunkIds = false;
+        let readAhead = isAdaptiveRemoteRead
+            ? Math.min(
+                  resolvedFile.chunkCount,
+                  persistChunkReads
+                      ? hasCompleteChunkEntryHeads
+                          ? readAheadLimit
+                          : REMOTE_PERSISTED_READ_AHEAD_MIN
+                      : LARGE_FILE_OBSERVER_READ_AHEAD,
+                  readAheadLimit
+              )
+            : Math.min(
+                  resolvedFile.chunkCount,
+                  REMOTE_PERSISTED_READ_AHEAD_MIN,
+                  readAheadLimit
+              );
+        const batchPromisesByIndex = new Map<number, Promise<void>>();
+        const batchAttemptedIndices = new Set<number>();
+        const intentionallySkippedBatchIndices = new Set<number>();
+        const skipPersistedRemoteBatch = (indices: number[]) => {
+            debug.chunkPersistedRemoteBatchSkipCount += 1;
+            debug.chunkPersistedRemoteBatchSkippedIndexCount += indices.length;
+            for (const index of indices) {
+                intentionallySkippedBatchIndices.add(index);
             }
-        }
-        if (!files.persistChunkReads) {
-            for (const chunk of await resolvedFile.fetchChunks(files, {
-                timeout: Math.min(
-                    properties?.timeout ?? LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS,
-                    LARGE_FILE_OBSERVER_PREFETCH_TIMEOUT_MS
-                ),
-            })) {
-                knownChunks.set(chunk.index || 0, chunk);
+        };
+        const reclassifyAsRemotePersistedRead = () => {
+            if (!persistChunkReads || isRemotePersistedRead) {
+                return;
             }
-            debug.prefetchedChunkCount = knownChunks.size;
-        }
-        if (files.persistChunkReads) {
-            debug.initialLocalChunkCount = await files
-                .countLocalChunks(resolvedFile)
-                .catch(() => null);
-        }
+            isRemotePersistedRead = true;
+            isAdaptiveRemoteRead = true;
+            localReadAheadVerified = false;
+            readAheadLimit = remoteReadAheadLimit;
+            readAhead = hasCompleteChunkEntryHeads
+                ? readAheadLimit
+                : Math.min(readAhead, readAheadLimit);
+            debug.chunkBatchRemoteReclassificationCount += 1;
+            debug.readAhead = readAhead;
+            debug.readAheadLimit = readAheadLimit;
+            debug.readAheadSource = "persisted-remote-adaptive";
+        };
+        const verifyLocalReadAhead = () => {
+            if (
+                !persistChunkReads ||
+                isRemotePersistedRead ||
+                localReadAheadVerified
+            ) {
+                return;
+            }
+            localReadAheadVerified = true;
+            readAheadLimit = localReadAheadLimit;
+            readAhead = readAheadLimit;
+            debug.readAhead = readAhead;
+            debug.readAheadLimit = readAheadLimit;
+            debug.readAheadPeak = Math.max(debug.readAheadPeak, readAhead);
+        };
+        const updateKnownChunkPeak = () => {
+            debug.peakKnownChunkCount = Math.max(
+                debug.peakKnownChunkCount,
+                knownChunks.size
+            );
+        };
+        let manifestHeadBatchDisabled = false;
+        const disableManifestHeadBatch = (reason: string) => {
+            manifestHeadBatchDisabled = true;
+            debug.chunkManifestHeadBatchDisabled = true;
+            debug.chunkManifestHeadBatchDisabledReason ??= reason;
+        };
+        type ManifestHeadEntry =
+            | {
+                  getPayloadValue: () => Promise<Operation>;
+              }
+            | undefined;
+        type ManifestHeadRemote =
+            | false
+            | {
+                  timeout: number;
+                  replicate: true;
+                  from: string[] | undefined;
+                  signal: AbortSignal;
+              };
+        const readManifestHeadEntries = async (
+            heads: string[],
+            remote: ManifestHeadRemote
+        ): Promise<ManifestHeadEntry[]> => {
+            const log = files.files.log.log as any;
+            if (typeof log.getMany === "function") {
+                return log.getMany(heads, { remote });
+            }
+
+            const entryIndex = log.entryIndex;
+            if (typeof entryIndex?.getMany === "function") {
+                return entryIndex.getMany(heads, {
+                    type: "full",
+                    ignoreMissing: true,
+                    remote,
+                });
+            }
+
+            if (typeof log.get !== "function") {
+                throw new Error("Log does not support manifest-head reads");
+            }
+            const batchSize = Math.max(
+                1,
+                Math.min(8, remoteReadAheadLimit || 1)
+            );
+            const entries: ManifestHeadEntry[] = [];
+            for (let offset = 0; offset < heads.length; offset += batchSize) {
+                if (remote && remote.signal.aborted) {
+                    throw remote.signal.reason;
+                }
+                entries.push(
+                    ...(await Promise.all(
+                        heads
+                            .slice(offset, offset + batchSize)
+                            .map((head) => log.get(head, { remote }))
+                    ))
+                );
+            }
+            return entries;
+        };
+        const queryPersistedManifestHeadBatch = async (
+            indices: number[],
+            from: string[] | undefined,
+            changeSignal: FileChangeSignal
+        ) => {
+            if (indices.length === 0) {
+                return indices;
+            }
+            changeSignal.throwIfClosed();
+            if (manifestHeadBatchDisabled) {
+                debug.chunkManifestHeadBatchDisabledSkipCount += 1;
+                debug.chunkManifestHeadBatchDisabledSkippedIndexCount +=
+                    indices.length;
+                return indices;
+            }
+
+            const heads = (resolvedFile as { chunkEntryHeads?: unknown })
+                .chunkEntryHeads;
+            const requested = indices.flatMap((index) => {
+                const head = Array.isArray(heads) ? heads[index] : undefined;
+                return typeof head === "string" ? [{ head, index }] : [];
+            });
+            if (requested.length === 0) {
+                return indices;
+            }
+
+            debug.chunkManifestHeadBatchQueryCount += 1;
+            debug.chunkManifestHeadBatchRequestedIndexCount += requested.length;
+            debug.maxManifestHeadBatchSize = Math.max(
+                debug.maxManifestHeadBatchSize,
+                requested.length
+            );
+            const attemptTimeout = Math.min(
+                LARGE_FILE_CHUNK_BATCH_SPECULATIVE_TIMEOUT_MS,
+                Math.max(
+                    1,
+                    properties?.timeout ??
+                        LARGE_FILE_CHUNK_BATCH_SPECULATIVE_TIMEOUT_MS
+                )
+            );
+            debug.chunkManifestHeadBatchAttemptTimeoutMs = attemptTimeout;
+            debug.activeManifestHeadBatches += 1;
+            debug.maxConcurrentManifestHeadBatches = Math.max(
+                debug.maxConcurrentManifestHeadBatches,
+                debug.activeManifestHeadBatches
+            );
+
+            let accepted = 0;
+            const acceptEntries = async (
+                candidates: typeof requested,
+                entries: ManifestHeadEntry[],
+                phase: "local" | "remote"
+            ) => {
+                const missing: typeof requested = [];
+                for (const [
+                    position,
+                    { head, index },
+                ] of candidates.entries()) {
+                    const entry = entries[position];
+                    if (!entry) {
+                        missing.push({ head, index });
+                        continue;
+                    }
+
+                    let operation: Operation;
+                    try {
+                        operation = await entry.getPayloadValue();
+                        changeSignal.throwIfClosed();
+                    } catch (error) {
+                        changeSignal.throwIfClosed();
+                        debug.chunkManifestHeadBatchInvalidCount += 1;
+                        (debug.chunkManifestHeadBatchInvalidErrors ||= []).push(
+                            {
+                                index,
+                                message: getErrorMessage(error),
+                            }
+                        );
+                        continue;
+                    }
+                    if (!isPutOperation(operation)) {
+                        debug.chunkManifestHeadBatchInvalidCount += 1;
+                        continue;
+                    }
+
+                    let chunk: AbstractFile;
+                    try {
+                        chunk = files.files.index.valueEncoding.decoder(
+                            operation.data
+                        );
+                    } catch (error) {
+                        debug.chunkManifestHeadBatchInvalidCount += 1;
+                        (debug.chunkManifestHeadBatchInvalidErrors ||= []).push(
+                            {
+                                index,
+                                message: getErrorMessage(error),
+                            }
+                        );
+                        continue;
+                    }
+                    if (
+                        !(chunk instanceof TinyFile) ||
+                        chunk.parentId !== resolvedFile.id ||
+                        chunk.index !== index
+                    ) {
+                        debug.chunkManifestHeadBatchInvalidCount += 1;
+                        continue;
+                    }
+
+                    if (persistChunkReads) {
+                        files.retainChunkEntryHead(
+                            head,
+                            resolvedFile.id,
+                            chunk.id
+                        );
+                    }
+                    knownChunks.set(index, chunk);
+                    if (persistChunkReads) {
+                        files.retainResolvedChunk(chunk, persistChunkReads);
+                    }
+                    debug.chunkManifestHeadBatchResolved[index] = head;
+                    accepted += 1;
+                    debug.chunkManifestHeadBatchAcceptedCount += 1;
+                    debug.prefetchedChunkCount += 1;
+                    if (phase === "local") {
+                        debug.chunkManifestHeadLocalBatchAcceptedCount += 1;
+                    } else {
+                        debug.chunkManifestHeadRemoteBatchAcceptedCount += 1;
+                    }
+                }
+                return missing;
+            };
+
+            try {
+                debug.chunkManifestHeadLocalBatchQueryCount += 1;
+                const localEntries = await readManifestHeadEntries(
+                    requested.map(({ head }) => head),
+                    false
+                );
+                changeSignal.throwIfClosed();
+                const remotelyMissing = await acceptEntries(
+                    requested,
+                    localEntries,
+                    "local"
+                );
+                if (remotelyMissing.length > 0) {
+                    debug.chunkManifestHeadRemoteBatchQueryCount += 1;
+                    const remoteEntries = await readManifestHeadEntries(
+                        remotelyMissing.map(({ head }) => head),
+                        {
+                            timeout: attemptTimeout,
+                            replicate: true,
+                            from,
+                            signal: changeSignal.abortSignal,
+                        }
+                    );
+                    changeSignal.throwIfClosed();
+                    const stillMissing = await acceptEntries(
+                        remotelyMissing,
+                        remoteEntries,
+                        "remote"
+                    );
+                    debug.chunkManifestHeadBatchMissingCount +=
+                        stillMissing.length;
+                }
+            } catch (error) {
+                changeSignal.throwIfClosed();
+                debug.chunkManifestHeadBatchErrorCount += 1;
+                debug.chunkManifestHeadBatchErrors.push(getErrorMessage(error));
+                disableManifestHeadBatch("error");
+                return indices.filter((index) => !knownChunks.has(index));
+            } finally {
+                debug.activeManifestHeadBatches -= 1;
+            }
+
+            if (accepted === 0) {
+                disableManifestHeadBatch("zero-accepted");
+            } else if (accepted < requested.length) {
+                debug.chunkManifestHeadBatchPartialCount += 1;
+            }
+            return indices.filter((index) => !knownChunks.has(index));
+        };
+        const queryChunkBatch = async (
+            indices: number[],
+            from: string[] | undefined,
+            remote: boolean,
+            fallback: boolean,
+            changeSignal: FileChangeSignal
+        ) => {
+            if (indices.length === 0) {
+                return [];
+            }
+            changeSignal.throwIfClosed();
+            debug.chunkBatchQueryCount += 1;
+            if (remote) {
+                debug.maxRemoteChunkBatchSize = Math.max(
+                    debug.maxRemoteChunkBatchSize,
+                    indices.length
+                );
+                debug.activeRemoteChunkBatches += 1;
+                debug.maxConcurrentRemoteChunkBatches = Math.max(
+                    debug.maxConcurrentRemoteChunkBatches,
+                    debug.activeRemoteChunkBatches
+                );
+            }
+            const requested = new Map(
+                indices.map((index) => [
+                    getChunkId(resolvedFile.id, index),
+                    index,
+                ])
+            );
+            let results: AbstractFile[];
+            try {
+                const totalTimeout =
+                    properties?.timeout ?? LARGE_FILE_CHUNK_LOOKUP_TIMEOUT_MS;
+                const batchAttemptTimeout = Math.min(
+                    getChunkLookupAttemptTimeout(
+                        resolvedFile.size,
+                        resolvedFile.chunkCount,
+                        indices[0],
+                        totalTimeout
+                    ),
+                    LARGE_FILE_CHUNK_BATCH_SPECULATIVE_TIMEOUT_MS
+                );
+                if (remote) {
+                    debug.chunkBatchAttemptTimeoutMs = batchAttemptTimeout;
+                }
+                results = await files.files.index.search(
+                    new SearchRequest({
+                        query: new Or(
+                            [...requested.keys()].map(
+                                (id) =>
+                                    new StringMatch({
+                                        key: "id",
+                                        value: id,
+                                        caseInsensitive: false,
+                                        method: StringMatchMethod.exact,
+                                    })
+                            )
+                        ),
+                        fetch: indices.length,
+                    }),
+                    remote
+                        ? ({
+                              local: false,
+                              signal: changeSignal.abortSignal,
+                              remote: {
+                                  timeout: batchAttemptTimeout,
+                                  throwOnMissing: false,
+                                  retryMissingResponses: false,
+                                  replicate: persistChunkReads,
+                                  from,
+                              },
+                          } as any)
+                        : ({
+                              local: true,
+                              remote: false,
+                              signal: changeSignal.abortSignal,
+                          } as any)
+                );
+                changeSignal.throwIfClosed();
+            } catch (error) {
+                changeSignal.throwIfClosed();
+                debug.chunkBatchErrorCount += 1;
+                (debug.chunkBatchErrors ||= []).push(getErrorMessage(error));
+                return indices.filter((index) => !knownChunks.has(index));
+            } finally {
+                if (remote) {
+                    debug.activeRemoteChunkBatches -= 1;
+                }
+            }
+
+            let accepted = 0;
+            for (const candidate of results) {
+                const expectedIndex = requested.get(candidate.id);
+                if (
+                    expectedIndex == null ||
+                    !(candidate instanceof TinyFile) ||
+                    candidate.parentId !== resolvedFile.id ||
+                    candidate.index !== expectedIndex ||
+                    candidate.id !== getChunkId(resolvedFile.id, expectedIndex)
+                ) {
+                    continue;
+                }
+                if (!knownChunks.has(expectedIndex)) {
+                    knownChunks.set(expectedIndex, candidate);
+                    if (persistChunkReads) {
+                        files.retainResolvedChunk(candidate, persistChunkReads);
+                    }
+                    accepted += 1;
+                }
+            }
+            debug.chunkBatchResultCount += accepted;
+            if (fallback) {
+                debug.chunkBatchFallbackResultCount += accepted;
+            }
+            debug.prefetchedChunkCount += accepted;
+            return indices.filter((index) => !knownChunks.has(index));
+        };
+        const queryLocalIndexedChunkBatch = async (
+            indices: number[],
+            changeSignal: FileChangeSignal
+        ) => {
+            const missing: number[] = [];
+            for (const index of indices) {
+                changeSignal.throwIfClosed();
+                debug.chunkLocalIndexedBatchQueryCount += 1;
+                try {
+                    const results = await files.files.index.search(
+                        new SearchRequest({
+                            query: [
+                                new StringMatch({
+                                    key: "parentId",
+                                    value: resolvedFile.id,
+                                    caseInsensitive: false,
+                                    method: StringMatchMethod.exact,
+                                }),
+                                new StringMatch({
+                                    key: "name",
+                                    value: `${resolvedFile.name}/${index}`,
+                                    caseInsensitive: false,
+                                    method: StringMatchMethod.exact,
+                                }),
+                            ],
+                            fetch: 1,
+                        }),
+                        {
+                            local: true,
+                            remote: false,
+                            signal: changeSignal.abortSignal,
+                        } as any
+                    );
+                    changeSignal.throwIfClosed();
+                    const chunk = (results as unknown[]).find(
+                        (candidate): candidate is TinyFile =>
+                            candidate instanceof TinyFile &&
+                            candidate.parentId === resolvedFile.id &&
+                            candidate.index === index
+                    );
+                    if (chunk) {
+                        knownChunks.set(index, chunk);
+                        if (persistChunkReads) {
+                            files.retainResolvedChunk(chunk, persistChunkReads);
+                        }
+                        debug.chunkLocalIndexedBatchResultCount += 1;
+                    } else {
+                        missing.push(index);
+                    }
+                } catch (error) {
+                    changeSignal.throwIfClosed();
+                    debug.chunkBatchErrorCount += 1;
+                    (debug.chunkBatchErrors ||= []).push(
+                        getErrorMessage(error)
+                    );
+                    missing.push(index);
+                }
+            }
+            return missing;
+        };
+        const prefetchChunkBatch = async (
+            indices: number[],
+            changeSignal: FileChangeSignal
+        ) => {
+            changeSignal.throwIfClosed();
+            const hintedFrom =
+                readContext.lastReadPeerHints ??
+                (await files.getReadPeerHints());
+            changeSignal.throwIfClosed();
+            if (hintedFrom) {
+                readContext.lastReadPeerHints = hintedFrom;
+            }
+            if (persistChunkReads && isRemotePersistedRead) {
+                const boundedIndices = indices.slice(0, remoteReadAheadLimit);
+                const deferred = indices.slice(remoteReadAheadLimit);
+                for (const index of deferred) {
+                    batchAttemptedIndices.delete(index);
+                }
+                const missing = await queryPersistedManifestHeadBatch(
+                    boundedIndices,
+                    hintedFrom,
+                    changeSignal
+                );
+                skipPersistedRemoteBatch(missing);
+                updateKnownChunkPeak();
+                return [...missing, ...deferred];
+            }
+            let missing = await queryChunkBatch(
+                indices,
+                undefined,
+                false,
+                false,
+                changeSignal
+            );
+            if (
+                missing.length > 0 &&
+                persistChunkReads &&
+                !isRemotePersistedRead &&
+                (!localReadAheadVerified || usesLegacyLocalChunkIds)
+            ) {
+                const before = missing.length;
+                missing = await queryLocalIndexedChunkBatch(
+                    missing,
+                    changeSignal
+                );
+                if (missing.length < before) {
+                    usesLegacyLocalChunkIds = true;
+                }
+                if (missing.length === 0) {
+                    // Legacy ids cannot use the 32-id deterministic query, so
+                    // retain a small local window and resolve by indexed fields.
+                    localReadAheadVerified = true;
+                    updateKnownChunkPeak();
+                    return missing;
+                }
+            }
+            if (missing.length === 0) {
+                verifyLocalReadAhead();
+                updateKnownChunkPeak();
+                return missing;
+            }
+            if (persistChunkReads && isRemotePersistedRead) {
+                skipPersistedRemoteBatch(missing);
+                updateKnownChunkPeak();
+                return missing;
+            }
+            const wasVerifiedLocalRead =
+                persistChunkReads && !isRemotePersistedRead;
+            reclassifyAsRemotePersistedRead();
+            const boundedIndices = indices.slice(0, remoteReadAheadLimit);
+            const deferred = indices.slice(remoteReadAheadLimit);
+            let evictedLocalResults = 0;
+            // A batch may have been assembled under the former 32-chunk local
+            // window. Discard payload-bearing results outside the new network
+            // budget and unlock them for a later bounded local-first batch.
+            for (const index of deferred) {
+                if (wasVerifiedLocalRead && knownChunks.delete(index)) {
+                    evictedLocalResults += 1;
+                }
+                batchAttemptedIndices.delete(index);
+            }
+            debug.chunkBatchResultCount -= evictedLocalResults;
+            debug.prefetchedChunkCount -= evictedLocalResults;
+            missing = boundedIndices.filter((index) => !knownChunks.has(index));
+            if (persistChunkReads && isRemotePersistedRead) {
+                missing = await queryPersistedManifestHeadBatch(
+                    missing,
+                    hintedFrom,
+                    changeSignal
+                );
+                skipPersistedRemoteBatch(missing);
+                updateKnownChunkPeak();
+                return [...missing, ...deferred];
+            }
+            if (missing.length > 0) {
+                missing = await queryChunkBatch(
+                    missing,
+                    hintedFrom,
+                    true,
+                    false,
+                    changeSignal
+                );
+            }
+            if (hintedFrom && missing.length > 0) {
+                debug.chunkBatchFallbackCount += 1;
+                missing = await queryChunkBatch(
+                    missing,
+                    undefined,
+                    true,
+                    true,
+                    changeSignal
+                );
+            }
+            updateKnownChunkPeak();
+            return [...missing, ...deferred];
+        };
+        const prefetchBatchForIndex = (
+            index: number,
+            changeSignal: FileChangeSignal
+        ) => {
+            if (knownChunks.has(index)) {
+                return Promise.resolve();
+            }
+            const existing = batchPromisesByIndex.get(index);
+            if (existing) {
+                return existing;
+            }
+            if (batchAttemptedIndices.has(index)) {
+                return Promise.resolve();
+            }
+            const indices: number[] = [];
+            for (
+                let candidate = index;
+                candidate <
+                Math.min(
+                    resolvedFile.chunkCount,
+                    index + Math.max(readAhead, 1)
+                );
+                candidate++
+            ) {
+                if (!knownChunks.has(candidate)) {
+                    indices.push(candidate);
+                    batchAttemptedIndices.add(candidate);
+                }
+            }
+            if (indices.length === 0) {
+                return Promise.resolve();
+            }
+            let pending: Promise<void>;
+            pending = prefetchChunkBatch(indices, changeSignal)
+                .then(() => undefined)
+                .finally(() => {
+                    for (const candidate of indices) {
+                        if (batchPromisesByIndex.get(candidate) === pending) {
+                            batchPromisesByIndex.delete(candidate);
+                        }
+                    }
+                });
+            for (const candidate of indices) {
+                batchPromisesByIndex.set(candidate, pending);
+            }
+            return pending;
+        };
         const inFlightChunks = new Map<number, Promise<TinyFile>>();
         const resolveChunkWithReadAhead = (index: number) => {
             const cached = inFlightChunks.get(index);
@@ -1362,18 +2697,45 @@ export class LargeFile extends AbstractFile {
             }
             const pending = (async () => {
                 debug.chunkResolveStartedAt[index] = Date.now();
+                const chunkId = getChunkId(resolvedFile.id, index);
+                const changeSignal = files.createFileChangeSignal(
+                    (file) =>
+                        file.id === chunkId ||
+                        (file instanceof TinyFile &&
+                            file.parentId === resolvedFile.id &&
+                            file.index === index)
+                );
+                readContext.fileChangeSignals!.add(changeSignal);
                 try {
-                    return await resolvedFile.resolveChunk(
+                    await prefetchBatchForIndex(index, changeSignal);
+                    while (
+                        !knownChunks.has(index) &&
+                        !batchAttemptedIndices.has(index)
+                    ) {
+                        await prefetchBatchForIndex(index, changeSignal);
+                    }
+                    const intentionallySkippedBatch =
+                        intentionallySkippedBatchIndices.delete(index);
+                    if (!knownChunks.has(index) && !intentionallySkippedBatch) {
+                        debug.chunkBatchResolverFallbackCount += 1;
+                    }
+                    const chunk = await resolvedFile.resolveChunk(
                         files,
                         index,
                         knownChunks,
                         readContext,
+                        changeSignal,
                         {
                             timeout: properties?.timeout,
                             debug,
+                            persist: persistChunkReads,
                         }
                     );
+                    updateKnownChunkPeak();
+                    return chunk;
                 } finally {
+                    changeSignal.close();
+                    readContext.fileChangeSignals!.delete(changeSignal);
                     debug.chunkResolveFinishedAt[index] = Date.now();
                 }
             })();
@@ -1381,65 +2743,120 @@ export class LargeFile extends AbstractFile {
             return pending;
         };
 
-        const configuredReadAhead = files.persistChunkReads
-            ? debug.initialLocalChunkCount != null &&
-              debug.initialLocalChunkCount < resolvedFile.chunkCount
-                ? LARGE_FILE_REMOTE_PERSISTED_READ_AHEAD
-                : LARGE_FILE_PERSISTED_READ_AHEAD
-            : LARGE_FILE_OBSERVER_READ_AHEAD;
-        const readAhead = Math.min(
-            resolvedFile.chunkCount,
-            configuredReadAhead
-        );
         debug.readAhead = readAhead;
-        debug.readAheadSource = files.persistChunkReads
-            ? readAhead === LARGE_FILE_PERSISTED_READ_AHEAD
-                ? "persisted-local"
-                : "persisted-remote"
-            : "observer";
+        debug.readAheadInitial = readAhead;
+        debug.readAheadLimit = readAheadLimit;
+        debug.readAheadPeak = readAhead;
+        debug.readAheadSource = persistChunkReads
+            ? isRemotePersistedRead
+                ? "persisted-remote-adaptive"
+                : "persisted-local"
+            : "observer-adaptive";
 
-        for (
-            let index = 0;
-            index < Math.min(resolvedFile.chunkCount, readAhead);
-            index++
-        ) {
-            void resolveChunkWithReadAhead(index).catch(() => undefined);
-        }
-
-        for (let index = 0; index < resolvedFile.chunkCount; index++) {
-            const chunkFile = await resolveChunkWithReadAhead(index);
-            inFlightChunks.delete(index);
-            const nextIndex = index + readAhead;
-            if (nextIndex < resolvedFile.chunkCount) {
-                void resolveChunkWithReadAhead(nextIndex).catch(
-                    () => undefined
-                );
+        let nextChunkToSchedule = 0;
+        const fillReadAhead = () => {
+            // One resolver can still issue a 32-id local query. Keeping only
+            // that resolver active lets a partial local miss reclassify the
+            // stream before any deferred index can start a remote RPC.
+            const schedulerLimit = isAdaptiveRemoteRead ? readAhead : 1;
+            while (
+                nextChunkToSchedule < resolvedFile.chunkCount &&
+                inFlightChunks.size < schedulerLimit
+            ) {
+                const index = nextChunkToSchedule++;
+                void resolveChunkWithReadAhead(index).catch(() => undefined);
             }
-            if (!chunkFile) {
-                throw new Error(
-                    `Failed to resolve chunk ${index + 1}/${resolvedFile.chunkCount} for file ${resolvedFile.id}`
-                );
-            }
-            debug.chunkMaterializeStartedAt[index] = Date.now();
-            const chunk = await chunkFile.getFile(files, {
-                as: "joined",
-                timeout: properties?.timeout,
-            });
-            debug.chunkMaterializeFinishedAt[index] = Date.now();
-            debug.chunkHashStartedAt[index] = Date.now();
-            hasher?.update(chunk);
-            debug.chunkHashFinishedAt[index] = Date.now();
-            processed += chunk.byteLength;
-            properties?.progress?.(
-                processed / Math.max(Number(resolvedFile.size), 1)
+            debug.maxInFlightChunks = Math.max(
+                debug.maxInFlightChunks,
+                inFlightChunks.size
             );
-            yield chunk;
-        }
+        };
 
-        if (hasher && toBase64(hasher.digest()) !== resolvedFile.finalHash) {
-            throw new Error("File hash does not match the expected content");
+        try {
+            fillReadAhead();
+
+            for (let index = 0; index < resolvedFile.chunkCount; index++) {
+                const demandStartedAt = Date.now();
+                const chunkFile = await resolveChunkWithReadAhead(index);
+                const demandWaitMs = Date.now() - demandStartedAt;
+                inFlightChunks.delete(index);
+                if (isAdaptiveRemoteRead) {
+                    const attempts = debug.chunkAttempts[index] ?? 1;
+                    const adaptedReadAhead = adaptRemotePersistedReadAhead(
+                        readAhead,
+                        readAheadLimit,
+                        { demandWaitMs, attempts }
+                    );
+                    if (adaptedReadAhead !== readAhead) {
+                        debug.readAheadChanges.push({
+                            index,
+                            from: readAhead,
+                            to: adaptedReadAhead,
+                            demandWaitMs,
+                            attempts,
+                        });
+                        readAhead = adaptedReadAhead;
+                        debug.readAhead = readAhead;
+                        debug.readAheadPeak = Math.max(
+                            debug.readAheadPeak,
+                            readAhead
+                        );
+                    }
+                }
+                fillReadAhead();
+                if (!chunkFile) {
+                    throw new Error(
+                        `Failed to resolve chunk ${index + 1}/${resolvedFile.chunkCount} for file ${resolvedFile.id}`
+                    );
+                }
+                debug.chunkMaterializeStartedAt[index] = Date.now();
+                const chunk = await chunkFile.getFile(files, {
+                    as: "joined",
+                    timeout: properties?.timeout,
+                });
+                debug.chunkMaterializeFinishedAt[index] = Date.now();
+                const nextProcessed = processed + BigInt(chunk.byteLength);
+                if (nextProcessed > resolvedFile.size) {
+                    throw new Error(
+                        `File size does not match the expected size. Expected ${resolvedFile.size} bytes, got at least ${nextProcessed}`
+                    );
+                }
+                debug.chunkHashStartedAt[index] = Date.now();
+                hasher?.update(chunk);
+                debug.chunkHashFinishedAt[index] = Date.now();
+                processed = nextProcessed;
+                properties?.progress?.(
+                    Number(processed) / Math.max(Number(resolvedFile.size), 1)
+                );
+                yield chunk;
+                knownChunks.delete(index);
+            }
+
+            if (processed !== resolvedFile.size) {
+                throw new Error(
+                    `File size does not match the expected size. Expected ${resolvedFile.size} bytes, got ${processed}`
+                );
+            }
+            if (
+                hasher &&
+                toBase64(hasher.digest()) !== resolvedFile.finalHash
+            ) {
+                throw new Error(
+                    "File hash does not match the expected content"
+                );
+            }
+            debug.finishedAt = Date.now();
+        } finally {
+            for (const signal of readContext.fileChangeSignals ?? []) {
+                signal.close();
+            }
+            readContext.fileChangeSignals?.clear();
+            knownChunks.clear();
+            batchPromisesByIndex.clear();
+            batchAttemptedIndices.clear();
+            intentionallySkippedBatchIndices.clear();
+            debug.finalKnownChunkCount = knownChunks.size;
         }
-        debug.finishedAt = Date.now();
     }
 }
 
@@ -1540,6 +2957,19 @@ export const isLargeFileLike = (value: unknown): value is LargeFile => {
     );
 };
 
+const getCompleteChunkEntryHeads = (file: LargeFile): string[] | undefined => {
+    const candidateHeads = (file as LargeFile & { chunkEntryHeads?: unknown })
+        .chunkEntryHeads;
+    return Array.isArray(candidateHeads) &&
+        candidateHeads.length === file.chunkCount &&
+        candidateHeads.every(
+            (head): head is string =>
+                typeof head === "string" && head.length > 0
+        )
+        ? candidateHeads
+        : undefined;
+};
+
 const toReadableLargeFile = (value: unknown): LargeFile | undefined => {
     if (!isLargeFileLike(value)) {
         return;
@@ -1616,6 +3046,10 @@ type UploadDiagnostics = {
     chunkReadMaxMs: number;
     chunkPutTotalMs: number;
     chunkPutMaxMs: number;
+    chunkPutConcurrencyLimit: number;
+    chunkPutByteLimit: number;
+    maxConcurrentChunkPuts: number;
+    maxConcurrentChunkPutBytes: number;
     slowestChunkIndex: number | null;
     slowestChunkPutMs: number | null;
     readyManifestStartedAt: number | null;
@@ -1644,7 +3078,21 @@ export class Files extends Program<Args> {
     lastReadDiagnostics?: Record<string, any>;
     lastUploadDiagnostics?: UploadDiagnostics;
     private retainedChunkIds = new Set<string>();
+    private retainedChunkIdsByFileId = new Map<string, Set<string>>();
+    private retainedLargeFileChunkCounts = new Map<string, number>();
     private retainedChunkEntryHeads = new Set<string>();
+    private retainedEntryHeadsByFileId = new Map<string, Set<string>>();
+    private retainedEntryHeadsByDocumentId = new Map<string, Set<string>>();
+    private retainedChunkEntryHeadOwners = new Map<
+        string,
+        Map<string, Set<string>>
+    >();
+    private retainedEntryHeadDocumentIds = new Map<string, Set<string>>();
+    private unscopedRetainedChunkEntryHeads = new Set<string>();
+    private pendingAuthoredDocumentIds = new Map<string, number>();
+    private activeFileChangeSignals = new Set<FileChangeSignal>();
+    private fileMutationTails = new Map<string, Promise<void>>();
+    private pendingLargeFileDeletions = new Map<string, LargeFile>();
 
     constructor(
         properties: {
@@ -1671,52 +3119,682 @@ export class Files extends Program<Args> {
         this.persistChunkReads = true;
     }
 
-    retainChunkRead(chunkId: string) {
+    retainChunkRead(chunkId: string, fileId?: string) {
         this.retainedChunkIds ??= new Set();
         this.retainedChunkIds.add(chunkId);
+        const trackedFileId =
+            fileId ??
+            (() => {
+                const separator = chunkId.lastIndexOf(":");
+                return separator > 0 &&
+                    /^\d+$/.test(chunkId.slice(separator + 1))
+                    ? chunkId.slice(0, separator)
+                    : undefined;
+            })();
+        if (trackedFileId) {
+            this.retainedChunkIdsByFileId ??= new Map();
+            let ids = this.retainedChunkIdsByFileId.get(trackedFileId);
+            if (!ids) {
+                ids = new Set();
+                this.retainedChunkIdsByFileId.set(trackedFileId, ids);
+            }
+            ids.add(chunkId);
+        }
     }
 
-    retainChunkEntryHead(entryHash: string) {
+    retainChunkEntryHead(
+        entryHash: string,
+        fileId?: string,
+        documentId?: string
+    ) {
         this.retainedChunkEntryHeads ??= new Set();
         this.retainedChunkEntryHeads.add(entryHash);
+        if (fileId) {
+            this.retainedChunkEntryHeadOwners ??= new Map();
+            let ownersByFile = this.retainedChunkEntryHeadOwners.get(entryHash);
+            if (!ownersByFile) {
+                ownersByFile = new Map();
+                this.retainedChunkEntryHeadOwners.set(entryHash, ownersByFile);
+            }
+            const trackedDocumentId = documentId ?? fileId;
+            let ownedDocumentIds = ownersByFile.get(fileId);
+            if (!ownedDocumentIds) {
+                ownedDocumentIds = new Set();
+                ownersByFile.set(fileId, ownedDocumentIds);
+            }
+            ownedDocumentIds.add(trackedDocumentId);
+            this.retainedEntryHeadsByFileId ??= new Map();
+            let heads = this.retainedEntryHeadsByFileId.get(fileId);
+            if (!heads) {
+                heads = new Set();
+                this.retainedEntryHeadsByFileId.set(fileId, heads);
+            }
+            heads.add(entryHash);
+            this.retainedEntryHeadsByDocumentId ??= new Map();
+            let documentHeads =
+                this.retainedEntryHeadsByDocumentId.get(trackedDocumentId);
+            if (!documentHeads) {
+                documentHeads = new Set();
+                this.retainedEntryHeadsByDocumentId.set(
+                    trackedDocumentId,
+                    documentHeads
+                );
+            }
+            documentHeads.add(entryHash);
+            this.retainedEntryHeadDocumentIds ??= new Map();
+            let headDocumentIds =
+                this.retainedEntryHeadDocumentIds.get(entryHash);
+            if (!headDocumentIds) {
+                headDocumentIds = new Set();
+                this.retainedEntryHeadDocumentIds.set(
+                    entryHash,
+                    headDocumentIds
+                );
+            }
+            headDocumentIds.add(trackedDocumentId);
+        } else {
+            this.unscopedRetainedChunkEntryHeads ??= new Set();
+            this.unscopedRetainedChunkEntryHeads.add(entryHash);
+        }
     }
 
-    retainResolvedChunk(value: unknown) {
+    retainResolvedChunk(
+        value: unknown,
+        persistChunkReads = this.persistChunkReads
+    ) {
+        if (!persistChunkReads) {
+            return;
+        }
+        if (isLargeFileChunk(value)) {
+            this.retainChunkRead(value.id, value.parentId);
+        }
         const head = getContextHead(value);
         if (head) {
-            this.retainChunkEntryHead(head);
+            const file = value as { id?: unknown };
+            const fileId =
+                value instanceof AbstractFile
+                    ? getRetentionOwnerId(value)
+                    : typeof file.id === "string"
+                      ? file.id
+                      : undefined;
+            this.retainChunkEntryHead(
+                head,
+                fileId,
+                typeof file.id === "string" ? file.id : undefined
+            );
         }
     }
 
     retainFileRead(file: AbstractFile) {
-        if (file instanceof TinyFile && file.parentId != null) {
-            this.retainChunkRead(file.id);
+        if (isLargeFileChunk(file)) {
+            this.retainChunkRead(file.id, file.parentId);
             return;
         }
         if (isLargeFileLike(file)) {
-            for (let index = 0; index < file.chunkCount; index++) {
-                this.retainChunkRead(getChunkId(file.id, index));
+            this.retainedLargeFileChunkCounts ??= new Map();
+            this.retainedLargeFileChunkCounts.set(file.id, file.chunkCount);
+        }
+    }
+
+    private retainAuthoredFile(file: AbstractFile, entryHash?: string) {
+        if (isLargeFileChunk(file)) {
+            this.retainChunkRead(file.id, file.parentId);
+        } else if (isLargeFileLike(file)) {
+            this.retainedLargeFileChunkCounts ??= new Map();
+            this.retainedLargeFileChunkCounts.set(file.id, file.chunkCount);
+        }
+        if (entryHash) {
+            this.retainChunkEntryHead(
+                entryHash,
+                getRetentionOwnerId(file),
+                file.id
+            );
+        }
+    }
+
+    private async putAuthoredFile(
+        file: AbstractFile,
+        options?: Parameters<Documents<AbstractFile, IndexableFile>["put"]>[1],
+        onLocalCommit?: (entryHead: string) => void
+    ) {
+        let capturedLocalHead: string | undefined;
+        const captureLocalHead = onLocalCommit
+            ? (
+                  event: CustomEvent<
+                      DocumentsChange<AbstractFile, IndexableFile>
+                  >
+              ) => {
+                  if (capturedLocalHead) {
+                      return;
+                  }
+                  const committed = event.detail.added.find(
+                      (candidate) =>
+                          candidate.id === file.id &&
+                          this.isExactFileVersion(candidate, file)
+                  );
+                  const committedHead = getContextHead(committed);
+                  if (!committedHead) {
+                      return;
+                  }
+                  capturedLocalHead = committedHead;
+                  onLocalCommit(committedHead);
+                  this.files.events.removeEventListener(
+                      "change",
+                      captureLocalHead
+                  );
+              }
+            : undefined;
+        if (captureLocalHead) {
+            this.files.events.addEventListener("change", captureLocalHead);
+        }
+        this.pendingAuthoredDocumentIds ??= new Map();
+        this.pendingAuthoredDocumentIds.set(
+            file.id,
+            (this.pendingAuthoredDocumentIds.get(file.id) ?? 0) + 1
+        );
+        try {
+            const appended = await this.files.put(file, options);
+            if (onLocalCommit && !capturedLocalHead) {
+                capturedLocalHead = appended.entry.hash;
+                onLocalCommit(capturedLocalHead);
+            }
+            this.retainAuthoredFile(file, appended.entry.hash);
+            return appended;
+        } finally {
+            if (captureLocalHead) {
+                this.files.events.removeEventListener(
+                    "change",
+                    captureLocalHead
+                );
+            }
+            const remaining =
+                (this.pendingAuthoredDocumentIds.get(file.id) ?? 1) - 1;
+            if (remaining > 0) {
+                this.pendingAuthoredDocumentIds.set(file.id, remaining);
+            } else {
+                this.pendingAuthoredDocumentIds.delete(file.id);
             }
         }
     }
 
-    private retainAuthoredChunk(chunk: TinyFile, entryHash?: string) {
-        if (chunk.parentId != null) {
-            this.retainChunkRead(chunk.id);
+    private isExactFileVersion(
+        current: AbstractFile,
+        target: AbstractFile,
+        expectedHead?: string
+    ) {
+        if (current.id !== target.id) {
+            return false;
         }
-        if (entryHash) {
-            this.retainChunkEntryHead(entryHash);
+        if (expectedHead != null) {
+            return getContextHead(current) === expectedHead;
         }
+        if (current instanceof TinyFile && target instanceof TinyFile) {
+            return (
+                current.name === target.name &&
+                current.parentId === target.parentId &&
+                current.index === target.index &&
+                current.hash === target.hash
+            );
+        }
+        if (isLargeFileLike(current) && isLargeFileLike(target)) {
+            const currentHeads = (current as { chunkEntryHeads?: unknown })
+                .chunkEntryHeads;
+            const targetHeads = (target as { chunkEntryHeads?: unknown })
+                .chunkEntryHeads;
+            const sameChunkHeads =
+                Array.isArray(currentHeads) || Array.isArray(targetHeads)
+                    ? Array.isArray(currentHeads) &&
+                      Array.isArray(targetHeads) &&
+                      currentHeads.length === targetHeads.length &&
+                      currentHeads.every(
+                          (head, index) => head === targetHeads[index]
+                      )
+                    : true;
+            return (
+                current.name === target.name &&
+                current.size === target.size &&
+                current.chunkCount === target.chunkCount &&
+                current.ready === target.ready &&
+                current.finalHash === target.finalHash &&
+                sameChunkHeads
+            );
+        }
+        return false;
+    }
+
+    private async confirmRejectedDeleteCommitted(
+        id: string,
+        deleteError: unknown
+    ) {
+        let current: AbstractFile | undefined;
+        try {
+            current = await this.files.index.get(id, {
+                local: true,
+                remote: false,
+            });
+        } catch {
+            throw deleteError;
+        }
+        if (current) {
+            throw deleteError;
+        }
+    }
+
+    private async cleanupFailedUploadIfCurrent(
+        target: LargeFile,
+        expectedHead: string | undefined,
+        chunkEntryHeads: string[],
+        expectedChunkCount: number
+    ) {
+        if (!expectedHead) {
+            return false;
+        }
+        return this.withFileMutation(target.id, async () => {
+            let current: AbstractFile | undefined;
+            try {
+                current = await this.files.index.get(target.id, {
+                    local: true,
+                    remote: false,
+                });
+            } catch {
+                return false;
+            }
+            if (current) {
+                if (!this.isExactFileVersion(current, target, expectedHead)) {
+                    return false;
+                }
+
+                let targetEntry;
+                try {
+                    targetEntry = await this.files.log.log.get(expectedHead);
+                } catch {
+                    return false;
+                }
+                if (!targetEntry) {
+                    return false;
+                }
+
+                try {
+                    await this.files.del(target.id, {
+                        meta: { next: [targetEntry] },
+                    });
+                } catch {
+                    try {
+                        current = await this.files.index.get(target.id, {
+                            local: true,
+                            remote: false,
+                        });
+                    } catch {
+                        return false;
+                    }
+                    if (current != null) {
+                        return false;
+                    }
+                }
+
+                try {
+                    current = await this.files.index.get(target.id, {
+                        local: true,
+                        remote: false,
+                    });
+                } catch {
+                    return false;
+                }
+                if (current != null) {
+                    return false;
+                }
+            }
+
+            this.releaseOwnedEntryHead(expectedHead, target.id, target.id);
+            await this.cleanupChunkedUpload(
+                target.id,
+                expectedChunkCount,
+                chunkEntryHeads
+            ).catch(() => {});
+
+            try {
+                current = await this.files.index.get(target.id, {
+                    local: true,
+                    remote: false,
+                });
+            } catch {
+                return true;
+            }
+            this.retainedLargeFileChunkCounts ??= new Map();
+            if (!current) {
+                this.retainedLargeFileChunkCounts.delete(target.id);
+            } else if (isLargeFileLike(current)) {
+                this.retainedLargeFileChunkCounts.set(
+                    target.id,
+                    current.chunkCount
+                );
+            } else {
+                this.retainedLargeFileChunkCounts.delete(target.id);
+            }
+            return true;
+        });
+    }
+
+    private async commitReadyManifest(
+        pendingFile: LargeFile,
+        pendingPut: { entry: { hash: string } },
+        readyFile: LargeFileWithChunkHeads
+    ) {
+        await this.withFileMutation(readyFile.id, async () => {
+            const pendingHead = pendingPut.entry.hash;
+            const currentPending = await this.files.index.get(readyFile.id, {
+                local: true,
+                remote: false,
+            });
+            if (
+                !currentPending ||
+                !isLargeFileLike(currentPending) ||
+                currentPending.ready ||
+                getContextHead(currentPending) !== pendingHead ||
+                !this.isExactFileVersion(currentPending, pendingFile)
+            ) {
+                throw new Error(
+                    `Upload ${readyFile.id} was cancelled or superseded before ready manifest commit`
+                );
+            }
+
+            try {
+                await this.putAuthoredFile(readyFile, {
+                    meta: { next: [pendingPut.entry as any] },
+                });
+            } catch (error) {
+                let current: AbstractFile | undefined;
+                try {
+                    current = await this.files.index.get(readyFile.id, {
+                        local: true,
+                        remote: false,
+                    });
+                } catch {
+                    throw error;
+                }
+                if (!current || !this.isExactFileVersion(current, readyFile)) {
+                    throw error;
+                }
+                const currentHead = getContextHead(current);
+                if (!currentHead) {
+                    throw error;
+                }
+                this.retainAuthoredFile(current, currentHead);
+            }
+            this.retireAuthoredFileEntry(pendingFile, pendingHead);
+        });
+    }
+
+    private retireAuthoredFileEntry(file: AbstractFile, entryHash: string) {
+        this.releaseOwnedEntryHead(
+            entryHash,
+            getRetentionOwnerId(file),
+            file.id
+        );
+    }
+
+    private forgetRetainedChunkRead(fileId: string, chunkId: string) {
+        this.retainedChunkIds.delete(chunkId);
+        const ids = this.retainedChunkIdsByFileId.get(fileId);
+        ids?.delete(chunkId);
+        if (ids?.size === 0) {
+            this.retainedChunkIdsByFileId.delete(fileId);
+        }
+    }
+
+    private async validateCurrentChild(
+        file: TinyFile
+    ): Promise<"valid" | "invalid" | "unknown"> {
+        if (file.parentId == null) {
+            return "invalid";
+        }
+        const parentId = file.parentId;
+        this.retainedLargeFileChunkCounts.delete(parentId);
+
+        let parent: AbstractFile | undefined;
+        try {
+            parent = await this.files.index.get(parentId, {
+                local: true,
+                remote: false,
+            });
+        } catch {
+            return "unknown";
+        }
+
+        const index = file.index;
+        const deterministicId =
+            index == null ? undefined : getChunkId(parentId, index);
+        const isLegacyId =
+            file.id.length > 0 && !file.id.startsWith(`${parentId}:`);
+        if (!isLargeFileLike(parent)) {
+            this.forgetRetainedChunkRead(parentId, file.id);
+            return "invalid";
+        }
+        const valid =
+            parent.id === parentId &&
+            index != null &&
+            Number.isInteger(index) &&
+            index >= 0 &&
+            Number.isInteger(parent.chunkCount) &&
+            index < parent.chunkCount &&
+            file.name === `${parent.name}/${index}` &&
+            (file.id === deterministicId || isLegacyId);
+        if (!valid) {
+            this.forgetRetainedChunkRead(parentId, file.id);
+            return "invalid";
+        }
+
+        this.retainedLargeFileChunkCounts.set(parentId, parent.chunkCount);
+        this.retainChunkRead(file.id, parentId);
+        return "valid";
+    }
+
+    private async retainedEntryHeadStatus(
+        entryHash: string
+    ): Promise<"current" | "stale" | "unknown"> {
+        this.retainedEntryHeadDocumentIds ??= new Map();
+        const documentIds = this.retainedEntryHeadDocumentIds.get(entryHash);
+        if (!documentIds || documentIds.size === 0) {
+            return "unknown";
+        }
+        let lookupFailed = false;
+        for (const documentId of documentIds) {
+            try {
+                const current = await this.files.index.get(documentId, {
+                    local: true,
+                    remote: false,
+                } as any);
+                if (getContextHead(current) === entryHash) {
+                    if (isLargeFileChunk(current)) {
+                        const childStatus =
+                            await this.validateCurrentChild(current);
+                        if (childStatus === "valid") {
+                            return "current";
+                        }
+                        if (childStatus === "unknown") {
+                            lookupFailed = true;
+                        }
+                        continue;
+                    }
+                    return "current";
+                }
+            } catch {
+                lookupFailed = true;
+            }
+        }
+        return lookupFailed ? "unknown" : "stale";
+    }
+
+    private isPendingAuthoredEntryHead(entryHash: string) {
+        this.pendingAuthoredDocumentIds ??= new Map();
+        return [
+            ...(this.retainedEntryHeadDocumentIds.get(entryHash) ?? []),
+        ].some((documentId) => this.pendingAuthoredDocumentIds.has(documentId));
+    }
+
+    private releaseRetainedEntryHead(entryHash: string) {
+        this.retainedChunkEntryHeadOwners ??= new Map();
+        this.unscopedRetainedChunkEntryHeads ??= new Set();
+        const ownersByFile = this.retainedChunkEntryHeadOwners.get(entryHash);
+        for (const [fileId, documentIds] of [
+            ...(ownersByFile?.entries() ?? []),
+        ]) {
+            for (const documentId of [...documentIds]) {
+                this.releaseOwnedEntryHead(entryHash, fileId, documentId);
+            }
+        }
+        this.unscopedRetainedChunkEntryHeads.delete(entryHash);
+        if (!this.retainedChunkEntryHeadOwners.has(entryHash)) {
+            this.retainedChunkEntryHeads.delete(entryHash);
+        }
+    }
+
+    private releaseOwnedEntryHead(
+        entryHash: string,
+        fileId: string,
+        documentId?: string
+    ) {
+        this.retainedChunkEntryHeadOwners ??= new Map();
+        this.unscopedRetainedChunkEntryHeads ??= new Set();
+        this.retainedEntryHeadsByDocumentId ??= new Map();
+        this.retainedEntryHeadDocumentIds ??= new Map();
+        const ownersByFile = this.retainedChunkEntryHeadOwners.get(entryHash);
+        const ownedDocumentIds = ownersByFile?.get(fileId);
+        if (!ownedDocumentIds) {
+            return false;
+        }
+        const removedDocumentIds = documentId
+            ? ownedDocumentIds.delete(documentId)
+                ? [documentId]
+                : []
+            : [...ownedDocumentIds];
+        if (removedDocumentIds.length === 0) {
+            return false;
+        }
+        if (documentId == null) {
+            ownedDocumentIds.clear();
+        }
+        if (ownedDocumentIds.size === 0) {
+            ownersByFile!.delete(fileId);
+            const fileHeads = this.retainedEntryHeadsByFileId.get(fileId);
+            fileHeads?.delete(entryHash);
+            if (fileHeads?.size === 0) {
+                this.retainedEntryHeadsByFileId.delete(fileId);
+            }
+        }
+        for (const removedDocumentId of removedDocumentIds) {
+            const remainsOwned = [...(ownersByFile?.values() ?? [])].some(
+                (ids) => ids.has(removedDocumentId)
+            );
+            if (!remainsOwned) {
+                const documentHeads =
+                    this.retainedEntryHeadsByDocumentId.get(removedDocumentId);
+                documentHeads?.delete(entryHash);
+                if (documentHeads?.size === 0) {
+                    this.retainedEntryHeadsByDocumentId.delete(
+                        removedDocumentId
+                    );
+                }
+                this.retainedEntryHeadDocumentIds
+                    .get(entryHash)
+                    ?.delete(removedDocumentId);
+            }
+        }
+        if (ownersByFile?.size === 0) {
+            this.retainedChunkEntryHeadOwners.delete(entryHash);
+            if (!this.unscopedRetainedChunkEntryHeads.has(entryHash)) {
+                this.retainedChunkEntryHeads.delete(entryHash);
+                for (const trackedDocumentId of this.retainedEntryHeadDocumentIds.get(
+                    entryHash
+                ) ?? []) {
+                    const documentHeads =
+                        this.retainedEntryHeadsByDocumentId.get(
+                            trackedDocumentId
+                        );
+                    documentHeads?.delete(entryHash);
+                    if (documentHeads?.size === 0) {
+                        this.retainedEntryHeadsByDocumentId.delete(
+                            trackedDocumentId
+                        );
+                    }
+                }
+                this.retainedEntryHeadDocumentIds.delete(entryHash);
+            }
+        }
+        return true;
+    }
+
+    releaseChunkRetention(
+        fileId: string,
+        chunkId: string,
+        _entryHead?: string
+    ) {
+        this.forgetRetainedChunkRead(fileId, chunkId);
+
+        const heads = new Set(
+            this.retainedEntryHeadsByDocumentId.get(chunkId) ?? []
+        );
+        // Context heads are only hints. Ownership comes exclusively from the
+        // validated group/document mapping above.
+        for (const head of heads) {
+            this.releaseOwnedEntryHead(head, fileId, chunkId);
+        }
+    }
+
+    releaseFileRetention(
+        fileOrId:
+            | string
+            | {
+                  id: string;
+                  chunkEntryHeads?: unknown;
+              }
+    ) {
+        const file = typeof fileOrId === "string" ? { id: fileOrId } : fileOrId;
+        this.retainedChunkIds ??= new Set();
+        this.retainedChunkIdsByFileId ??= new Map();
+        this.retainedLargeFileChunkCounts ??= new Map();
+        this.retainedChunkEntryHeads ??= new Set();
+        this.retainedEntryHeadsByFileId ??= new Map();
+
+        this.retainedLargeFileChunkCounts.delete(file.id);
+        const trackedChunkIds = this.retainedChunkIdsByFileId.get(file.id);
+        if (trackedChunkIds) {
+            for (const chunkId of [...trackedChunkIds]) {
+                this.releaseChunkRetention(file.id, chunkId);
+            }
+            this.retainedChunkIdsByFileId.delete(file.id);
+        }
+        const trackedHeads = this.retainedEntryHeadsByFileId.get(file.id);
+        if (trackedHeads) {
+            for (const head of [...trackedHeads]) {
+                this.releaseOwnedEntryHead(head, file.id);
+            }
+            this.retainedEntryHeadsByFileId.delete(file.id);
+        }
+    }
+
+    releaseLargeFileRetention(file: {
+        id: string;
+        chunkCount: number;
+        chunkEntryHeads?: unknown;
+    }) {
+        this.releaseFileRetention(file);
+    }
+
+    createFileChangeSignal(predicate: FileChangePredicate) {
+        this.activeFileChangeSignals ??= new Set();
+        let signal: FileChangeSignal;
+        signal = new FileChangeSignal(this.files.events, predicate, () => {
+            this.activeFileChangeSignals.delete(signal);
+        });
+        this.activeFileChangeSignals.add(signal);
+        return signal;
     }
 
     private async shouldKeepFileEntry(entryLike: unknown) {
         this.retainedChunkIds ??= new Set();
+        this.retainedLargeFileChunkCounts ??= new Map();
         this.retainedChunkEntryHeads ??= new Set();
-        const hash = getEntryHash(entryLike);
-        if (hash && this.retainedChunkEntryHeads.has(hash)) {
-            return true;
-        }
-
         const isSignedBySelf = (
             signatures:
                 | { publicKey?: { equals?: (key: unknown) => boolean } }[]
@@ -1725,12 +3803,20 @@ export class Files extends Program<Args> {
             signatures?.some((signature) =>
                 signature.publicKey?.equals?.(this.node.identity.publicKey)
             ) === true;
-
-        if (isSignedBySelf(getEntrySignatures(entryLike))) {
-            if (hash) {
-                this.retainedChunkEntryHeads.add(hash);
+        const hash = getEntryHash(entryLike);
+        if (hash && this.retainedChunkEntryHeads.has(hash)) {
+            const status = await this.retainedEntryHeadStatus(hash);
+            if (status === "current" || status === "unknown") {
+                return true;
             }
-            return true;
+            if (
+                isSignedBySelf(getEntrySignatures(entryLike)) &&
+                this.isPendingAuthoredEntryHead(hash)
+            ) {
+                return true;
+            }
+            this.releaseRetainedEntryHead(hash);
+            return false;
         }
 
         let entry:
@@ -1754,41 +3840,83 @@ export class Files extends Program<Args> {
             return false;
         }
 
-        if (isSignedBySelf(getEntrySignatures(entry))) {
-            const entryHash = hash ?? getEntryHash(entry);
-            if (entryHash) {
-                this.retainedChunkEntryHeads.add(entryHash);
-            }
-            return true;
-        }
-
         if (!entry) {
-            return false;
-        }
-
-        if (!this.persistChunkReads) {
             return false;
         }
 
         try {
             const operation = await entry.getPayloadValue();
             if (!isPutOperation(operation)) {
-                return false;
+                return (
+                    isDeleteOperation(operation) &&
+                    (isSignedBySelf(getEntrySignatures(entryLike)) ||
+                        isSignedBySelf(getEntrySignatures(entry)))
+                );
             }
             const file = this.files.index.valueEncoding.decoder(operation.data);
-            if (
-                (file instanceof TinyFile || isLargeFileLike(file)) &&
-                file.parentId == null
-            ) {
-                this.retainedChunkEntryHeads.add(entry.hash);
+            const signedBySelf =
+                isSignedBySelf(getEntrySignatures(entryLike)) ||
+                isSignedBySelf(getEntrySignatures(entry));
+            let currentHead: string | undefined;
+            try {
+                const current = await this.files.index.get(file.id, {
+                    local: true,
+                    remote: false,
+                } as any);
+                currentHead = getContextHead(current);
+            } catch {
+                if (
+                    signedBySelf &&
+                    this.pendingAuthoredDocumentIds.has(file.id)
+                ) {
+                    return true;
+                }
+                return false;
+            }
+            if (currentHead !== entry.hash) {
+                if (
+                    signedBySelf &&
+                    this.pendingAuthoredDocumentIds.has(file.id)
+                ) {
+                    return true;
+                }
+                return false;
+            }
+            if (!signedBySelf && !this.persistChunkReads) {
+                return false;
+            }
+
+            if (isLargeFileChunk(file)) {
+                const childStatus = await this.validateCurrentChild(file);
+                if (childStatus !== "valid") {
+                    // A current authored entry is kept conservatively if its
+                    // parent lookup failed transiently. Confirmed missing or
+                    // incompatible parents are never enough to retain it.
+                    return childStatus === "unknown" && signedBySelf;
+                }
+                if (signedBySelf) {
+                    this.retainAuthoredFile(file, entry.hash);
+                } else {
+                    this.retainChunkEntryHead(
+                        entry.hash,
+                        file.parentId,
+                        file.id
+                    );
+                }
                 return true;
             }
+
+            if (signedBySelf) {
+                this.retainAuthoredFile(file, entry.hash);
+                return true;
+            }
+
             if (
-                file instanceof TinyFile &&
-                file.parentId != null &&
-                this.retainedChunkIds.has(file.id)
+                (file instanceof TinyFile && !isLargeFileChunk(file)) ||
+                (isLargeFileLike(file) && file.parentId == null)
             ) {
-                this.retainedChunkEntryHeads.add(entry.hash);
+                this.retainFileRead(file);
+                this.retainChunkEntryHead(entry.hash, file.id, file.id);
                 return true;
             }
         } catch {
@@ -1811,7 +3939,7 @@ export class Files extends Program<Args> {
         progress?.(0);
         if (BigInt(file.byteLength) <= TINY_FILE_SIZE_LIMIT_BIGINT) {
             const tinyFile = new TinyFile({ name, file, parentId });
-            await this.files.put(tinyFile);
+            await this.putAuthoredFile(tinyFile);
             progress?.(1);
             return tinyFile.id;
         }
@@ -1846,7 +3974,7 @@ export class Files extends Program<Args> {
                 file: new Uint8Array(await file.arrayBuffer()),
                 parentId,
             });
-            await this.files.put(tinyFile);
+            await this.putAuthoredFile(tinyFile);
             progress?.(1);
             return tinyFile.id;
         }
@@ -1874,8 +4002,21 @@ export class Files extends Program<Args> {
             const chunks: Uint8Array[] = [];
             let processed = 0n;
             for await (const chunk of source.readChunks(TINY_FILE_SIZE_LIMIT)) {
-                chunks.push(chunk);
-                processed += BigInt(chunk.byteLength);
+                if (!(chunk instanceof Uint8Array)) {
+                    throw new Error("Source yielded a non-Uint8Array chunk");
+                }
+                if (chunk.byteLength === 0) {
+                    continue;
+                }
+                const nextProcessed = processed + BigInt(chunk.byteLength);
+                if (nextProcessed > source.size) {
+                    ensureSourceSize(nextProcessed, source.size);
+                }
+                // Sources are allowed to reuse their yielded buffer. Take a
+                // stable copy before requesting the next chunk.
+                const stableChunk = new Uint8Array(chunk);
+                chunks.push(stableChunk);
+                processed = nextProcessed;
             }
             ensureSourceSize(processed, source.size);
             const tinyFile = new TinyFile({
@@ -1883,7 +4024,7 @@ export class Files extends Program<Args> {
                 file: chunks.length === 0 ? new Uint8Array(0) : concat(chunks),
                 parentId,
             });
-            await this.files.put(tinyFile);
+            await this.putAuthoredFile(tinyFile);
             progress?.(1);
             return tinyFile.id;
         }
@@ -1913,6 +4054,10 @@ export class Files extends Program<Args> {
             chunkReadMaxMs: 0,
             chunkPutTotalMs: 0,
             chunkPutMaxMs: 0,
+            chunkPutConcurrencyLimit: LARGE_FILE_CHUNK_PUT_CONCURRENCY,
+            chunkPutByteLimit: LARGE_FILE_CHUNK_PUT_BYTE_LIMIT,
+            maxConcurrentChunkPuts: 0,
+            maxConcurrentChunkPutBytes: 0,
             slowestChunkIndex: null,
             slowestChunkPutMs: null,
             readyManifestStartedAt: null,
@@ -1930,50 +4075,153 @@ export class Files extends Program<Args> {
             ready: false,
         });
 
-        diagnostics.manifestStartedAt = Date.now();
-        const pendingManifest = await this.files.put(manifest);
-        diagnostics.manifestFinishedAt = Date.now();
+        let pendingManifest:
+            | Awaited<ReturnType<typeof this.putAuthoredFile>>
+            | undefined;
+        let pendingManifestHead: string | undefined;
         const hasher = new SHA256();
+        const putQueue = new BoundedAsyncWorkQueue(
+            LARGE_FILE_CHUNK_PUT_CONCURRENCY,
+            LARGE_FILE_CHUNK_PUT_BYTE_LIMIT
+        );
+        const updateQueueDiagnostics = () => {
+            diagnostics.maxConcurrentChunkPuts = putQueue.peakCount;
+            diagnostics.maxConcurrentChunkPutBytes = putQueue.peakBytes;
+        };
+        let chunkCount = 0;
+        const chunkEntryHeads: string[] = [];
+        let sourceIterator: AsyncIterator<Uint8Array> | undefined;
+        let sourceIteratorDone = false;
         try {
-            let uploadedBytes = 0n;
-            let chunkCount = 0;
-            const chunkEntryHeads: string[] = [];
-            for await (const chunkBytes of source.readChunks(chunkSize)) {
-                hasher.update(chunkBytes);
-                const putStartedAt = Date.now();
-                diagnostics.firstChunkStartedAt ??= putStartedAt;
-                const chunk = new TinyFile({
-                    name: name + "/" + chunkCount,
-                    file: chunkBytes,
-                    parentId: uploadId,
-                    index: chunkCount,
-                });
-                this.retainAuthoredChunk(chunk);
-                const appended = await this.files.put(chunk);
-                this.retainAuthoredChunk(chunk, appended.entry.hash);
-                chunkEntryHeads[chunkCount] = appended.entry.hash;
-                const putFinishedAt = Date.now();
-                const putDurationMs = putFinishedAt - putStartedAt;
-                diagnostics.firstChunkFinishedAt ??= putFinishedAt;
-                diagnostics.lastChunkFinishedAt = putFinishedAt;
-                diagnostics.chunkPutCount += 1;
-                diagnostics.chunkPutTotalMs += putDurationMs;
-                diagnostics.chunkPutMaxMs = Math.max(
-                    diagnostics.chunkPutMaxMs,
-                    putDurationMs
-                );
-                if (
-                    diagnostics.slowestChunkPutMs == null ||
-                    putDurationMs > diagnostics.slowestChunkPutMs
-                ) {
-                    diagnostics.slowestChunkPutMs = putDurationMs;
-                    diagnostics.slowestChunkIndex = chunkCount;
+            diagnostics.manifestStartedAt = Date.now();
+            pendingManifest = await this.putAuthoredFile(
+                manifest,
+                undefined,
+                (entryHead) => {
+                    pendingManifestHead ??= entryHead;
                 }
-                uploadedBytes += BigInt(chunkBytes.byteLength);
-                chunkCount++;
-                progress?.(Number(uploadedBytes) / Math.max(Number(size), 1));
+            );
+            pendingManifestHead = pendingManifest.entry.hash;
+            diagnostics.manifestFinishedAt = Date.now();
+            // Iterator construction belongs inside the guarded region: a
+            // source may throw synchronously before yielding its first chunk.
+            sourceIterator = source
+                .readChunks(chunkSize)
+                [Symbol.asyncIterator]();
+            let readBytes = 0n;
+            let committedBytes = 0n;
+            const normalizedChunk = new Uint8Array(chunkSize);
+            let normalizedChunkLength = 0;
+            const enqueueNormalizedChunk = async (chunkBytes: Uint8Array) => {
+                hasher.update(chunkBytes);
+                const chunkIndex = chunkCount;
+                await putQueue.enqueue(chunkBytes.byteLength, async () => {
+                    // The normalizer reuses its one-chunk buffer. Copy only
+                    // after queue capacity is reserved and before it is reused.
+                    const stableChunkBytes = new Uint8Array(chunkBytes);
+                    const chunk = new TinyFile({
+                        name: name + "/" + chunkIndex,
+                        file: stableChunkBytes,
+                        parentId: uploadId,
+                        index: chunkIndex,
+                    });
+                    const putStartedAt = Date.now();
+                    diagnostics.firstChunkStartedAt ??= putStartedAt;
+                    const appended = await this.putAuthoredFile(
+                        chunk,
+                        undefined,
+                        (entryHead) => {
+                            chunkEntryHeads[chunkIndex] ??= entryHead;
+                        }
+                    );
+                    chunkEntryHeads[chunkIndex] = appended.entry.hash;
+                    const putFinishedAt = Date.now();
+                    const putDurationMs = putFinishedAt - putStartedAt;
+                    diagnostics.firstChunkFinishedAt ??= putFinishedAt;
+                    diagnostics.lastChunkFinishedAt = putFinishedAt;
+                    diagnostics.chunkPutCount += 1;
+                    diagnostics.chunkPutTotalMs += putDurationMs;
+                    diagnostics.chunkPutMaxMs = Math.max(
+                        diagnostics.chunkPutMaxMs,
+                        putDurationMs
+                    );
+                    if (
+                        diagnostics.slowestChunkPutMs == null ||
+                        putDurationMs > diagnostics.slowestChunkPutMs
+                    ) {
+                        diagnostics.slowestChunkPutMs = putDurationMs;
+                        diagnostics.slowestChunkIndex = chunkIndex;
+                    }
+                    committedBytes += BigInt(stableChunkBytes.byteLength);
+                    progress?.(
+                        Math.min(
+                            Number(committedBytes) / Math.max(Number(size), 1),
+                            1
+                        )
+                    );
+                });
+                chunkCount += 1;
+                updateQueueDiagnostics();
+            };
+            while (true) {
+                const next = await Promise.race([
+                    sourceIterator.next(),
+                    putQueue.failureSignal,
+                ]);
+                if (next.done) {
+                    sourceIteratorDone = true;
+                    break;
+                }
+                const sourceBytes = next.value;
+                putQueue.throwIfFailed();
+                if (!(sourceBytes instanceof Uint8Array)) {
+                    throw new Error("Source yielded a non-Uint8Array chunk");
+                }
+                if (sourceBytes.byteLength === 0) {
+                    continue;
+                }
+                const nextReadBytes =
+                    readBytes + BigInt(sourceBytes.byteLength);
+                if (nextReadBytes > source.size) {
+                    ensureSourceSize(nextReadBytes, source.size);
+                }
+                readBytes = nextReadBytes;
+
+                let sourceOffset = 0;
+                while (sourceOffset < sourceBytes.byteLength) {
+                    // Keep the newest normalized chunk unpublished until more
+                    // data or iterator completion proves whether it is final.
+                    if (normalizedChunkLength === chunkSize) {
+                        await enqueueNormalizedChunk(normalizedChunk);
+                        normalizedChunkLength = 0;
+                    }
+                    const take = Math.min(
+                        chunkSize - normalizedChunkLength,
+                        sourceBytes.byteLength - sourceOffset
+                    );
+                    normalizedChunk.set(
+                        sourceBytes.subarray(sourceOffset, sourceOffset + take),
+                        normalizedChunkLength
+                    );
+                    normalizedChunkLength += take;
+                    sourceOffset += take;
+                }
+                if (
+                    normalizedChunkLength === chunkSize &&
+                    readBytes < source.size
+                ) {
+                    await enqueueNormalizedChunk(normalizedChunk);
+                    normalizedChunkLength = 0;
+                }
             }
-            ensureSourceSize(uploadedBytes, source.size);
+            ensureSourceSize(readBytes, source.size);
+            if (normalizedChunkLength > 0) {
+                await enqueueNormalizedChunk(
+                    normalizedChunk.subarray(0, normalizedChunkLength)
+                );
+            }
+            await putQueue.drain();
+            updateQueueDiagnostics();
             diagnostics.readyManifestStartedAt = Date.now();
             const readyManifest = new LargeFileWithChunkHeads({
                 id: uploadId,
@@ -1984,17 +4232,36 @@ export class Files extends Program<Args> {
                 finalHash: toBase64(hasher.digest()),
                 chunkEntryHeads,
             });
-            await this.files.put(readyManifest, {
-                meta: { next: [pendingManifest.entry] },
-            });
+            await this.commitReadyManifest(
+                manifest,
+                pendingManifest,
+                readyManifest
+            );
             diagnostics.readyManifestFinishedAt = Date.now();
             diagnostics.chunkCount = chunkCount;
         } catch (error) {
+            if (!sourceIteratorDone) {
+                try {
+                    const returned = sourceIterator?.return?.();
+                    if (returned) {
+                        void Promise.resolve(returned).catch(() => undefined);
+                    }
+                } catch {
+                    // Best-effort cancellation; cleanup must not wait on a
+                    // source whose current next() is blocked.
+                }
+            }
+            await putQueue.settle();
+            updateQueueDiagnostics();
             diagnostics.failureAt = Date.now();
             diagnostics.failureMessage =
                 error instanceof Error ? error.message : String(error);
-            await this.cleanupChunkedUpload(uploadId).catch(() => {});
-            await this.files.del(uploadId).catch(() => {});
+            await this.cleanupFailedUploadIfCurrent(
+                manifest,
+                pendingManifest?.entry.hash ?? pendingManifestHead,
+                chunkEntryHeads,
+                Math.max(expectedChunkCount, chunkCount)
+            );
             throw error;
         }
 
@@ -2003,18 +4270,93 @@ export class Files extends Program<Args> {
         return uploadId;
     }
 
-    private async cleanupChunkedUpload(uploadId: string) {
-        const chunks = await this.files.index.search(
-            new SearchRequest({
-                query: new StringMatch({
-                    key: "parentId",
-                    value: uploadId,
-                }),
-                fetch: 0xffffffff,
-            }),
-            { local: true }
-        );
-        await Promise.all(chunks.map((chunk) => this.files.del(chunk.id)));
+    private async cleanupChunkedUpload(
+        uploadId: string,
+        _expectedChunkCount: number,
+        chunkEntryHeads: string[],
+        preserveFailedCleanupState = false
+    ) {
+        let firstError: unknown;
+        for (const [index, expectedHead] of chunkEntryHeads.entries()) {
+            if (!expectedHead) {
+                continue;
+            }
+            const chunkId = getChunkId(uploadId, index);
+            let current: AbstractFile | undefined;
+            let releaseExpectedHead = false;
+            try {
+                current = await this.files.index.get(chunkId, {
+                    local: true,
+                    remote: false,
+                });
+                if (
+                    !isLargeFileChunk(current) ||
+                    current.parentId !== uploadId ||
+                    getContextHead(current) !== expectedHead
+                ) {
+                    releaseExpectedHead = true;
+                    continue;
+                }
+                const targetEntry = await this.files.log.log.get(expectedHead);
+                if (!targetEntry) {
+                    throw new Error(
+                        `Missing exact entry '${expectedHead}' while cleaning chunk '${chunkId}'`
+                    );
+                }
+                try {
+                    await this.files.del(chunkId, {
+                        meta: { next: [targetEntry] },
+                    });
+                } catch (error) {
+                    try {
+                        current = await this.files.index.get(chunkId, {
+                            local: true,
+                            remote: false,
+                        });
+                    } catch {
+                        throw error;
+                    }
+                    if (getContextHead(current) === expectedHead) {
+                        throw error;
+                    }
+                }
+                current = await this.files.index.get(chunkId, {
+                    local: true,
+                    remote: false,
+                });
+                if (getContextHead(current) === expectedHead) {
+                    throw new Error(
+                        `Exact chunk '${chunkId}' remained after deletion`
+                    );
+                }
+                releaseExpectedHead = true;
+            } catch (error) {
+                firstError ??= error;
+            } finally {
+                if (releaseExpectedHead || !preserveFailedCleanupState) {
+                    this.releaseOwnedEntryHead(expectedHead, uploadId, chunkId);
+                    try {
+                        current = await this.files.index.get(chunkId, {
+                            local: true,
+                            remote: false,
+                        });
+                        if (
+                            !current ||
+                            getContextHead(current) === expectedHead
+                        ) {
+                            this.forgetRetainedChunkRead(uploadId, chunkId);
+                        }
+                    } catch {
+                        // Preserve id-level retention when replacement state cannot
+                        // be established safely.
+                    }
+                }
+            }
+        }
+
+        if (firstError) {
+            throw firstError;
+        }
     }
 
     private async addChunkedFile(
@@ -2048,6 +4390,10 @@ export class Files extends Program<Args> {
             chunkReadMaxMs: 0,
             chunkPutTotalMs: 0,
             chunkPutMaxMs: 0,
+            chunkPutConcurrencyLimit: LARGE_FILE_CHUNK_PUT_CONCURRENCY,
+            chunkPutByteLimit: LARGE_FILE_CHUNK_PUT_BYTE_LIMIT,
+            maxConcurrentChunkPuts: 0,
+            maxConcurrentChunkPutBytes: 0,
             slowestChunkIndex: null,
             slowestChunkPutMs: null,
             readyManifestStartedAt: null,
@@ -2065,16 +4411,37 @@ export class Files extends Program<Args> {
             ready: false,
         });
 
-        diagnostics.manifestStartedAt = Date.now();
-        const pendingManifest = await this.files.put(manifest);
-        diagnostics.manifestFinishedAt = Date.now();
+        let pendingManifest:
+            | Awaited<ReturnType<typeof this.putAuthoredFile>>
+            | undefined;
+        let pendingManifestHead: string | undefined;
         const hasher = new SHA256();
+        const putQueue = new BoundedAsyncWorkQueue(
+            LARGE_FILE_CHUNK_PUT_CONCURRENCY,
+            LARGE_FILE_CHUNK_PUT_BYTE_LIMIT
+        );
+        const chunkEntryHeads: string[] = [];
+        const updateQueueDiagnostics = () => {
+            diagnostics.maxConcurrentChunkPuts = putQueue.peakCount;
+            diagnostics.maxConcurrentChunkPutBytes = putQueue.peakBytes;
+        };
         try {
-            let uploadedBytes = 0;
-            const chunkEntryHeads: string[] = [];
+            diagnostics.manifestStartedAt = Date.now();
+            pendingManifest = await this.putAuthoredFile(
+                manifest,
+                undefined,
+                (entryHead) => {
+                    pendingManifestHead ??= entryHead;
+                }
+            );
+            pendingManifestHead = pendingManifest.entry.hash;
+            diagnostics.manifestFinishedAt = Date.now();
+            let committedBytes = 0;
             for (let i = 0; i < chunkCount; i++) {
+                putQueue.throwIfFailed();
                 const readStartedAt = Date.now();
                 const chunkBytes = await getChunk(i);
+                putQueue.throwIfFailed();
                 const readFinishedAt = Date.now();
                 diagnostics.chunkReadTotalMs += readFinishedAt - readStartedAt;
                 diagnostics.chunkReadMaxMs = Math.max(
@@ -2082,38 +4449,52 @@ export class Files extends Program<Args> {
                     readFinishedAt - readStartedAt
                 );
                 hasher.update(chunkBytes);
-                const putStartedAt = Date.now();
-                diagnostics.firstChunkStartedAt ??= putStartedAt;
-                const chunk = new TinyFile({
-                    name: name + "/" + i,
-                    file: chunkBytes,
-                    parentId: uploadId,
-                    index: i,
+                await putQueue.enqueue(chunkBytes.byteLength, async () => {
+                    // Reserve queue capacity before allocating the stable
+                    // per-chunk copy counted by the byte limit.
+                    const stableChunkBytes = new Uint8Array(chunkBytes);
+                    const chunk = new TinyFile({
+                        name: name + "/" + i,
+                        file: stableChunkBytes,
+                        parentId: uploadId,
+                        index: i,
+                    });
+                    const putStartedAt = Date.now();
+                    diagnostics.firstChunkStartedAt ??= putStartedAt;
+                    const appended = await this.putAuthoredFile(
+                        chunk,
+                        undefined,
+                        (entryHead) => {
+                            chunkEntryHeads[i] ??= entryHead;
+                        }
+                    );
+                    chunkEntryHeads[i] = appended.entry.hash;
+                    const putFinishedAt = Date.now();
+                    const putDurationMs = putFinishedAt - putStartedAt;
+                    diagnostics.firstChunkFinishedAt ??= putFinishedAt;
+                    diagnostics.lastChunkFinishedAt = putFinishedAt;
+                    diagnostics.chunkPutCount += 1;
+                    diagnostics.chunkPutTotalMs += putDurationMs;
+                    diagnostics.chunkPutMaxMs = Math.max(
+                        diagnostics.chunkPutMaxMs,
+                        putDurationMs
+                    );
+                    if (
+                        diagnostics.slowestChunkPutMs == null ||
+                        putDurationMs > diagnostics.slowestChunkPutMs
+                    ) {
+                        diagnostics.slowestChunkPutMs = putDurationMs;
+                        diagnostics.slowestChunkIndex = i;
+                    }
+                    committedBytes += stableChunkBytes.byteLength;
+                    progress?.(
+                        Math.min(committedBytes / Math.max(Number(size), 1), 1)
+                    );
                 });
-                this.retainAuthoredChunk(chunk);
-                const appended = await this.files.put(chunk);
-                this.retainAuthoredChunk(chunk, appended.entry.hash);
-                chunkEntryHeads[i] = appended.entry.hash;
-                const putFinishedAt = Date.now();
-                const putDurationMs = putFinishedAt - putStartedAt;
-                diagnostics.firstChunkFinishedAt ??= putFinishedAt;
-                diagnostics.lastChunkFinishedAt = putFinishedAt;
-                diagnostics.chunkPutCount += 1;
-                diagnostics.chunkPutTotalMs += putDurationMs;
-                diagnostics.chunkPutMaxMs = Math.max(
-                    diagnostics.chunkPutMaxMs,
-                    putDurationMs
-                );
-                if (
-                    diagnostics.slowestChunkPutMs == null ||
-                    putDurationMs > diagnostics.slowestChunkPutMs
-                ) {
-                    diagnostics.slowestChunkPutMs = putDurationMs;
-                    diagnostics.slowestChunkIndex = i;
-                }
-                uploadedBytes += chunkBytes.byteLength;
-                progress?.(uploadedBytes / Math.max(Number(size), 1));
+                updateQueueDiagnostics();
             }
+            await putQueue.drain();
+            updateQueueDiagnostics();
             diagnostics.readyManifestStartedAt = Date.now();
             const readyManifest = new LargeFileWithChunkHeads({
                 id: uploadId,
@@ -2124,16 +4505,24 @@ export class Files extends Program<Args> {
                 finalHash: toBase64(hasher.digest()),
                 chunkEntryHeads,
             });
-            await this.files.put(readyManifest, {
-                meta: { next: [pendingManifest.entry] },
-            });
+            await this.commitReadyManifest(
+                manifest,
+                pendingManifest,
+                readyManifest
+            );
             diagnostics.readyManifestFinishedAt = Date.now();
         } catch (error) {
+            await putQueue.settle();
+            updateQueueDiagnostics();
             diagnostics.failureAt = Date.now();
             diagnostics.failureMessage =
                 error instanceof Error ? error.message : String(error);
-            await this.cleanupChunkedUpload(uploadId).catch(() => {});
-            await this.files.del(uploadId).catch(() => {});
+            await this.cleanupFailedUploadIfCurrent(
+                manifest,
+                pendingManifest?.entry.hash ?? pendingManifestHead,
+                chunkEntryHeads,
+                chunkCount
+            );
             throw error;
         }
 
@@ -2142,12 +4531,135 @@ export class Files extends Program<Args> {
         return uploadId;
     }
 
-    async removeById(id: string) {
-        const file = await this.files.index.get(id);
-        if (file) {
-            await file.delete(this);
-            await this.files.del(file.id);
+    private async removeFileUnlocked(file: AbstractFile) {
+        if (isLargeFileLike(file)) {
+            this.pendingLargeFileDeletions ??= new Map();
+            let pending = this.pendingLargeFileDeletions.get(file.id);
+            if (!pending) {
+                try {
+                    await this.files.del(file.id);
+                } catch (error) {
+                    await this.confirmRejectedDeleteCommitted(file.id, error);
+                }
+                pending = file;
+                this.pendingLargeFileDeletions.set(file.id, pending);
+            }
+
+            const chunkEntryHeads = getCompleteChunkEntryHeads(pending);
+            if (chunkEntryHeads) {
+                await this.cleanupChunkedUpload(
+                    pending.id,
+                    pending.chunkCount,
+                    chunkEntryHeads,
+                    true
+                );
+                const rootHead = getContextHead(pending);
+                if (rootHead) {
+                    this.releaseOwnedEntryHead(
+                        rootHead,
+                        pending.id,
+                        pending.id
+                    );
+                }
+                const currentRoot = await this.files.index.get(pending.id, {
+                    local: true,
+                    remote: false,
+                });
+                if (isLargeFileLike(currentRoot)) {
+                    this.retainedLargeFileChunkCounts.set(
+                        pending.id,
+                        currentRoot.chunkCount
+                    );
+                } else {
+                    this.retainedLargeFileChunkCounts.delete(pending.id);
+                }
+            } else {
+                await (toReadableLargeFile(pending) ?? pending).delete(this);
+                this.releaseFileRetention(pending);
+            }
+            this.pendingLargeFileDeletions.delete(file.id);
+            return;
         }
+
+        const head = getContextHead(file);
+        try {
+            await this.files.del(file.id);
+        } catch (error) {
+            await this.confirmRejectedDeleteCommitted(file.id, error);
+        }
+
+        if (isLargeFileChunk(file)) {
+            this.releaseChunkRetention(file.parentId, file.id, head);
+            return;
+        }
+
+        this.releaseFileRetention(file);
+    }
+
+    private removeFile(file: AbstractFile) {
+        return this.withFileMutation(file.id, () =>
+            this.removeFileUnlocked(file)
+        );
+    }
+
+    async removeById(id: string) {
+        await this.withFileMutation(id, async () => {
+            const pending = this.pendingLargeFileDeletions?.get(id);
+            if (pending) {
+                await this.removeFileUnlocked(pending);
+                return;
+            }
+            let file = await this.files.index.get(id, {
+                local: true,
+                remote: false,
+            });
+            if (!file) {
+                const remoteFrom = await this.getReadPeerHints();
+                if (!remoteFrom?.length) {
+                    throw new Error(
+                        `Cannot confirm whether file '${id}' exists because no remote read peers are available`
+                    );
+                }
+                const remoteMatches = await this.files.index.search(
+                    new SearchRequest({
+                        query: new StringMatch({
+                            key: "id",
+                            value: id,
+                            caseInsensitive: false,
+                            method: StringMatchMethod.exact,
+                        }),
+                        fetch: 0xffffffff,
+                    }),
+                    {
+                        local: false,
+                        remote: {
+                            timeout: 10_000,
+                            throwOnMissing: true,
+                            retryMissingResponses: false,
+                            replicate: true,
+                            from: remoteFrom,
+                        },
+                    } as any
+                );
+                const remoteRoot = remoteMatches.find(
+                    (candidate) =>
+                        candidate.id === id && candidate.parentId == null
+                );
+                if (!remoteRoot) {
+                    return;
+                }
+                file = await this.files.index.get(id, {
+                    local: true,
+                    remote: false,
+                });
+                if (!file || file.id !== id || file.parentId != null) {
+                    throw new Error(
+                        `Failed to materialize current remote file '${id}' for deletion`
+                    );
+                }
+            }
+            await this.removeFileUnlocked(file);
+        });
     }
 
     async removeByName(name: string) {
@@ -2163,8 +4675,7 @@ export class Files extends Program<Args> {
             })
         );
         for (const file of files) {
-            await file.delete(this);
-            await this.files.del(file.id);
+            await this.removeFile(file);
         }
     }
 
@@ -2240,6 +4751,33 @@ export class Files extends Program<Args> {
         return count;
     }
 
+    /**
+     * Count exact manifest entry blocks that are present in the local block
+     * store. This is deliberately separate from countLocalChunks(), which
+     * reports Documents index rows. Persisted observer reads cache exact entry
+     * blocks without joining them into the replication log or document index.
+     *
+     * Undefined means the manifest does not contain one valid entry head for
+     * every chunk, so block locality cannot be measured by this fast path.
+     */
+    async countLocalChunkBlocks(
+        parent: LargeFile
+    ): Promise<number | undefined> {
+        const candidateHeads = getCompleteChunkEntryHeads(parent);
+        if (!candidateHeads) {
+            return undefined;
+        }
+
+        const blocks = this.files.log.log.blocks;
+        const local =
+            typeof blocks.hasMany === "function"
+                ? await blocks.hasMany(candidateHeads)
+                : await Promise.all(
+                      candidateHeads.map((head) => blocks.has(head))
+                  );
+        return local.reduce((count, present) => count + (present ? 1 : 0), 0);
+    }
+
     async resolveById(
         id: string,
         properties?: {
@@ -2266,6 +4804,22 @@ export class Files extends Program<Args> {
                 replicate: properties?.replicate,
                 from: properties?.from,
             },
+        });
+    }
+
+    private withFileMutation<T>(id: string, operation: () => Promise<T>) {
+        this.fileMutationTails ??= new Map();
+        const previous = this.fileMutationTails.get(id) ?? Promise.resolve();
+        const result = previous.then(operation, operation);
+        const tail = result.then(
+            () => undefined,
+            () => undefined
+        );
+        this.fileMutationTails.set(id, tail);
+        return result.finally(() => {
+            if (this.fileMutationTails.get(id) === tail) {
+                this.fileMutationTails.delete(id);
+            }
         });
     }
 
@@ -2400,6 +4954,42 @@ export class Files extends Program<Args> {
                 };
             }
         }
+    }
+
+    private clearFileRuntimeState() {
+        this.activeFileChangeSignals ??= new Set();
+        for (const signal of [...this.activeFileChangeSignals]) {
+            signal.close();
+        }
+        this.activeFileChangeSignals.clear();
+        this.retainedChunkIds?.clear();
+        this.retainedChunkIdsByFileId?.clear();
+        this.retainedLargeFileChunkCounts?.clear();
+        this.retainedChunkEntryHeads?.clear();
+        this.retainedEntryHeadsByFileId?.clear();
+        this.retainedEntryHeadsByDocumentId?.clear();
+        this.retainedChunkEntryHeadOwners?.clear();
+        this.retainedEntryHeadDocumentIds?.clear();
+        this.unscopedRetainedChunkEntryHeads?.clear();
+        this.pendingAuthoredDocumentIds?.clear();
+        this.fileMutationTails?.clear();
+        this.pendingLargeFileDeletions?.clear();
+    }
+
+    async close(from?: Program): Promise<boolean> {
+        const closed = await super.close(from);
+        if (closed) {
+            this.clearFileRuntimeState();
+        }
+        return closed;
+    }
+
+    async drop(from?: Program): Promise<boolean> {
+        const dropped = await super.drop(from);
+        if (dropped) {
+            this.clearFileRuntimeState();
+        }
+        return dropped;
     }
 
     // Setup lifecycle, will be invoked on 'open'

--- a/packages/file-share/library/src/read-scheduling.ts
+++ b/packages/file-share/library/src/read-scheduling.ts
@@ -1,0 +1,45 @@
+export const REMOTE_PERSISTED_READ_AHEAD_MIN = 2;
+const REMOTE_PERSISTED_READ_AHEAD_MAX = 8;
+const REMOTE_PERSISTED_READ_AHEAD_BYTE_BUDGET = 4 * 1024 * 1024;
+const REMOTE_PERSISTED_READ_AHEAD_GROW_WAIT_MS = 25;
+
+export const getRemotePersistedReadAheadLimit = (
+    size: number | bigint,
+    chunkCount: number
+) => {
+    if (chunkCount <= 0) {
+        return 0;
+    }
+    const estimatedChunkBytes = Math.max(
+        1,
+        Math.ceil(Number(size) / chunkCount)
+    );
+    const byteBudgetLimit = Math.max(
+        1,
+        Math.floor(
+            REMOTE_PERSISTED_READ_AHEAD_BYTE_BUDGET / estimatedChunkBytes
+        )
+    );
+    return Math.min(
+        chunkCount,
+        REMOTE_PERSISTED_READ_AHEAD_MAX,
+        byteBudgetLimit
+    );
+};
+
+export const adaptRemotePersistedReadAhead = (
+    current: number,
+    limit: number,
+    observation: { demandWaitMs: number; attempts: number }
+) => {
+    if (observation.attempts > 1) {
+        return Math.max(
+            Math.min(REMOTE_PERSISTED_READ_AHEAD_MIN, limit),
+            Math.floor(current / 2)
+        );
+    }
+    if (observation.demandWaitMs >= REMOTE_PERSISTED_READ_AHEAD_GROW_WAIT_MS) {
+        return Math.min(limit, current + 1);
+    }
+    return current;
+};


### PR DESCRIPTION
## Summary

- make large uploads transactional, exact-head safe, bounded to four puts and two MiB, and retry-safe during cleanup
- stream reads with shared cancellation/deadlines, adaptive bounded prefetch, exact manifest-head lookup, integrity checks, and constant-space retention
- separate Documents index locality from exact local block presence for demand-persisted reads
- coalesce incremental UI refreshes, stabilize provider and dial state, reconcile remote roots safely, and clean up transfer lifecycles
- add deterministic production 64/256 MiB transfer cohorts with topology, integrity, heap, RSS, and real streaming-file evidence

## Correctness fixes

- pending-to-ready manifests and post-commit rejection reconciliation
- captured-head rollback and ownership-safe deletion
- retryable exact child cleanup after the root tombstone commits
- strict source geometry, chunk size, hash, and cancellation validation
- storage-limit bytes/MB round-trip without remount inflation
- observer, live-replicator, and cold-persisted cohort invariants

## Validation

- library: 141/141 tests
- frontend: 116/116 unit tests
- CLI: 6/6 tests
- library, frontend, and CLI builds
- formatting and diff checks
- production Chromium matrix: 24/24 integrity/topology/memory-valid transfers
- 64 MiB live median download: 8.93 MiB/s versus 6.02 MiB/s stock
- 256 MiB live median download: 5.47 MiB/s; all three runs completed, with no censored hang
- independent Critical/P1/P2 review approved