### PR TITLE
perf(file-share): increase bounded upload concurrency

### DIFF
--- a/.changeset/bright-files-upload.md
+++ b/.changeset/bright-files-upload.md
@@ -1,0 +1,6 @@
+---
+"@peerbit/please": patch
+"@peerbit/please-lib": patch
+---
+
+Increase the bounded large-file upload queue to eight concurrent chunk puts and four MiB after counterbalanced production-browser validation. Clarify index-row diagnostics separately from exact local block presence and require complete post-read blocks in live transfer benchmarks.

--- a/packages/file-share/frontend/src/Drop.tsx
+++ b/packages/file-share/frontend/src/Drop.tsx
@@ -801,31 +801,39 @@ export const Drop = () => {
                 );
                 const peerAddresses = getPeerDialAddresses(peer);
                 const listedFiles = await Promise.all(
-                    list.map(async (file) => ({
-                        id: file.id,
-                        name: file.name,
-                        type: isLargeFileLike(file) ? "large" : "tiny",
-                        size: file.size.toString(),
-                        ready: isLargeFileLike(file) ? file.ready : undefined,
-                        finalHash: isLargeFileLike(file)
-                            ? file.finalHash
-                            : undefined,
-                        chunkCount: isLargeFileLike(file)
-                            ? file.chunkCount
-                            : undefined,
-                        localChunkCount:
+                    list.map(async (file) => {
+                        const [localChunkIndexRowCount, localChunkBlockCount] =
                             activeProgram && isLargeFileLike(file)
-                                ? await activeProgram
-                                      .countLocalChunks(file)
-                                      .catch(() => null)
+                                ? await Promise.all([
+                                      activeProgram
+                                          .countLocalChunks(file)
+                                          .catch(() => null),
+                                      activeProgram
+                                          .countLocalChunkBlocks(file)
+                                          .catch(() => null),
+                                  ])
+                                : [undefined, undefined];
+                        return {
+                            id: file.id,
+                            name: file.name,
+                            type: isLargeFileLike(file) ? "large" : "tiny",
+                            size: file.size.toString(),
+                            ready: isLargeFileLike(file)
+                                ? file.ready
                                 : undefined,
-                        localChunkBlockCount:
-                            activeProgram && isLargeFileLike(file)
-                                ? await activeProgram
-                                      .countLocalChunkBlocks(file)
-                                      .catch(() => null)
+                            finalHash: isLargeFileLike(file)
+                                ? file.finalHash
                                 : undefined,
-                    }))
+                            chunkCount: isLargeFileLike(file)
+                                ? file.chunkCount
+                                : undefined,
+                            localChunkIndexRowCount,
+                            // Compatibility alias for existing benchmark
+                            // consumers. This is not a local-block count.
+                            localChunkCount: localChunkIndexRowCount,
+                            localChunkBlockCount,
+                        };
+                    })
                 );
                 return {
                     programAddress: program?.address ?? null,

--- a/packages/file-share/frontend/tests/transfer-benchmark.ts
+++ b/packages/file-share/frontend/tests/transfer-benchmark.ts
@@ -211,12 +211,62 @@ export type ReaderCohortEvidence = {
     integrityVerified: boolean;
     programPersistChunkReads: boolean | null;
     persistChunkReads: boolean | null;
+    /** Documents index rows; retained for result-schema compatibility. */
     initialLocalChunkCount: number | null;
+    /** Exact manifest-entry blocks present in the local block store. */
     initialLocalChunkBlockCount: number | null;
     readAheadSource: string | null;
+    /** Documents index rows; retained for result-schema compatibility. */
     postReadLocalChunkCount: number | null;
+    /** Exact manifest-entry blocks present in the local block store. */
     postReadLocalChunkBlockCount: number | null;
     chunkCount: number | null;
+};
+
+export const resolveCompatibleIndexRowCount = (
+    explicitIndexRowCount: number | null,
+    legacyLocalChunkCount: number | null,
+    label: string
+) => {
+    if (
+        explicitIndexRowCount != null &&
+        legacyLocalChunkCount != null &&
+        explicitIndexRowCount !== legacyLocalChunkCount
+    ) {
+        throw new Error(
+            `${label} index-row diagnostics disagree: explicit=${explicitIndexRowCount}, legacy=${legacyLocalChunkCount}`
+        );
+    }
+    return explicitIndexRowCount ?? legacyLocalChunkCount;
+};
+
+const requireCompletePostReadChunkBlocks = (
+    evidence: ReaderCohortEvidence,
+    validationReasons: string[]
+) => {
+    const hasKnownPositiveChunkCount =
+        evidence.chunkCount != null &&
+        Number.isFinite(evidence.chunkCount) &&
+        evidence.chunkCount > 0;
+    if (!hasKnownPositiveChunkCount) {
+        validationReasons.push(
+            evidence.chunkCount == null
+                ? "missing-chunk-count"
+                : "invalid-chunk-count"
+        );
+    }
+    if (evidence.postReadLocalChunkBlockCount == null) {
+        validationReasons.push("missing-post-read-local-block-count");
+    } else if (
+        hasKnownPositiveChunkCount &&
+        evidence.postReadLocalChunkBlockCount !== evidence.chunkCount
+    ) {
+        validationReasons.push(
+            evidence.postReadLocalChunkBlockCount < evidence.chunkCount!
+                ? "incomplete-post-read-local-chunk-blocks"
+                : "unexpected-post-read-local-chunk-block-count"
+        );
+    }
 };
 
 const classifyLiveRead = ({
@@ -270,6 +320,7 @@ export const classifyReaderCohort = (
         ) {
             validationReasons.push("live-read-ahead-mismatch");
         }
+        requireCompletePostReadChunkBlocks(evidence, validationReasons);
     } else if (cohort === "cold-observer") {
         classification = "cold";
         classificationBasis = "configured-cold-observer";
@@ -313,25 +364,7 @@ export const classifyReaderCohort = (
         if (evidence.readAheadSource !== "persisted-remote-adaptive") {
             validationReasons.push("persisted-read-ahead-mismatch");
         }
-        const hasKnownPositiveChunkCount =
-            evidence.chunkCount != null &&
-            Number.isFinite(evidence.chunkCount) &&
-            evidence.chunkCount > 0;
-        if (!hasKnownPositiveChunkCount) {
-            validationReasons.push(
-                evidence.chunkCount == null
-                    ? "missing-chunk-count"
-                    : "invalid-chunk-count"
-            );
-        }
-        if (evidence.postReadLocalChunkBlockCount == null) {
-            validationReasons.push("missing-post-read-local-block-count");
-        } else if (
-            hasKnownPositiveChunkCount &&
-            evidence.postReadLocalChunkBlockCount < evidence.chunkCount!
-        ) {
-            validationReasons.push("incomplete-post-read-local-chunk-blocks");
-        }
+        requireCompletePostReadChunkBlocks(evidence, validationReasons);
     }
 
     const valid = validationReasons.length === 0;
@@ -344,6 +377,8 @@ export const classifyReaderCohort = (
         eligible: cohort === "live-replicator" ? true : valid,
         valid,
         ...evidence,
+        initialLocalChunkIndexRowCount: evidence.initialLocalChunkCount,
+        postReadLocalChunkIndexRowCount: evidence.postReadLocalChunkCount,
         classificationBasis,
         validationReasons,
     };

--- a/packages/file-share/frontend/tests/transfer-benchmark.unit.test.ts
+++ b/packages/file-share/frontend/tests/transfer-benchmark.unit.test.ts
@@ -4,6 +4,7 @@ import {
     classifyReaderCohort,
     classifyReaderTopology,
     getBrowserDialablePeerAddresses,
+    resolveCompatibleIndexRowCount,
     resolveReaderCohort,
     stopSamplerAtCompletion,
     TINY_FILE_SIZE_LIMIT_BYTES,
@@ -46,6 +47,15 @@ const readyTopology = (
 });
 
 describe("file-share transfer benchmark cohorts", () => {
+    it("prefers explicit index-row diagnostics and rejects alias drift", () => {
+        expect(resolveCompatibleIndexRowCount(7, 7, "post-read")).toBe(7);
+        expect(resolveCompatibleIndexRowCount(null, 6, "post-read")).toBe(6);
+        expect(resolveCompatibleIndexRowCount(5, null, "post-read")).toBe(5);
+        expect(() => resolveCompatibleIndexRowCount(7, 6, "post-read")).toThrow(
+            "post-read index-row diagnostics disagree: explicit=7, legacy=6"
+        );
+    });
+
     it("selects browser-dialable writer addresses without duplicates", () => {
         expect(
             getBrowserDialablePeerAddresses([
@@ -294,6 +304,8 @@ describe("file-share transfer benchmark cohorts", () => {
             valid: true,
             classification: "indexed-local",
             classificationBasis: "initial-index-row-count",
+            initialLocalChunkIndexRowCount: 8,
+            postReadLocalChunkIndexRowCount: 0,
         });
         expect(
             classifyReaderCohort(
@@ -336,6 +348,46 @@ describe("file-share transfer benchmark cohorts", () => {
             ).validationReasons
         ).toContain("live-read-ahead-mismatch");
     });
+
+    it("accepts partial live index rows when every exact chunk block is local", () => {
+        expect(
+            classifyReaderCohort(
+                "live-replicator",
+                validEvidence({
+                    initialLocalChunkCount: 3,
+                    postReadLocalChunkCount: 7,
+                    postReadLocalChunkBlockCount: 8,
+                })
+            )
+        ).toMatchObject({
+            eligible: true,
+            valid: true,
+            classification: "indexed-hybrid",
+            postReadLocalChunkIndexRowCount: 7,
+            postReadLocalChunkBlockCount: 8,
+            validationReasons: [],
+        });
+    });
+
+    it.each([
+        [null, "missing-post-read-local-block-count"],
+        [7, "incomplete-post-read-local-chunk-blocks"],
+        [9, "unexpected-post-read-local-chunk-block-count"],
+    ] as const)(
+        "rejects a live read with post-read exact-block count %s",
+        (postReadLocalChunkBlockCount, validationReason) => {
+            expect(
+                classifyReaderCohort(
+                    "live-replicator",
+                    validEvidence({ postReadLocalChunkBlockCount })
+                )
+            ).toMatchObject({
+                eligible: true,
+                valid: false,
+                validationReasons: [validationReason],
+            });
+        }
+    );
 
     it("validates a non-persisting observer read", () => {
         expect(

--- a/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/transfer.bench.e2e.spec.ts
@@ -31,6 +31,7 @@ import {
     classifyReaderTopology,
     getBrowserDialablePeerAddresses,
     getLegacyReaderRole,
+    resolveCompatibleIndexRowCount,
     resolveReaderCohort,
     stopSamplerAtCompletion,
     validateJsHeapMeasurement,
@@ -751,6 +752,16 @@ const createCohortResult = (
 ) => {
     const read = asRecord(diagnostics?.lastReadDiagnostics);
     const listedFile = getListedFile(diagnostics, fileName);
+    const initialLocalChunkIndexRowCount = resolveCompatibleIndexRowCount(
+        asNumber(read?.initialLocalChunkIndexRowCount),
+        asNumber(read?.initialLocalChunkCount),
+        "initial local chunk"
+    );
+    const postReadLocalChunkIndexRowCount = resolveCompatibleIndexRowCount(
+        asNumber(listedFile?.localChunkIndexRowCount),
+        asNumber(listedFile?.localChunkCount),
+        "post-read local chunk"
+    );
     return classifyReaderCohort(cohort, {
         integrityVerified,
         programPersistChunkReads:
@@ -761,7 +772,7 @@ const createCohortResult = (
             typeof read?.persistChunkReads === "boolean"
                 ? read.persistChunkReads
                 : null,
-        initialLocalChunkCount: asNumber(read?.initialLocalChunkCount),
+        initialLocalChunkCount: initialLocalChunkIndexRowCount,
         initialLocalChunkBlockCount: asNumber(
             read?.initialLocalChunkBlockCount
         ),
@@ -769,7 +780,7 @@ const createCohortResult = (
             typeof read?.readAheadSource === "string"
                 ? read.readAheadSource
                 : null,
-        postReadLocalChunkCount: asNumber(listedFile?.localChunkCount),
+        postReadLocalChunkCount: postReadLocalChunkIndexRowCount,
         postReadLocalChunkBlockCount: asNumber(
             listedFile?.localChunkBlockCount
         ),

--- a/packages/file-share/library/src/__tests__/index.integration.test.ts
+++ b/packages/file-share/library/src/__tests__/index.integration.test.ts
@@ -1681,10 +1681,10 @@ describe("index", () => {
             );
             expect(
                 filestore.lastUploadDiagnostics?.maxConcurrentChunkPuts
-            ).to.be.within(1, 4);
+            ).to.be.within(1, 8);
             expect(
                 filestore.lastUploadDiagnostics?.maxConcurrentChunkPutBytes
-            ).to.be.lessThanOrEqual(2 * 1024 * 1024);
+            ).to.be.lessThanOrEqual(4 * 1024 * 1024);
             expect(
                 filestore.lastUploadDiagnostics?.manifestFinishedAt
             ).to.not.eq(null);
@@ -1865,7 +1865,9 @@ describe("index", () => {
             }
 
             const diagnostics = filestore.lastUploadDiagnostics!;
-            expect(maxActivePuts).to.eq(4);
+            expect(maxActivePuts).to.eq(8);
+            expect(diagnostics.chunkPutConcurrencyLimit).to.eq(8);
+            expect(diagnostics.chunkPutByteLimit).to.eq(4 * 1024 * 1024);
             expect(maxActivePuts).to.be.lessThanOrEqual(
                 diagnostics.chunkPutConcurrencyLimit
             );
@@ -1974,7 +1976,8 @@ describe("index", () => {
 
             const diagnostics = filestore.lastUploadDiagnostics!;
             expect(maxActivePuts).to.be.greaterThan(1);
-            expect(maxActivePuts).to.be.lessThanOrEqual(4);
+            expect(maxActivePuts).to.be.lessThanOrEqual(8);
+            expect(diagnostics.chunkPutConcurrencyLimit).to.eq(8);
             expect(activePuts).to.eq(0);
             expect(readyManifestWritten).to.be.false;
             expect(diagnostics.readyManifestStartedAt).to.eq(null);
@@ -2171,6 +2174,9 @@ describe("index", () => {
             expect(readAhead).to.be.lessThanOrEqual(file!.chunkCount);
             expect(readDiagnostics.readAheadSource).to.eq(
                 "persisted-remote-adaptive"
+            );
+            expect(readDiagnostics.initialLocalChunkIndexRowCount).to.eq(
+                readDiagnostics.initialLocalChunkCount
             );
             expect(
                 filestoreReader.lastReadDiagnostics?.initialLocalChunkCount
@@ -4230,6 +4236,10 @@ describe("index", () => {
             expect(
                 filestore.lastReadDiagnostics?.lastReadyProbe?.localChunkCount
             ).to.eq(1);
+            expect(
+                filestore.lastReadDiagnostics?.lastReadyProbe
+                    ?.localChunkIndexRowCount
+            ).to.eq(1);
             expect(streamedChunks).to.have.length(0);
         });
 
@@ -4310,6 +4320,10 @@ describe("index", () => {
             ).not.to.eq("pending-manifest");
             expect(
                 filestore.lastReadDiagnostics?.lastReadyProbe?.localChunkCount
+            ).to.eq(localChunkCount);
+            expect(
+                filestore.lastReadDiagnostics?.lastReadyProbe
+                    ?.localChunkIndexRowCount
             ).to.eq(localChunkCount);
             expect(streamedChunks).to.have.length(0);
         });

--- a/packages/file-share/library/src/index.ts
+++ b/packages/file-share/library/src/index.ts
@@ -527,8 +527,8 @@ const LARGE_FILE_CHUNK_BATCH_SPECULATIVE_TIMEOUT_MS = 1_500;
 const LARGE_FILE_PERSISTED_READ_AHEAD = 32;
 const LARGE_FILE_OBSERVER_READ_AHEAD = 2;
 const LARGE_FILE_CHANGE_WAIT_FALLBACK_MS = 250;
-const LARGE_FILE_CHUNK_PUT_CONCURRENCY = 4;
-const LARGE_FILE_CHUNK_PUT_BYTE_LIMIT = 2 * 1024 * 1024;
+const LARGE_FILE_CHUNK_PUT_CONCURRENCY = 8;
+const LARGE_FILE_CHUNK_PUT_BYTE_LIMIT = 4 * 1024 * 1024;
 const LARGE_FILE_MIN_CHUNK_ATTEMPT_TIMEOUT_MS = 5_000;
 const LARGE_FILE_MAX_CHUNK_ATTEMPT_TIMEOUT_MS = 45_000;
 const LARGE_FILE_REMOTE_CHUNK_TIMEOUT_OVERHEAD_MS = 5_000;
@@ -1728,6 +1728,9 @@ export class LargeFile extends AbstractFile {
                     at: Date.now(),
                     ready: readinessCandidate.ready,
                     from: remoteFrom ?? null,
+                    localChunkIndexRowCount: null,
+                    // Compatibility alias. This counts Documents index rows,
+                    // not exact locally persisted chunk blocks.
                     localChunkCount: null,
                 };
             }
@@ -1841,14 +1844,16 @@ export class LargeFile extends AbstractFile {
                     hasChunkEntryHeads(remoteReady))
                     ? remoteReady
                     : readinessCandidate;
-            const localChunkCount = await files
+            const localChunkIndexRowCount = await files
                 .countLocalChunks(countCandidate)
                 .catch(() => 0);
             changeSignal.throwIfClosed();
             if (debug?.lastReadyProbe) {
-                debug.lastReadyProbe.localChunkCount = localChunkCount;
+                debug.lastReadyProbe.localChunkIndexRowCount =
+                    localChunkIndexRowCount;
+                debug.lastReadyProbe.localChunkCount = localChunkIndexRowCount;
             }
-            if (localChunkCount >= countCandidate.chunkCount) {
+            if (localChunkIndexRowCount >= countCandidate.chunkCount) {
                 if (debug) {
                     debug.waitUntilReadyResolvedBy = "complete-chunks";
                 }
@@ -1950,6 +1955,9 @@ export class LargeFile extends AbstractFile {
                 demandWaitMs: number;
                 attempts: number;
             }[],
+            initialLocalChunkIndexRowCount: null as number | null,
+            // Compatibility alias for benchmark consumers written before the
+            // index-row/local-block distinction was made explicit.
             initialLocalChunkCount: null as number | null,
             initialLocalChunkBlockCount: null as number | null,
             readAheadSource: null as string | null,
@@ -2008,12 +2016,16 @@ export class LargeFile extends AbstractFile {
             debug.initialReadPeerHints = initialReadPeerHints;
         }
         if (persistChunkReads) {
-            const [initialLocalChunkCount, initialLocalChunkBlockCount] =
-                await Promise.all([
-                    files.countLocalChunks(resolvedFile).catch(() => null),
-                    files.countLocalChunkBlocks(resolvedFile).catch(() => null),
-                ]);
-            debug.initialLocalChunkCount = initialLocalChunkCount;
+            const [
+                initialLocalChunkIndexRowCount,
+                initialLocalChunkBlockCount,
+            ] = await Promise.all([
+                files.countLocalChunks(resolvedFile).catch(() => null),
+                files.countLocalChunkBlocks(resolvedFile).catch(() => null),
+            ]);
+            debug.initialLocalChunkIndexRowCount =
+                initialLocalChunkIndexRowCount;
+            debug.initialLocalChunkCount = initialLocalChunkIndexRowCount;
             debug.initialLocalChunkBlockCount =
                 initialLocalChunkBlockCount ?? null;
         }
@@ -2036,8 +2048,8 @@ export class LargeFile extends AbstractFile {
             );
         let isRemotePersistedRead =
             persistChunkReads &&
-            (debug.initialLocalChunkCount == null ||
-                debug.initialLocalChunkCount < resolvedFile.chunkCount);
+            (debug.initialLocalChunkIndexRowCount == null ||
+                debug.initialLocalChunkIndexRowCount < resolvedFile.chunkCount);
         let isAdaptiveRemoteRead = !persistChunkReads || isRemotePersistedRead;
         let readAheadLimit = isAdaptiveRemoteRead
             ? remoteReadAheadLimit


### PR DESCRIPTION
## Summary

- raise the memory-bounded large-file upload queue from four puts / 2 MiB to eight puts / 4 MiB
- expose explicit Documents index-row diagnostic names while retaining the existing compatibility fields
- require live and cold-persisted benchmark reads to finish with every exact manifest-entry block local
- test that partial index rows with complete blocks are valid, while missing, partial, or excess blocks are invalid

## Performance evidence

Three counterbalanced 256 MiB live-replicator pairs ran q4→q8, q8→q4, q4→q8 with fresh persistent OPFS profiles. q8 won every upload, chunk-wall, end-to-end, and download comparison.

Median q8 versus q4:

- upload throughput: +36.91%
- chunk-put wall time: -26.77%
- end-to-end time: -21.95%
- download throughput: +21.14%
- aligned combined Chromium RSS: -13.05%
- writer RSS: +1.07%; reader RSS: -21.49%

All six transfers passed source/manifest/library-stream/sink integrity, SHA-256, CRC-32, topology, cohort, and 512/512 exact-local-block gates.

A fresh 64 MiB production-browser smoke on this commit also passed with SHA integrity, a valid live cohort, 128/128 exact local blocks, eight concurrent puts reached, and the full 4 MiB cap exercised. Its 103 index rows / 128 exact blocks additionally validates that row convergence is not confused with block completeness.

## Validation

- focused file-share library integration gate: 6 passed
- file-share frontend unit suite: 123 passed
- file-share library and production frontend builds: passed
- deterministic 64 MiB live-replicator Playwright transfer: passed
- formatting and changeset status: passed

A full clean-lockfile library run reached 102 passing tests before the unchanged `persists batched manifest-head reads for an offline local reread` fixture called an unavailable `log.getMany` on the locked dependency. The q8-related integration tests pass, and this fixture/API mismatch is unchanged from master.
