### PR TITLE
fix: reserve local development domains

### DIFF
--- a/.changeset/safe-test-origins.md
+++ b/.changeset/safe-test-origins.md
@@ -1,0 +1,7 @@
+---
+"@giga-app/app-service": patch
+"@giga-app/sdk": patch
+---
+
+Use RFC-reserved local app origins and replace retired examples homepage
+metadata with the active repository.

--- a/packages/chess/frontend/package.json
+++ b/packages/chess/frontend/package.json
@@ -2,7 +2,7 @@
     "name": "chess",
     "version": "0.0.4",
     "private": true,
-    "homepage": "https://dao-xyz.github.io/peerbit-examples",
+    "homepage": "https://github.com/dao-xyz/peerbit-examples",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/chess/frontend/vite.config.remote.ts
+++ b/packages/chess/frontend/vite.config.remote.ts
@@ -26,7 +26,7 @@ export default defineConfig({
                   key: fs.readFileSync("./.cert/key.pem"),
                   cert: fs.readFileSync("./.cert/cert.pem"),
               },
-              host: "chess.test.xyz",
+              host: "chess.test",
               port: 5806,
           }
         : undefined,

--- a/packages/collaborative-learning/frontend/package.json
+++ b/packages/collaborative-learning/frontend/package.json
@@ -2,7 +2,7 @@
     "name": "collaborative-learning",
     "version": "0.0.1",
     "private": true,
-    "homepage": "https://dao-xyz.github.io/peerbit-examples",
+    "homepage": "https://github.com/dao-xyz/peerbit-examples",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/file-share/frontend/package.json
+++ b/packages/file-share/frontend/package.json
@@ -2,7 +2,7 @@
     "name": "file-share",
     "version": "0.0.8",
     "private": true,
-    "homepage": "https://dao-xyz.github.io/peerbit-examples",
+    "homepage": "https://github.com/dao-xyz/peerbit-examples",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/file-share/frontend/vite.config.remote.ts
+++ b/packages/file-share/frontend/vite.config.remote.ts
@@ -75,7 +75,7 @@ export default defineConfig({
                   key: fs.readFileSync("./.cert/key.pem"),
                   cert: fs.readFileSync("./.cert/cert.pem"),
               },
-              host: "filedrop.test.xyz",
+              host: "filedrop.test",
               port: 5803,
           }
         : undefined,

--- a/packages/many-chat-rooms/frontend/package.json
+++ b/packages/many-chat-rooms/frontend/package.json
@@ -2,7 +2,7 @@
     "name": "chat-frontend",
     "version": "0.2.3",
     "private": true,
-    "homepage": "https://dao-xyz.github.io/peerbit-examples",
+    "homepage": "https://github.com/dao-xyz/peerbit-examples",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/media-streaming/music-library/frontend/vite.config.remote.ts
+++ b/packages/media-streaming/music-library/frontend/vite.config.remote.ts
@@ -27,7 +27,7 @@ export default defineConfig({
                   key: fs.readFileSync("./.cert/key.pem"),
                   cert: fs.readFileSync("./.cert/cert.pem"),
               },
-              host: "stream.test.xyz",
+              host: "stream.test",
           }
         : undefined,
 });

--- a/packages/media-streaming/video-streaming/frontend/vite.config.remote.ts
+++ b/packages/media-streaming/video-streaming/frontend/vite.config.remote.ts
@@ -27,7 +27,7 @@ export default defineConfig({
                   key: fs.readFileSync("./.cert/key.pem"),
                   cert: fs.readFileSync("./.cert/cert.pem"),
               },
-              host: "stream.test.xyz",
+              host: "stream.test",
           }
         : undefined,
 });

--- a/packages/one-chat-room/frontend/package.json
+++ b/packages/one-chat-room/frontend/package.json
@@ -2,7 +2,7 @@
     "name": "chat-room",
     "version": "0.0.4",
     "private": true,
-    "homepage": "https://dao-xyz.github.io/peerbit-examples",
+    "homepage": "https://github.com/dao-xyz/peerbit-examples",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/one-chat-room/frontend/vite.config.remote.ts
+++ b/packages/one-chat-room/frontend/vite.config.remote.ts
@@ -37,7 +37,7 @@ export default defineConfig({
                   key: fs.readFileSync("./.cert/key.pem"),
                   cert: fs.readFileSync("./.cert/cert.pem"),
               },
-              host: "chat.test.xyz",
+              host: "chat.test",
           }
         : undefined,
 });

--- a/packages/one-chat-room/frontend/vite.config.ts
+++ b/packages/one-chat-room/frontend/vite.config.ts
@@ -31,15 +31,4 @@ export default defineConfig({
     define: {
         APP_VERSION: JSON.stringify(process.env.npm_package_version),
     },
-
-    /*  server: fs.existsSync("./.cert/key.pem")
-         ? {
-               port: 5802,
-               https: {
-                   key: fs.readFileSync("./.cert/key.pem"),
-                   cert: fs.readFileSync("./.cert/cert.pem"),
-               },
-               host: "chat.test.xyz",
-           }
-         : undefined, */
 });

