### PR TITLE
fix: tolerate Cloudflare range propagation

### DIFF
--- a/scripts/verify-cloudflare-sites.mjs
+++ b/scripts/verify-cloudflare-sites.mjs
@@ -50,16 +50,24 @@ const request = async (url, init = {}) => {
         throw new Error(`${url}: ${error}`);
     }
 };
+// A newly deployed Worker and its asset metadata can take more than a minute
+// to converge at the data center used by the verifier. Keep retrying long
+// enough to distinguish propagation from a persistent range-handling defect.
+const VERIFY_ATTEMPTS = 150;
+const VERIFY_RETRY_DELAY_MS = 2_000;
 const verifyEventually = async (label, check) => {
     let lastError;
-    for (let attempt = 1; attempt <= 30; attempt += 1) {
+    for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt += 1) {
         try {
             await check();
             return;
         } catch (error) {
             lastError = error;
-            if (attempt < 30)
-                await new Promise((resolve) => setTimeout(resolve, 2_000));
+            if (attempt < VERIFY_ATTEMPTS) {
+                await new Promise((resolve) =>
+                    setTimeout(resolve, VERIFY_RETRY_DELAY_MS)
+                );
+            }
         }
     }
     throw new Error(`${label} did not converge: ${lastError}`);
@@ -170,9 +178,10 @@ for (const site of target === "legacy-redirect" ? [] : manifest.staticSites) {
                         `${origin}${mediaPath}: invalid range Content-Length`
                     );
                 }
-                if (media.headers.get("accept-ranges") !== "bytes") {
+                const acceptRanges = media.headers.get("accept-ranges");
+                if (acceptRanges && acceptRanges !== "bytes") {
                     throw new Error(
-                        `${origin}${mediaPath}: missing Accept-Ranges header`
+                        `${origin}${mediaPath}: invalid Accept-Ranges header`
                     );
                 }
                 if (!media.headers.get("etag")) {
@@ -206,9 +215,11 @@ for (const site of target === "legacy-redirect" ? [] : manifest.staticSites) {
                         `${origin}${mediaPath}: invalid cached range Content-Length`
                     );
                 }
-                if (cachedRange.headers.get("accept-ranges") !== "bytes") {
+                const cachedAcceptRanges =
+                    cachedRange.headers.get("accept-ranges");
+                if (cachedAcceptRanges && cachedAcceptRanges !== "bytes") {
                     throw new Error(
-                        `${origin}${mediaPath}: cached range is missing Accept-Ranges`
+                        `${origin}${mediaPath}: cached range has an invalid Accept-Ranges header`
                     );
                 }
                 if (cachedRange.headers.get("cf-cache-status") !== "HIT") {


### PR DESCRIPTION
## Summary

- allow Cloudflare-synthesized `206` responses to omit `Accept-Ranges` while still rejecting an explicitly invalid value
- extend deployment convergence from one minute to five minutes so a newly deployed Worker/asset configuration can reach the verifier's data center

Cloudflare's Workers Cache documentation specifies byte slicing by the observed `206`/`Content-Range`/body behavior; `Accept-Ranges` is not required for the cached partial response: https://developers.cloudflare.com/workers/cache/configuration/#range-requests

## Evidence

The first master preview run deployed successfully but initially observed an old `200` response and later exact `206` responses without `Accept-Ranges`. With this patch, the verifier passed all eight apps plus the legacy redirect against deployed commit `7b8bbe5ce40ed4591dbcb60e747e35342e4a6708`, including byte equality, disjoint cache-hit ranges, and `416` handling.