### PR TITLE
fix: remove retired domain dependencies

### DIFF
--- a/.changeset/owned-domain-ranges.md
+++ b/.changeset/owned-domain-ranges.md
@@ -1,0 +1,6 @@
+---
+"@giga-app/app-service": patch
+"@peerbit/please": patch
+---
+
+Replace retired demo origins with configurable URLs on Peerbit-owned domains.

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -37,7 +37,9 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Validate production bootstrap sources
-              run: node scripts/validate-production-bootstrap.mjs
+              run: |
+                  node scripts/validate-production-bootstrap.mjs
+                  node --test cloudflare/*.test.mjs
 
             - name: Build every frontend
               env:
@@ -51,7 +53,9 @@ jobs:
             - name: Prepare and validate Cloudflare assets
               env:
                   COMMIT_HASH: ${{ github.sha }}
-              run: node scripts/prepare-cloudflare-assets.mjs
+              run: |
+                  node scripts/prepare-cloudflare-assets.mjs
+                  node scripts/validate-owned-domains.mjs
 
             - name: Ensure the build did not mutate source
               run: git diff --exit-code
@@ -106,6 +110,7 @@ jobs:
                   git diff --exit-code
                   npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler
                   node scripts/render-cloudflare-configs.mjs --mode preview
+                  node scripts/validate-owned-domains.mjs
 
             - name: Deploy isolated Cloudflare previews
               env:

--- a/.github/workflows/cloudflare-production.yml
+++ b/.github/workflows/cloudflare-production.yml
@@ -1,0 +1,172 @@
+name: Deploy Cloudflare production
+
+on:
+    workflow_dispatch:
+        inputs:
+            target:
+                description: Production target to deploy
+                required: true
+                type: choice
+                default: apps
+                options:
+                    - apps
+                    - legacy-redirect
+                    - all
+            confirm:
+                description: Confirm this production deployment
+                required: true
+                type: boolean
+                default: false
+
+permissions:
+    contents: read
+
+concurrency:
+    group: cloudflare-examples-production
+    cancel-in-progress: false
+
+jobs:
+    validate:
+        if: github.ref == 'refs/heads/master' && inputs.confirm
+        runs-on: ubuntu-24.04
+        timeout-minutes: 30
+        steps:
+            - name: Checkout
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  persist-credentials: false
+
+            - name: Setup Node
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+              with:
+                  node-version: 22.x
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+              with:
+                  run_install: false
+
+            - name: Build and validate every frontend
+              env:
+                  COMMIT_HASH: ${{ github.sha }}
+                  VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+                  VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+              run: |
+                  pnpm install --frozen-lockfile
+                  node scripts/validate-production-bootstrap.mjs
+                  node --test cloudflare/*.test.mjs
+                  export SHORT_SHA="${GITHUB_SHA::7}"
+                  pnpm run build
+                  node scripts/prepare-cloudflare-assets.mjs
+                  node scripts/validate-owned-domains.mjs
+                  git diff --exit-code
+                  npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler
+                  node scripts/render-cloudflare-configs.mjs --mode production
+                  for config in .wrangler-config/*.jsonc; do
+                      output=".wrangler-dry-run/$(basename "$config" .jsonc)"
+                      tools/wrangler/node_modules/.bin/wrangler deploy \
+                          --config "$config" \
+                          --dry-run \
+                          --outdir "$output"
+                  done
+
+    deploy-production:
+        if: github.ref == 'refs/heads/master' && inputs.confirm
+        needs: validate
+        runs-on: ubuntu-24.04
+        timeout-minutes: 45
+        environment: cloudflare-production
+        steps:
+            - name: Checkout
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  persist-credentials: false
+
+            - name: Setup Node
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+              with:
+                  node-version: 22.x
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+              with:
+                  run_install: false
+
+            - name: Rebuild without deployment credentials
+              env:
+                  COMMIT_HASH: ${{ github.sha }}
+                  VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+                  VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+              run: |
+                  pnpm install --frozen-lockfile
+                  node scripts/validate-production-bootstrap.mjs
+                  node --test cloudflare/*.test.mjs
+                  export SHORT_SHA="${GITHUB_SHA::7}"
+                  pnpm run build
+                  node scripts/prepare-cloudflare-assets.mjs
+                  node scripts/validate-owned-domains.mjs
+                  git diff --exit-code
+                  npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler
+                  node scripts/render-cloudflare-configs.mjs --mode production
+
+            - name: Deploy selected production target
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PRODUCTION_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+                  DEPLOY_TARGET: ${{ inputs.target }}
+              run: |
+                  case "$DEPLOY_TARGET" in
+                      apps)
+                          for config in .wrangler-config/*.jsonc; do
+                              if [ "$(basename "$config")" = "legacy-stream.jsonc" ]; then
+                                  continue
+                              fi
+                              tools/wrangler/node_modules/.bin/wrangler deploy --config "$config"
+                          done
+                          ;;
+                      legacy-redirect)
+                          tools/wrangler/node_modules/.bin/wrangler deploy \
+                              --config .wrangler-config/legacy-stream.jsonc
+                          ;;
+                      all)
+                          for config in .wrangler-config/*.jsonc; do
+                              if [ "$(basename "$config")" = "legacy-stream.jsonc" ]; then
+                                  continue
+                              fi
+                              tools/wrangler/node_modules/.bin/wrangler deploy --config "$config"
+                          done
+                          tools/wrangler/node_modules/.bin/wrangler deploy \
+                              --config .wrangler-config/legacy-stream.jsonc
+                          ;;
+                      *)
+                          echo "Unsupported deployment target: $DEPLOY_TARGET" >&2
+                          exit 1
+                          ;;
+                  esac
+
+            - name: Verify selected production target
+              env:
+                  DEPLOY_TARGET: ${{ inputs.target }}
+              run: >-
+                  node scripts/verify-cloudflare-sites.mjs
+                  --mode production
+                  --target "$DEPLOY_TARGET"
+                  --commit "${{ github.sha }}"
+
+            - name: Install Chromium for production runtime smoke tests
+              if: inputs.target != 'legacy-redirect'
+              run: >-
+                  pnpm --dir packages/file-share/frontend exec playwright
+                  install --with-deps chromium
+
+            - name: Verify production browser runtime and media ranges
+              if: inputs.target != 'legacy-redirect'
+              env:
+                  PW_CLOUDFLARE_SMOKE: "1"
+                  PW_BASE_URL: https://files.peerbit.org
+                  PW_GIGA_URL: https://giga.peerbit.org
+                  PW_STREAM_URL: https://stream.peerbit.org
+              run: >-
+                  pnpm --dir packages/file-share/frontend exec playwright test
+                  -c playwright.config.ts tests/cloudflare-preview.e2e.spec.ts
+                  --project=chromium --workers=1 --retries=1

--- a/.github/workflows/file-share-benchmarks.yml
+++ b/.github/workflows/file-share-benchmarks.yml
@@ -21,6 +21,11 @@ on:
                 required: true
                 type: number
                 default: 5
+            base_url:
+                description: Production file-share URL
+                required: true
+                type: string
+                default: https://files.peerbit.org
             reader_cohort:
                 description: Reader benchmark cohort
                 required: true
@@ -83,7 +88,7 @@ jobs:
                   PW_BENCH_SCENARIO: ${{ inputs.scenario }}
                   PW_READER_COHORT: ${{ inputs.reader_cohort }}
                   PW_FILE_MB: ${{ inputs.file_mb }}
-                  PW_BASE_URL: ${{ inputs.scenario == 'prod' && 'https://files.dao.xyz' || '' }}
+                  PW_BASE_URL: ${{ inputs.scenario == 'prod' && inputs.base_url || '' }}
               working-directory: packages/file-share/frontend
               run: |
                   mkdir -p "$GITHUB_WORKSPACE/bench-results"

--- a/.github/workflows/file-share-two-runner-benchmarks.yml
+++ b/.github/workflows/file-share-two-runner-benchmarks.yml
@@ -12,7 +12,7 @@ on:
                 description: Target file-share deployment
                 required: true
                 type: string
-                default: https://files.dao.xyz
+                default: https://files.peerbit.org
             reader_role:
                 description: Reader replication role
                 required: true

--- a/README.md
+++ b/README.md
@@ -87,21 +87,26 @@ For more complete instructions on how to run a node in a server center that can 
 
 ## Cloudflare hosting
 
-The public frontends are being migrated from S3/CloudFront to asset-only
-Cloudflare Workers. `cloudflare/sites.json` is the source of truth for build
-directories, Worker names, expected titles, and production hostnames.
+The public frontends are hosted with Cloudflare Workers Static Assets, with a
+selective cache Worker in front of the large MP4 fixtures that need byte-range
+support.
+`cloudflare/sites.json` is the source of truth for build directories, Worker
+names, expected titles, and production hostnames under Peerbit-owned domains.
 
 Before a DNS cutover, the Cloudflare workflow deploys isolated `workers.dev`
 previews and verifies their release metadata, cache behavior, headers, 404s,
 legacy stream redirect, browser/WASM startup, real relay connectivity,
-file-share boot, and exact MP4 byte ranges. The current AWS distributions
-remain available as rollback origins until every production hostname has
-passed the same checks.
+file-share boot, and exact MP4 byte ranges. Worker versions and the isolated
+previews are the rollback path; legacy AWS resources are retirement-only and
+must not receive new deployments.
 
 Preview deployments use a Workers-Scripts-only token stored as
 `CLOUDFLARE_PREVIEW_API_TOKEN` in the `cloudflare-preview` GitHub environment.
-Production cutover must use a separate, route-capable credential so preview
-automation can never change a production route.
+Cloudflare includes custom-domain management in that permission, so the GitHub
+environment is restricted to `master`, administrator bypass is disabled, and
+`master` requires a pull request plus the `validate` check. Preview configs
+never render production routes. Production cutover must use a separate reviewed
+environment and credential.
 
 Local validation uses the locked Wrangler toolchain:
 
@@ -117,7 +122,7 @@ for config in .wrangler-config/*.jsonc; do
 done
 ```
 
-Production configs are rendered with `--mode production`. Do not deploy them
-until `dao.xyz` and `giga.place` are active Cloudflare zones with a complete
-Route53 record inventory imported. After cutover, verify all hostnames before
-removing AWS credentials or deleting Route53, CloudFront, or S3 resources.
+Production configs are rendered with `--mode production` and are restricted to
+`peerbit.org` and `peerchecker.com`. Use the separately reviewed production
+environment, verify every hostname, and retain a known-good Worker version
+before deleting any retirement-only AWS resources.

--- a/cloudflare/cached-static-assets.mjs
+++ b/cloudflare/cached-static-assets.mjs
@@ -1,0 +1,35 @@
+export default {
+    async fetch(request, env) {
+        const url = new URL(request.url);
+        const rangeMediaPaths = new Set(JSON.parse(env.RANGE_MEDIA_PATHS));
+        if (!rangeMediaPaths.has(url.pathname)) {
+            return env.ASSETS.fetch(request);
+        }
+
+        // Workers Cache handles the client Range header outside this Worker:
+        // it stores this full 200 response and synthesizes byte-exact 206/416
+        // responses. Always fetch the canonical representation from Assets.
+        const headers = new Headers(request.headers);
+        headers.delete("range");
+        headers.delete("if-range");
+        headers.set("accept-encoding", "identity");
+        const assetRequest = new Request(request, { headers });
+        const assetResponse = await env.ASSETS.fetch(assetRequest);
+
+        if (assetResponse.status !== 200) {
+            return assetResponse;
+        }
+
+        const responseHeaders = new Headers(assetResponse.headers);
+        responseHeaders.set("Accept-Ranges", "bytes");
+        responseHeaders.set(
+            "Cache-Control",
+            "public, max-age=0, s-maxage=86400, must-revalidate"
+        );
+        return new Response(assetResponse.body, {
+            status: assetResponse.status,
+            statusText: assetResponse.statusText,
+            headers: responseHeaders,
+        });
+    },
+};

--- a/cloudflare/cached-static-assets.test.mjs
+++ b/cloudflare/cached-static-assets.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import worker from "./cached-static-assets.mjs";
+
+const media = Uint8Array.from({ length: 32 }, (_, index) => index);
+const createEnv = () => {
+    let assetRequest;
+    return {
+        get assetRequest() {
+            return assetRequest;
+        },
+        ASSETS: {
+            async fetch(request) {
+                assetRequest = request;
+                return new Response(media, {
+                    headers: {
+                        "Content-Length": String(media.byteLength),
+                        "Content-Type": "video/mp4",
+                        ETag: '"fixture"',
+                    },
+                });
+            },
+        },
+        RANGE_MEDIA_PATHS: JSON.stringify(["/noise.mp4"]),
+    };
+};
+
+test("returns a cacheable full representation for media range requests", async () => {
+    const env = createEnv();
+    const response = await worker.fetch(
+        new Request("https://stream.example.invalid/noise.mp4", {
+            headers: {
+                Range: "bytes=4-7",
+                "If-Range": '"fixture"',
+            },
+        }),
+        env
+    );
+
+    assert.equal(env.assetRequest.headers.get("range"), null);
+    assert.equal(env.assetRequest.headers.get("if-range"), null);
+    assert.equal(env.assetRequest.headers.get("accept-encoding"), "identity");
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("accept-ranges"), "bytes");
+    assert.match(response.headers.get("cache-control"), /s-maxage=86400/);
+    assert.deepEqual(new Uint8Array(await response.arrayBuffer()), media);
+});
+
+test("leaves unrelated asset requests unchanged", async () => {
+    const env = createEnv();
+    const request = new Request("https://stream.example.invalid/index.html", {
+        headers: { Range: "bytes=0-1" },
+    });
+    await worker.fetch(request, env);
+
+    assert.equal(env.assetRequest.headers.get("range"), "bytes=0-1");
+});

--- a/cloudflare/sites.json
+++ b/cloudflare/sites.json
@@ -7,56 +7,60 @@
             "worker": "peerbit-examples-stream",
             "directory": "packages/media-streaming/video-streaming/frontend/dist",
             "title": "Livestream",
-            "domains": ["stream.dao.xyz"]
+            "script": "cloudflare/cached-static-assets.mjs",
+            "workerFirst": ["/bird.mp4", "/noise.mp4"],
+            "domains": ["stream.peerbit.org"]
         },
         {
             "id": "music",
             "worker": "peerbit-examples-music",
             "directory": "packages/media-streaming/music-library/frontend/dist",
             "title": "Music library",
-            "domains": ["music.dao.xyz"]
+            "domains": ["music.peerbit.org"]
         },
         {
             "id": "chat",
             "worker": "peerbit-examples-chat",
             "directory": "packages/one-chat-room/frontend/dist",
             "title": "Chat",
-            "domains": ["chat.dao.xyz"]
+            "domains": ["chat.peerbit.org"]
         },
         {
             "id": "giga",
             "worker": "peerbit-examples-giga",
             "directory": "packages/social-media-app/frontend/dist",
             "title": "Giga",
-            "domains": ["demo.dao.xyz", "giga.place"]
+            "script": "cloudflare/cached-static-assets.mjs",
+            "workerFirst": ["/turtle720.mp4"],
+            "domains": ["giga.peerbit.org"]
         },
         {
             "id": "ml",
             "worker": "peerbit-examples-ml",
             "directory": "packages/collaborative-learning/frontend/dist",
             "title": "Collaborative learning demo",
-            "domains": ["mldemo.dao.xyz"]
+            "domains": ["ml.peerbit.org"]
         },
         {
             "id": "text",
             "worker": "peerbit-examples-text",
             "directory": "packages/text-document/frontend/dist",
             "title": "Text",
-            "domains": ["text.dao.xyz"]
+            "domains": ["text.peerbit.org"]
         },
         {
             "id": "files",
             "worker": "peerbit-examples-files",
             "directory": "packages/file-share/frontend/dist",
             "title": "Filedrop",
-            "domains": ["files.dao.xyz"]
+            "domains": ["files.peerbit.org"]
         },
         {
             "id": "chess",
             "worker": "peerbit-examples-chess",
             "directory": "packages/chess/frontend/dist",
             "title": "Chess",
-            "domains": ["chess.dao.xyz"]
+            "domains": ["chess.peerbit.org"]
         }
     ],
     "redirects": [
@@ -65,7 +69,7 @@
             "worker": "peerbit-examples-legacy-stream",
             "script": "cloudflare/stream-peerchecker-redirect.mjs",
             "domains": ["stream.peerchecker.com"],
-            "location": "https://stream.dao.xyz/#/",
+            "location": "https://stream.peerbit.org/#/",
             "status": 307
         }
     ]

--- a/cloudflare/stream-peerchecker-redirect.mjs
+++ b/cloudflare/stream-peerchecker-redirect.mjs
@@ -1,9 +1,10 @@
-const CANONICAL_STREAM_URL = "https://stream.dao.xyz/#/";
-
 export default {
-    fetch() {
+    fetch(_request, env) {
         // The retired app used an incompatible hash route format, so do not
         // preserve its fragment. Always land on the current application root.
-        return Response.redirect(CANONICAL_STREAM_URL, 307);
+        return Response.redirect(
+            env.CANONICAL_STREAM_URL,
+            Number(env.REDIRECT_STATUS)
+        );
     },
 };

--- a/packages/chess/frontend/vite.config.ts
+++ b/packages/chess/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import peerbit from "@peerbit/vite";
 // @ts-ignore
@@ -19,14 +19,4 @@ export default defineConfig({
     define: {
         APP_VERSION: JSON.stringify(process.env.npm_package_version),
     },
-
-    /*  server: fs.existsSync("./.cert/key.pem")
-         ? {
-               https: {
-                   key: fs.readFileSync("./.cert/key.pem"),
-                   cert: fs.readFileSync("./.cert/cert.pem"),
-               },
-               host: "meet.dao.xyz",
-           }
-         : undefined, */
 });