--- a/packages/social-media-app/README.md
+++ b/packages/social-media-app/README.md
@@ -1,21 +1,57 @@
 # 🚧 WIP 🚧
 
-This app requires you to run all dependent apps (sub-apps) in the background. Todo so you also need to serve them using self signed certificates, that you create and put in `.cert`folders of each sub-application.
+This app can embed other examples from this repository. To use local versions,
+run each required frontend with its `start-remote` script. The remote Vite
+configurations use names under the RFC-reserved `.test` top-level domain, so
+local development never depends on public DNS.
 
-To generate certificates run 
+## Configure local names
 
-```sh
-openssl req -x509 -sha256 -new -nodes -days 3650 -key CA.key -out CA.pem
+Add this line to `/etc/hosts` on macOS or Linux, or to
+`C:\Windows\System32\drivers\etc\hosts` on Windows:
+
+```text
+127.0.0.1 stream.test chess.test chat.test text.test filedrop.test social.test
 ```
 
-To add a domain name to your system you can modify you hosts file, e.g. add 
+## Create a trusted local certificate
+
+Install [`mkcert`](https://github.com/FiloSottile/mkcert) with your operating
+system's package manager. Then, from the repository root, create one certificate
+covering every local name and copy it to the frontend directories that consume
+`.cert/key.pem` and `.cert/cert.pem`:
 
 ```sh