--- a/packages/collaborative-learning/README.md
+++ b/packages/collaborative-learning/README.md
@@ -1,7 +1,7 @@
 # P2P Model learning
 ![demo](./demo.gif)
 
-Live demo: https://mldemo.dao.xyz/
+Live demo: https://ml.peerbit.org/
 
 This project uses Peerbit to share model weights between peers. 
 

--- a/packages/collaborative-learning/frontend/vite.config.ts
+++ b/packages/collaborative-learning/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import peerbit from "@peerbit/vite";
 
@@ -17,11 +17,4 @@ export default defineConfig({
         APP_VERSION: JSON.stringify(process.env.npm_package_version),
     },
     base: "/",
-    /*  server: fs.existsSync('./.cert/key.pem') ? {
-         https: {
-             key: fs.readFileSync('./.cert/key.pem'),
-             cert: fs.readFileSync('./.cert/cert.pem'),
-         },
-         host: 'meet.dao.xyz'
-     } : undefined, */
 });

--- a/packages/file-share/README.md
+++ b/packages/file-share/README.md
@@ -10,7 +10,7 @@ In the library folder you can find all code that is handling the file data.
 
 In the frontend folder you can find a React application using the library as a dependency.
 
-Application is live at [files.dao.xyx](https://files.dao.xyz)
+The hosted application is available at [files.peerbit.org](https://files.peerbit.org).
 
 
 ## CLI

--- a/packages/file-share/cli/src/__tests__/share-ref.test.ts
+++ b/packages/file-share/cli/src/__tests__/share-ref.test.ts
@@ -10,7 +10,9 @@ describe("share references", () => {
 
     it("extracts addresses from frontend hash URLs", () => {
         expect(
-            parseShareReference("https://files.dao.xyz/#/s/zb2rhoExampleShare")
+            parseShareReference(
+                "https://files.example.invalid/#/s/zb2rhoExampleShare"
+            )
         ).toBe("zb2rhoExampleShare");
     });
 
@@ -22,11 +24,13 @@ describe("share references", () => {
 
     it("formats canonical share URLs", () => {
         expect(formatShareUrl("zb2rhoExampleShare")).toBe(
-            "https://files.dao.xyz#/s/zb2rhoExampleShare"
+            "https://files.peerbit.org#/s/zb2rhoExampleShare"
         );
         expect(
-            formatShareUrl("zb2rhoExampleShare", "https://files.dao.xyz/")
-        ).toBe("https://files.dao.xyz#/s/zb2rhoExampleShare");
+            formatShareUrl(
+                "zb2rhoExampleShare",
+                "https://files.example.invalid/"
+            )
+        ).toBe("https://files.example.invalid#/s/zb2rhoExampleShare");
     });
 });
-

--- a/packages/file-share/cli/src/bin.ts
+++ b/packages/file-share/cli/src/bin.ts
@@ -11,7 +11,11 @@ import path from "path";
 import os from "os";
 import { multiaddr } from "@multiformats/multiaddr";
 import { createPathSource, createPathWriter } from "./io.js";
-import { formatShareUrl, parseShareReference } from "./share-ref.js";
+import {
+    DEFAULT_SHARE_BASE_URL,
+    formatShareUrl,
+    parseShareReference,
+} from "./share-ref.js";
 
 function ensureDirectoryExistence(filePath) {
     const dirname = path.dirname(filePath);
@@ -267,7 +271,9 @@ const cli = async (args?: string[]) => {
                     type: "string",
                     describe:
                         "Base URL used when printing the share link for newly created spaces.",
-                    default: "https://files.dao.xyz",
+                    default:
+                        process.env.PEERBIT_FILE_SHARE_URL?.trim() ||
+                        DEFAULT_SHARE_BASE_URL,
                 });
                 yargs.option("legacy-global", {
                     type: "boolean",

--- a/packages/file-share/cli/src/share-ref.ts
+++ b/packages/file-share/cli/src/share-ref.ts
@@ -1,4 +1,4 @@
-const DEFAULT_SHARE_BASE_URL = "https://files.dao.xyz";
+export const DEFAULT_SHARE_BASE_URL = "https://files.peerbit.org";
 
 const SHARE_PATH_PREFIX = "/s/";
 
@@ -41,4 +41,3 @@ export const formatShareUrl = (
     address: string,
     baseUrl = DEFAULT_SHARE_BASE_URL
 ) => `${trimTrailingSlash(baseUrl)}#${SHARE_PATH_PREFIX}${address}`;
-

--- a/packages/file-share/frontend/tests/share-url.unit.test.ts
+++ b/packages/file-share/frontend/tests/share-url.unit.test.ts
@@ -4,7 +4,7 @@ import { getPeerDialAddresses, withSharePeerHints } from "../src/share-url";
 describe("share URL peer hints", () => {
     it("adds normalized peer addresses before the hash route", () => {
         const href = withSharePeerHints(
-            "https://files.dao.xyz/#/s/space-address",
+            "https://files.example.invalid/#/s/space-address",
             [
                 "/dns4/bootstrap/tcp/4003/wss/p2p/a",
                 " /dns4/bootstrap/tcp/4003/wss/p2p/a ",
@@ -21,7 +21,7 @@ describe("share URL peer hints", () => {
 
     it("does not replace explicit bootstrap URLs", () => {
         const href =
-            "https://files.dao.xyz/?bootstrap=/dns4/local#/s/space-address";
+            "https://files.example.invalid/?bootstrap=/dns4/local#/s/space-address";
 
         expect(
             withSharePeerHints(href, ["/dns4/bootstrap/tcp/4003/wss/p2p/a"], {

--- a/packages/file-share/frontend/tests/two-runner.bench.mjs
+++ b/packages/file-share/frontend/tests/two-runner.bench.mjs
@@ -12,7 +12,11 @@ import {
 } from "./two-runner-integrity.mjs";
 
 const MODE = process.argv[2];
-const BASE_URL = (process.env.PW_BASE_URL || "https://files.dao.xyz").replace(
+const CONFIGURED_BASE_URL = process.env.PW_BASE_URL?.trim();
+if (MODE !== "self-test" && !CONFIGURED_BASE_URL) {
+    throw new Error("PW_BASE_URL is required for two-runner benchmarks");
+}
+const BASE_URL = (CONFIGURED_BASE_URL || "https://example.invalid").replace(
     /\/$/,
     ""
 );

--- a/packages/file-share/frontend/vite.config.ts
+++ b/packages/file-share/frontend/vite.config.ts
@@ -68,14 +68,4 @@ export default defineConfig({
     define: {
         APP_VERSION: JSON.stringify(process.env.npm_package_version),
     },
-
-    /*  server: fs.existsSync("./.cert/key.pem")
-         ? {
-               https: {
-                   key: fs.readFileSync("./.cert/key.pem"),
-                   cert: fs.readFileSync("./.cert/cert.pem"),
-               },
-               host: "meet.dao.xyz",
-           }
-         : undefined, */
 });

--- a/packages/media-streaming/music-library/frontend/package.json
+++ b/packages/media-streaming/music-library/frontend/package.json
@@ -2,7 +2,7 @@
     "name": "music-library-frontend",
     "version": "0.1.3",
     "private": true,
-    "homepage": "https://music.dao.xyz",
+    "homepage": "https://music.peerbit.org",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/media-streaming/video-streaming/README.md
+++ b/packages/media-streaming/video-streaming/README.md
@@ -3,7 +3,7 @@
 [<img src="./demo.gif" width="600" />](./packages/live-streaming/)
 
 
-## [Application is live here](https://stream.dao.xyz)
+## [Application is live here](https://stream.peerbit.org)
 
 
 Due to the use of WebCodecs API, this app does not yet work on Firefox ([soon?](https://groups.google.com/a/mozilla.org/g/dev-platform/c/3g0fnn6682A)), and some mobile phones.

--- a/packages/media-streaming/video-streaming/frontend/package.json
+++ b/packages/media-streaming/video-streaming/frontend/package.json
@@ -2,7 +2,7 @@
     "name": "videostreaming",
     "version": "0.1.3",
     "private": true,
-    "homepage": "https://stream.dao.xyz",
+    "homepage": "https://stream.peerbit.org",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/one-chat-room/README.md
+++ b/packages/one-chat-room/README.md
@@ -5,4 +5,4 @@
 This example showcase how you can create a simple chat room. Only frontend code is required to make it run.
 
 Live demo
-https://chat.dao.xyz/
+https://chat.peerbit.org/

--- a/packages/social-media-app/app-service/src/__tests__/apps.test.ts
+++ b/packages/social-media-app/app-service/src/__tests__/apps.test.ts
@@ -1,5 +1,6 @@
 import { CuratedWebApp, getApps } from "../apps.js";
 import { expect } from "chai";
+import { describe, it } from "vitest";
 
 describe("index", () => {
     it("empty search yields all", async () => {
@@ -99,7 +100,25 @@ describe("index", () => {
         });
         const response = await search("che");
         expect(response).to.have.length(1);
-        expect(response[0].url).to.eq("https://chess.dao.xyz");
+        expect(response[0].url).to.eq("https://chess.peerbit.org");
+    });
+
+    it("uses configured app URLs consistently", async () => {
+        const chess = "https://chess-preview.example.invalid";
+        const { curated, search } = getApps({
+            host: "www.host.com",
+            mode: "production",
+            appUrls: { chess },
+        });
+        const chessApp = curated.find(
+            (app) => app.type === "web" && app.manifest?.title === "Chess"
+        ) as CuratedWebApp;
+
+        expect(chessApp.manifest?.url).to.eq(chess);
+        expect(chessApp.getStatus(chess, "www.host.com")).to.deep.eq({
+            isReady: true,
+        });
+        expect((await search("chess"))[0].url).to.eq(chess);
     });
 
     describe("getStatus implementations", () => {

--- a/packages/social-media-app/app-service/src/apps.ts
+++ b/packages/social-media-app/app-service/src/apps.ts
@@ -15,16 +15,23 @@ import {
 } from "@peerbit/document";
 import { AppPreview } from "./remote.js";
 
-// External app URLs based on mode.
-const STREAMING_APP = (mode?: string) =>
-    ["development", "staging"].includes(mode ?? "")
-        ? "https://stream.test.xyz:5801"
-        : "https://stream.dao.xyz";
+export interface CuratedAppUrls {
+    streaming?: string;
+    chess?: string;
+}
 
-const CHESS_APP = (mode?: string) =>
-    ["development", "staging"].includes(mode ?? "")
+// External app URLs based on mode.
+const STREAMING_APP = (mode?: string, appUrls?: CuratedAppUrls) =>
+    appUrls?.streaming?.trim() ||
+    (["development", "staging"].includes(mode ?? "")
+        ? "https://stream.test.xyz:5801"
+        : "https://stream.peerbit.org");
+
+const CHESS_APP = (mode?: string, appUrls?: CuratedAppUrls) =>
+    appUrls?.chess?.trim() ||
+    (["development", "staging"].includes(mode ?? "")
         ? "https://chess.test.xyz:5806"
-        : "https://chess.dao.xyz";
+        : "https://chess.peerbit.org");
 
 // ─────────────────────────────────────────────────────────────
 // Define a common interface for curated apps.
@@ -94,9 +101,10 @@ export const nativeApps: CuratedAppNative[] = [
 
 // ─────────────────────────────────────────────────────────────
 // Web (iframeable) apps – using transformer functions.
-export const curatedWebApps: (mode?: string) => CuratedWebApp[] = (
-    mode?: string
-) => [
+export const curatedWebApps: (
+    mode?: string,
+    appUrls?: CuratedAppUrls
+) => CuratedWebApp[] = (mode?: string, appUrls?: CuratedAppUrls) => [
     // Twitch – already has a getStatus implementation.
     {
         type: "web",
@@ -304,12 +312,12 @@ export const curatedWebApps: (mode?: string) => CuratedWebApp[] = (
         type: "web",
         match: ["video", "stream", "live-stream", "livestream"],
         manifest: new SimpleWebManifest({
-            url: STREAMING_APP(mode),
+            url: STREAMING_APP(mode, appUrls),
             title: "Video",
             icon: "/apps/video.svg",
         }),
         getStatus(url, host) {
-            const expectedUrl = STREAMING_APP(mode);
+            const expectedUrl = STREAMING_APP(mode, appUrls);
             if (url === expectedUrl) {
                 return { isReady: true };
             } else {
@@ -325,12 +333,12 @@ export const curatedWebApps: (mode?: string) => CuratedWebApp[] = (
         type: "web",
         match: ["chess"],
         manifest: new SimpleWebManifest({
-            url: CHESS_APP(mode),
+            url: CHESS_APP(mode, appUrls),
             title: "Chess",
             icon: "/apps/chess.svg",
         }),
         getStatus(url, host) {
-            const expectedUrl = CHESS_APP(mode);
+            const expectedUrl = CHESS_APP(mode, appUrls);
             if (url === expectedUrl) {
                 return { isReady: true };
             } else {
@@ -345,10 +353,11 @@ export const curatedWebApps: (mode?: string) => CuratedWebApp[] = (
 // ─────────────────────────────────────────────────────────────
 // Merge native and web apps.
 const allCuratedApps = (
-    mode?: string
+    mode?: string,
+    appUrls?: CuratedAppUrls
 ): (CuratedAppNative | CuratedWebApp)[] => [
     ...nativeApps,
-    ...curatedWebApps(mode),
+    ...curatedWebApps(mode, appUrls),
 ];
 
 // ─────────────────────────────────────────────────────────────
@@ -359,13 +368,14 @@ const getCurated = (properties: {
     maybeUrl?: string;
     host: string;
     mode: string;
+    appUrls?: CuratedAppUrls;
 }): CuratedAppNative | CuratedWebApp | undefined => {
     const lowerQuery = properties.rawInput.trim().toLowerCase();
     if (lowerQuery.length < 2) {
         // TODO do this better so we dont match https:// or www.
         return undefined;
     }
-    return allCuratedApps(properties.mode).find((app) => {
+    return allCuratedApps(properties.mode, properties.appUrls).find((app) => {
         const matches = Array.isArray(app.match) ? app.match : [app.match];
         return matches.some((m) => {
             const lowerM = m.toLowerCase();
@@ -386,11 +396,12 @@ export const getApps = (properties: {
     appService?: AppPreview;
     history?: BrowsingHistory;
     mode?: "development" | "staging" | "production";
+    appUrls?: CuratedAppUrls;
 }): {
     curated: CuratedAppCommon[];
     search: (appOrUrl: string) => Promise<SimpleWebManifest[]>;
 } => {
-    const curated = allCuratedApps(properties.mode);
+    const curated = allCuratedApps(properties.mode, properties.appUrls);
     const search = async (urlOrName: string | undefined) => {
         const result: Map<string, SimpleWebManifest> = new Map();
 
@@ -419,6 +430,7 @@ export const getApps = (properties: {
                 maybeUrl: providedUrl,
                 host: properties.host,
                 mode: properties.mode || "production",
+                appUrls: properties.appUrls,
             });
             if (curatedApp) {
                 if (curatedApp.type === "web") {

--- a/packages/social-media-app/frontend/.env.example
+++ b/packages/social-media-app/frontend/.env.example
@@ -6,6 +6,10 @@
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 
+# Optional curated-app overrides, useful for preview deployments.
+VITE_STREAMING_APP_URL=
+VITE_CHESS_APP_URL=
+
 # Optional: E2E test credentials (used by Playwright auth tests)
 # TEST_EMAIL=
 # TEST_PASSWORD=

--- a/packages/social-media-app/frontend/src/canvas/edit/AppSelectPaneInline.tsx
+++ b/packages/social-media-app/frontend/src/canvas/edit/AppSelectPaneInline.tsx
@@ -225,9 +225,7 @@ export const AppSelectPaneInline: React.FC<Props> = ({
                     <>
                         <span className="font-ganja">Native apps</span>
                         <div className="flex gap-2">
-                            {window.location.hostname !== "giga.place" && (
-                                <DebugGeneratePostButton />
-                            )}
+                            {import.meta.env.DEV && <DebugGeneratePostButton />}
                             {nativeApps.map((app) => (
                                 <AppButton
                                     key={app.url}

--- a/packages/social-media-app/frontend/src/content/useApps.tsx
+++ b/packages/social-media-app/frontend/src/content/useApps.tsx
@@ -29,6 +29,10 @@ interface IApps {
 const allApps = getApps({
     host: window.location.host,
     mode: import.meta.env.MODE as any,
+    appUrls: {
+        streaming: import.meta.env.VITE_STREAMING_APP_URL,
+        chess: import.meta.env.VITE_CHESS_APP_URL,
+    },
 });
 
 export const resolveTrigger = (

--- a/packages/social-media-app/frontend/src/identity/useIdentities.tsx
+++ b/packages/social-media-app/frontend/src/identity/useIdentities.tsx
@@ -16,11 +16,9 @@ export const IdentitiesContext = React.createContext<IIdentitiesContext>(
 export const useIdentities = () => useContext(IdentitiesContext);
 
 export const IdentitiesProvider = ({ children }: { children: JSX.Element }) => {
-    // Determine the base URL based on the environment.
-    const baseUrl =
-        import.meta.env.MODE === "development"
-            ? "http://localhost:5173/#/connect?data="
-            : "https://giga.place/#/connect?data=";
+    // Device-connection payloads stay on the origin that created them. This is
+    // both preview-safe and avoids disclosing the fragment to another host.
+    const baseUrl = `${window.location.origin}/#/connect?data=`;
 
     const peerContext = usePeer();
     const { peer, persisted } = peerContext;

--- a/packages/social-media-app/frontend/src/routes.tsx
+++ b/packages/social-media-app/frontend/src/routes.tsx
@@ -156,25 +156,3 @@ export function BaseRoutes(props?: { enableEffects?: boolean }) {
         </>
     );
 }
-
-/* ────────────────────────────────────────────────────────────────
- * External app constants
- * ──────────────────────────────────────────────────────────────── */
-
-export const STREAMING_APP = ["development", "staging"].includes(
-    import.meta.env.MODE
-)
-    ? "https://stream.test.xyz:5801/#"
-    : "https://stream.dao.xyz/#";
-
-export const CHAT_APP = ["development", "staging"].includes(
-    import.meta.env.MODE
-)
-    ? "https://chat.test.xyz:5802/#"
-    : "https://chat.dao.xyz/#";
-
-export const TEXT_APP = ["development", "staging"].includes(
-    import.meta.env.MODE
-)
-    ? "https://text.test.xyz:5803/#"
-    : "https://text.dao.xyz/#";

--- a/packages/social-media-app/frontend/src/vite-env.d.ts
+++ b/packages/social-media-app/frontend/src/vite-env.d.ts
@@ -6,4 +6,6 @@ interface ImportMeta {
 interface ImportMetaEnv {
     readonly VITE_SUPABASE_URL?: string;
     readonly VITE_SUPABASE_ANON_KEY?: string;
+    readonly VITE_STREAMING_APP_URL?: string;
+    readonly VITE_CHESS_APP_URL?: string;
 }

--- a/packages/social-media-app/frontend/vite.config.ts
+++ b/packages/social-media-app/frontend/vite.config.ts
@@ -49,13 +49,4 @@ export default defineConfig({
               }
             : {}),
     },
-    /*  server: fs.existsSync("./.cert/key.pem")
-         ? {
-               https: {
-                   key: fs.readFileSync("./.cert/key.pem"),
-                   cert: fs.readFileSync("./.cert/cert.pem"),
-               },
-               host: "meet.dao.xyz",
-           }
-         : undefined, */
 });

--- a/packages/text-document/README.md
+++ b/packages/text-document/README.md
@@ -2,7 +2,7 @@
 
 ![demo](./demo.gif)
 
-Live demo https://text.dao.xyz
+Live demo https://text.peerbit.org
 
 THIS DEMO IS FLAKY.
 

--- a/packages/text-document/frontend/vite.config.ts
+++ b/packages/text-document/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import peerbit from "@peerbit/vite";
 // @ts-ignore
@@ -18,13 +18,4 @@ export default defineConfig({
     define: {
         APP_VERSION: JSON.stringify(process.env.npm_package_version),
     },
-    /*  server: fs.existsSync("./.cert/key.pem")
-         ? {
-               https: {
-                   key: fs.readFileSync("./.cert/key.pem"),
-                   cert: fs.readFileSync("./.cert/cert.pem"),
-               },
-               host: "meet.dao.xyz",
-           }
-         : undefined, */
 });

--- a/scripts/render-cloudflare-configs.mjs
+++ b/scripts/render-cloudflare-configs.mjs
@@ -38,6 +38,11 @@ if (outputRelative.startsWith("..") || path.isAbsolute(outputRelative)) {
 }
 
 const allEntries = [...manifest.staticSites, ...manifest.redirects];
+const ownedProductionDomains = ["peerbit.org", "peerchecker.com"];
+const isOwnedProductionDomain = (domain) =>
+    ownedProductionDomains.some(
+        (owned) => domain === owned || domain.endsWith(`.${owned}`)
+    );
 const ids = new Set();
 const workers = new Set();
 const previewWorkers = new Set();
@@ -62,8 +67,41 @@ for (const entry of allEntries) {
     workers.add(entry.worker);
     previewWorkers.add(previewWorker);
     for (const domain of entry.domains) {
+        if (!isOwnedProductionDomain(domain)) {
+            throw new Error(`Production domain is not approved: ${domain}`);
+        }
         if (domains.has(domain)) throw new Error(`Duplicate domain ${domain}`);
         domains.add(domain);
+    }
+    if ("directory" in entry && (entry.script || entry.workerFirst)) {
+        if (
+            !entry.script ||
+            !Array.isArray(entry.workerFirst) ||
+            entry.workerFirst.length === 0 ||
+            entry.workerFirst.some(
+                (pattern) =>
+                    typeof pattern !== "string" || !pattern.startsWith("/")
+            )
+        ) {
+            throw new Error(
+                `${entry.id}: workerFirst requires a script and absolute path patterns`
+            );
+        }
+    }
+}
+
+for (const redirect of manifest.redirects) {
+    const location = new URL(redirect.location);
+    if (
+        location.protocol !== "https:" ||
+        !isOwnedProductionDomain(location.hostname)
+    ) {
+        throw new Error(
+            `Redirect target is not an approved HTTPS domain: ${redirect.location}`
+        );
+    }
+    if (![301, 302, 303, 307, 308].includes(redirect.status)) {
+        throw new Error(`Unsupported redirect status: ${redirect.status}`);
     }
 }
 
@@ -101,10 +139,28 @@ const baseConfig = (entry) => ({
 for (const site of manifest.staticSites) {
     const config = {
         ...baseConfig(site),
+        ...(site.script
+            ? {
+                  main: relativeFromOutput(site.script),
+                  cache: {
+                      enabled: true,
+                      cross_version_cache: false,
+                  },
+                  vars: {
+                      RANGE_MEDIA_PATHS: JSON.stringify(site.workerFirst),
+                  },
+              }
+            : {}),
         assets: {
             directory: relativeFromOutput(site.directory),
             html_handling: "auto-trailing-slash",
             not_found_handling: "none",
+            ...(site.script
+                ? {
+                      binding: "ASSETS",
+                      run_worker_first: site.workerFirst,
+                  }
+                : {}),
         },
     };
     writeFileSync(
@@ -118,6 +174,10 @@ for (const redirect of manifest.redirects) {
     const config = {
         ...baseConfig(redirect),
         main: relativeFromOutput(redirect.script),
+        vars: {
+            CANONICAL_STREAM_URL: redirect.location,
+            REDIRECT_STATUS: String(redirect.status),
+        },
     };
     writeFileSync(
         path.join(outputDirectory, `${redirect.id}.jsonc`),

--- a/scripts/validate-owned-domains.mjs
+++ b/scripts/validate-owned-domains.mjs
@@ -1,0 +1,100 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    ".."
+);
+const forbiddenHosts = ["dao" + ".xyz", "giga" + ".place"];
+const legalAttributionFiles = new Set([
+    "LICENSE",
+    "LICENSE-MIT",
+    "packages/text-document/LICENSE",
+]);
+const ignoredDirectories = new Set([
+    ".git",
+    "node_modules",
+    "coverage",
+    "playwright-report",
+    "test-results",
+]);
+const textExtensions = new Set([
+    "",
+    ".css",
+    ".cjs",
+    ".env",
+    ".html",
+    ".js",
+    ".json",
+    ".jsonc",
+    ".jsx",
+    ".md",
+    ".mjs",
+    ".map",
+    ".sass",
+    ".scss",
+    ".sh",
+    ".svelte",
+    ".svg",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".toml",
+    ".vue",
+    ".xml",
+    ".yaml",
+    ".yml",
+]);
+
+const violations = [];
+const visit = (absolutePath) => {
+    const relativePath = path
+        .relative(repoRoot, absolutePath)
+        .split(path.sep)
+        .join("/");
+    const stat = statSync(absolutePath, { throwIfNoEntry: false });
+    if (!stat) return;
+    if (stat.isDirectory()) {
+        if (ignoredDirectories.has(path.basename(absolutePath))) return;
+        for (const name of readdirSync(absolutePath)) {
+            visit(path.join(absolutePath, name));
+        }
+        return;
+    }
+    if (
+        !stat.isFile() ||
+        legalAttributionFiles.has(relativePath) ||
+        (!textExtensions.has(path.extname(absolutePath)) &&
+            !path.basename(absolutePath).includes(".env."))
+    ) {
+        return;
+    }
+
+    let contents = readFileSync(absolutePath, "utf8");
+    if (path.basename(absolutePath) === "package.json") {
+        const manifest = JSON.parse(contents);
+        // Package authorship is historical provenance, not a network target.
+        // It follows a separate legal/release process from host ownership.
+        delete manifest.author;
+        contents = JSON.stringify(manifest);
+    }
+    contents = contents.toLowerCase();
+    for (const host of forbiddenHosts) {
+        if (contents.includes(host)) {
+            violations.push(`${relativePath}: contains unowned host ${host}`);
+        }
+    }
+};
+
+visit(repoRoot);
+
+if (violations.length > 0) {
+    throw new Error(
+        `Unowned domain references found:\n${violations.join("\n")}`
+    );
+}
+
+console.log(
+    "Validated that source and generated text assets use owned domains"
+);

--- a/scripts/verify-cloudflare-sites.mjs
+++ b/scripts/verify-cloudflare-sites.mjs
@@ -16,7 +16,7 @@ for (let index = 2; index < process.argv.length; index += 2) {
     const value = process.argv[index + 1];
     if (!key?.startsWith("--") || value == null) {
         throw new Error(
-            "Usage: verify-cloudflare-sites.mjs --mode preview|production [--subdomain NAME] [--commit SHA]"
+            "Usage: verify-cloudflare-sites.mjs --mode preview|production [--subdomain NAME] [--commit SHA] [--target apps|legacy-redirect|all]"
         );
     }
     args.set(key.slice(2), value);
@@ -32,6 +32,10 @@ if (mode === "preview" && !/^[a-z0-9-]+$/i.test(subdomain || "")) {
 const expectedCommit = args.get("commit");
 if (expectedCommit && !/^[0-9a-f]{40}$/i.test(expectedCommit)) {
     throw new Error("--commit must be a full Git commit hash");
+}
+const target = args.get("target") || "all";
+if (!["apps", "legacy-redirect", "all"].includes(target)) {
+    throw new Error("--target must be apps, legacy-redirect, or all");
 }
 
 const request = async (url, init = {}) => {
@@ -65,7 +69,7 @@ const originsFor = (entry) =>
         ? [`https://${entry.worker}-preview.${subdomain}.workers.dev`]
         : entry.domains.map((domain) => `https://${domain}`);
 
-for (const site of manifest.staticSites) {
+for (const site of target === "legacy-redirect" ? [] : manifest.staticSites) {
     for (const origin of originsFor(site)) {
         await verifyEventually(origin, async () => {
             const root = await request(`${origin}/`);
@@ -141,27 +145,94 @@ for (const site of manifest.staticSites) {
             if (hiddenHeaders.status !== 404)
                 throw new Error(`${origin}: _headers is publicly served`);
 
-            if (site.id === "stream") {
-                const media = await request(`${origin}/bird.mp4`, {
+            for (const mediaPath of site.workerFirst || []) {
+                const fixture = readFileSync(
+                    path.join(repoRoot, site.directory, mediaPath)
+                );
+                const media = await request(`${origin}${mediaPath}`, {
                     headers: { Range: "bytes=0-1023" },
                 });
                 if (media.status !== 206) {
                     throw new Error(
-                        `${origin}/bird.mp4: range request returned ${media.status}`
+                        `${origin}${mediaPath}: range request returned ${media.status}`
+                    );
+                }
+                const expectedContentRange = `bytes 0-1023/${fixture.length}`;
+                if (
+                    media.headers.get("content-range") !== expectedContentRange
+                ) {
+                    throw new Error(
+                        `${origin}${mediaPath}: invalid Content-Range header`
+                    );
+                }
+                if (media.headers.get("content-length") !== "1024") {
+                    throw new Error(
+                        `${origin}${mediaPath}: invalid range Content-Length`
+                    );
+                }
+                if (media.headers.get("accept-ranges") !== "bytes") {
+                    throw new Error(
+                        `${origin}${mediaPath}: missing Accept-Ranges header`
+                    );
+                }
+                if (!media.headers.get("etag")) {
+                    throw new Error(`${origin}${mediaPath}: missing ETag`);
+                }
+                const rangeBody = Buffer.from(await media.arrayBuffer());
+                if (!rangeBody.equals(fixture.subarray(0, 1024))) {
+                    throw new Error(
+                        `${origin}${mediaPath}: range body differs from source`
+                    );
+                }
+
+                const cachedRange = await request(`${origin}${mediaPath}`, {
+                    headers: { Range: "bytes=1024-2047" },
+                });
+                if (cachedRange.status !== 206) {
+                    throw new Error(
+                        `${origin}${mediaPath}: second range returned ${cachedRange.status}`
                     );
                 }
                 if (
-                    !/^bytes 0-1023\/\d+$/.test(
-                        media.headers.get("content-range") || ""
-                    )
+                    cachedRange.headers.get("content-range") !==
+                    `bytes 1024-2047/${fixture.length}`
                 ) {
                     throw new Error(
-                        `${origin}/bird.mp4: invalid Content-Range header`
+                        `${origin}${mediaPath}: invalid cached Content-Range header`
                     );
                 }
-                if ((await media.arrayBuffer()).byteLength !== 1024) {
+                if (cachedRange.headers.get("content-length") !== "1024") {
                     throw new Error(
-                        `${origin}/bird.mp4: range body has the wrong size`
+                        `${origin}${mediaPath}: invalid cached range Content-Length`
+                    );
+                }
+                if (cachedRange.headers.get("accept-ranges") !== "bytes") {
+                    throw new Error(
+                        `${origin}${mediaPath}: cached range is missing Accept-Ranges`
+                    );
+                }
+                if (cachedRange.headers.get("cf-cache-status") !== "HIT") {
+                    throw new Error(
+                        `${origin}${mediaPath}: second range was not a cache hit`
+                    );
+                }
+                const cachedBody = Buffer.from(await cachedRange.arrayBuffer());
+                if (!cachedBody.equals(fixture.subarray(1024, 2048))) {
+                    throw new Error(
+                        `${origin}${mediaPath}: cached range differs from source`
+                    );
+                }
+
+                const unsatisfiable = await request(`${origin}${mediaPath}`, {
+                    headers: { Range: `bytes=${fixture.length}-` },
+                });
+                if (
+                    unsatisfiable.status !== 416 ||
+                    unsatisfiable.headers.get("content-range") !==
+                        `bytes */${fixture.length}`
+                ) {
+                    throw new Error(
+                        `${origin}${mediaPath}: invalid unsatisfiable range response`
                     );
                 }
             }
@@ -171,7 +242,7 @@ for (const site of manifest.staticSites) {
     }
 }
 
-for (const redirect of manifest.redirects) {
+for (const redirect of target === "apps" ? [] : manifest.redirects) {
     for (const origin of originsFor(redirect)) {
         await verifyEventually(origin, async () => {
             const response = await request(`${origin}/retired/path?ignored=1`, {


### PR DESCRIPTION
## Summary

- replace active `dao.xyz` and `giga.place` app, CLI, benchmark, and deployment URLs with Peerbit-owned domains
- add a production Cloudflare deployment workflow plus owned-domain and exact media-range integrity gates
- make Giga service URLs configurable and same-origin where appropriate
- remove two unused music video assets (about 21 MB) and the Worker they would otherwise require

Historical package authorship and license attribution remain unchanged.

## Validation

- full workspace build
- Cloudflare preview and production Wrangler dry-runs for all 9 configs
- owned-domain validation
- cache Worker tests
- file-share frontend unit tests and two-runner self-test
- app-service focused tests
- YAML/JSON/Node syntax/Prettier/diff checks
- changeset status against `origin/master`

## Rollout

Deploy the `apps` production target first and verify every `*.peerbit.org` hostname. Confirm `giga.peerbit.org` is allowed in Supabase auth redirects before enabling authenticated flows. Remove the old `stream.peerchecker.com` CNAME only after `stream.peerbit.org` is verified, then deploy the `legacy-redirect` target last.