-127.0.0.1 text.test.xyz
+mkcert -install
+
+cert_dir="$(mktemp -d)"
+mkcert \
+  -cert-file "$cert_dir/cert.pem" \
+  -key-file "$cert_dir/key.pem" \
+  stream.test chess.test chat.test text.test filedrop.test social.test
+
+for app_dir in \
+  packages/media-streaming/video-streaming/frontend \
+  packages/media-streaming/music-library/frontend \
+  packages/chess/frontend \
+  packages/one-chat-room/frontend \
+  packages/text-document/frontend \
+  packages/file-share/frontend \
+  packages/social-media-app/frontend
+do
+  mkdir -p "$app_dir/.cert"
+  cp "$cert_dir/key.pem" "$app_dir/.cert/key.pem"
+  cp "$cert_dir/cert.pem" "$app_dir/.cert/cert.pem"
+done
+
+rm -rf "$cert_dir"
 ```
 
-to support the use of `text.test.xyz` so you can interact with the app from the [text-document](./../text-document/) demo.
+The `.cert` directories are ignored by Git. Never commit the generated private
+key. Certificates issued for the previous public-DNS names do not match the new
+names and must be replaced.
 
-To see the domain names you need to support to run all apps, check corrsponding `vite.config.remote.ts` files.'
-
-
+Run `pnpm start-remote` from each frontend directory you need. The music and
+video frontends both use `stream.test:5801`, and the text and filedrop frontends
+both bind port `5803` on the mapped loopback address. Run only one frontend from
+each of those pairs at a time.

--- a/packages/social-media-app/app-sdk/package.json
+++ b/packages/social-media-app/app-sdk/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@giga-app/sdk",
     "version": "2.0.1",
-    "homepage": "https://dao-xyz.github.io/peerbit-examples",
+    "homepage": "https://github.com/dao-xyz/peerbit-examples",
     "module": "lib/esm/index.js",
     "types": "lib/esm/index.d.ts",
     "exports": {

--- a/packages/social-media-app/app-service/src/__tests__/apps.test.ts
+++ b/packages/social-media-app/app-service/src/__tests__/apps.test.ts
@@ -252,7 +252,7 @@ describe("index", () => {
         it("Generic Video: valid getStatus", () => {
             if (!videoApp) throw new Error("Video app not found");
             // For development mode the expected URL is from STREAMING_APP(mode)
-            const validUrl = "https://stream.test.xyz:5801";
+            const validUrl = "https://stream.test:5801";
             const status = videoApp.getStatus(validUrl, host);
             expect(status.isReady).to.be.true;
         });
@@ -273,7 +273,7 @@ describe("index", () => {
         it("Chess: valid getStatus", () => {
             if (!chessApp) throw new Error("Chess app not found");
             // For development mode the expected URL is from CHESS_APP(mode)
-            const validUrl = "https://chess.test.xyz:5806";
+            const validUrl = "https://chess.test:5806";
             const status = chessApp.getStatus(validUrl, host);
             expect(status.isReady).to.be.true;
         });

--- a/packages/social-media-app/app-service/src/apps.ts
+++ b/packages/social-media-app/app-service/src/apps.ts
@@ -24,13 +24,13 @@ export interface CuratedAppUrls {
 const STREAMING_APP = (mode?: string, appUrls?: CuratedAppUrls) =>
     appUrls?.streaming?.trim() ||
     (["development", "staging"].includes(mode ?? "")
-        ? "https://stream.test.xyz:5801"
+        ? "https://stream.test:5801"
         : "https://stream.peerbit.org");
 
 const CHESS_APP = (mode?: string, appUrls?: CuratedAppUrls) =>
     appUrls?.chess?.trim() ||
     (["development", "staging"].includes(mode ?? "")
-        ? "https://chess.test.xyz:5806"
+        ? "https://chess.test:5806"
         : "https://chess.peerbit.org");
 
 // ─────────────────────────────────────────────────────────────

--- a/packages/social-media-app/frontend/package.json
+++ b/packages/social-media-app/frontend/package.json
@@ -2,7 +2,7 @@
     "name": "@giga-app/interface-frontend",
     "version": "2.0.1",
     "private": true,
-    "homepage": "https://dao-xyz.github.io/peerbit-examples",
+    "homepage": "https://github.com/dao-xyz/peerbit-examples",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/social-media-app/frontend/vite.config.remote.ts
+++ b/packages/social-media-app/frontend/vite.config.remote.ts
@@ -36,7 +36,7 @@ export default defineConfig({
                   key: fs.readFileSync("./.cert/key.pem"),
                   cert: fs.readFileSync("./.cert/cert.pem"),
               },
-              host: "social.test.xyz",
+              host: "social.test",
               port: 6083,
           }
         : undefined,

--- a/packages/text-document/frontend/package.json
+++ b/packages/text-document/frontend/package.json
@@ -2,7 +2,7 @@
     "name": "text-document",
     "version": "0.0.1",
     "private": true,
-    "homepage": "https://dao-xyz.github.io/peerbit-examples",
+    "homepage": "https://github.com/dao-xyz/peerbit-examples",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/packages/text-document/frontend/vite.config.remote.ts
+++ b/packages/text-document/frontend/vite.config.remote.ts
@@ -25,7 +25,7 @@ export default defineConfig({
                   key: fs.readFileSync("./.cert/key.pem"),
                   cert: fs.readFileSync("./.cert/cert.pem"),
               },
-              host: "text.test.xyz",
+              host: "text.test",
               port: 5803,
           }
         : undefined,

--- a/scripts/validate-owned-domains.mjs
+++ b/scripts/validate-owned-domains.mjs
@@ -6,7 +6,24 @@ const repoRoot = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     ".."
 );
-const forbiddenHosts = ["dao" + ".xyz", "giga" + ".place"];
+const forbiddenReferences = [
+    {
+        needle: "dao" + ".xyz",
+        description: "unowned host",
+    },
+    {
+        needle: "giga" + ".place",
+        description: "unowned host",
+    },
+    {
+        needle: "." + "test" + ".xyz",
+        description: "unsafe public-DNS development suffix",
+    },
+    {
+        needle: "dao-xyz.github" + ".io/peerbit-examples",
+        description: "retired GitHub Pages URL",
+    },
+];
 const legalAttributionFiles = new Set([
     "LICENSE",
     "LICENSE-MIT",
@@ -80,9 +97,11 @@ const visit = (absolutePath) => {
         contents = JSON.stringify(manifest);
     }
     contents = contents.toLowerCase();
-    for (const host of forbiddenHosts) {
-        if (contents.includes(host)) {
-            violations.push(`${relativePath}: contains unowned host ${host}`);
+    for (const reference of forbiddenReferences) {
+        if (contents.includes(reference.needle)) {
+            violations.push(
+                `${relativePath}: contains ${reference.description} ${reference.needle}`
+            );
         }
     }
 };
@@ -91,10 +110,10 @@ visit(repoRoot);
 
 if (violations.length > 0) {
     throw new Error(
-        `Unowned domain references found:\n${violations.join("\n")}`
+        `Unsafe or retired domain references found:\n${violations.join("\n")}`
     );
 }
 
 console.log(
-    "Validated that source and generated text assets use owned domains"
+    "Validated that source and generated text assets avoid unsafe and retired project domains"
 );


### PR DESCRIPTION
## Summary

- move development-only app hosts from public `*.test.xyz` DNS names to RFC-reserved `.test` names
- replace stale GitHub Pages package homepages with the active repository URL
- document complete hosts-file and trusted multi-SAN local certificate setup
- extend the retired/unsafe domain regression gate

## Validation

- app-service tests: 24 passed
- app-service and SDK builds
- manifest parsing and Prettier checks
- remote host/documentation consistency check
- owned/unsafe-domain validator
- diff check and changeset status

Cloudflare production configuration is unchanged by this PR.