### PR TITLE
Disable stale Giga account authentication

### DIFF
--- a/.changeset/clean-auth-disabled.md
+++ b/.changeset/clean-auth-disabled.md
@@ -1,0 +1,4 @@
+---
+---
+
+Disable the unowned Giga account-auth integration in Cloudflare builds and add fail-closed build, artifact, UI, and runtime checks.

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -37,18 +37,22 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Validate production bootstrap sources
+              env:
+                  VITE_SUPABASE_AUTH_ENABLED: "false"
               run: |
                   node scripts/validate-production-bootstrap.mjs
+                  node scripts/validate-cloudflare-account-auth.mjs
                   node --test cloudflare/*.test.mjs
 
             - name: Build every frontend
               env:
                   COMMIT_HASH: ${{ github.sha }}
-                  VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-                  VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+                  VITE_SUPABASE_AUTH_ENABLED: "false"
               run: |
                   export SHORT_SHA="${GITHUB_SHA::7}"
                   pnpm run build
+                  node scripts/validate-cloudflare-account-auth.mjs \
+                      --dist packages/social-media-app/frontend/dist
 
             - name: Prepare and validate Cloudflare assets
               env:
@@ -99,13 +103,15 @@ jobs:
             - name: Install and build without deployment credentials
               env:
                   COMMIT_HASH: ${{ github.sha }}
-                  VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-                  VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+                  VITE_SUPABASE_AUTH_ENABLED: "false"
               run: |
                   pnpm install --frozen-lockfile
                   node scripts/validate-production-bootstrap.mjs
+                  node scripts/validate-cloudflare-account-auth.mjs
                   export SHORT_SHA="${GITHUB_SHA::7}"
                   pnpm run build
+                  node scripts/validate-cloudflare-account-auth.mjs \
+                      --dist packages/social-media-app/frontend/dist
                   node scripts/prepare-cloudflare-assets.mjs
                   git diff --exit-code
                   npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler

--- a/.github/workflows/cloudflare-production.yml
+++ b/.github/workflows/cloudflare-production.yml
@@ -49,14 +49,16 @@ jobs:
             - name: Build and validate every frontend
               env:
                   COMMIT_HASH: ${{ github.sha }}
-                  VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-                  VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+                  VITE_SUPABASE_AUTH_ENABLED: "false"
               run: |
                   pnpm install --frozen-lockfile
                   node scripts/validate-production-bootstrap.mjs
+                  node scripts/validate-cloudflare-account-auth.mjs
                   node --test cloudflare/*.test.mjs
                   export SHORT_SHA="${GITHUB_SHA::7}"
                   pnpm run build
+                  node scripts/validate-cloudflare-account-auth.mjs \
+                      --dist packages/social-media-app/frontend/dist
                   node scripts/prepare-cloudflare-assets.mjs
                   node scripts/validate-owned-domains.mjs
                   git diff --exit-code
@@ -95,14 +97,16 @@ jobs:
             - name: Rebuild without deployment credentials
               env:
                   COMMIT_HASH: ${{ github.sha }}
-                  VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-                  VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+                  VITE_SUPABASE_AUTH_ENABLED: "false"
               run: |
                   pnpm install --frozen-lockfile
                   node scripts/validate-production-bootstrap.mjs
+                  node scripts/validate-cloudflare-account-auth.mjs
                   node --test cloudflare/*.test.mjs
                   export SHORT_SHA="${GITHUB_SHA::7}"
                   pnpm run build
+                  node scripts/validate-cloudflare-account-auth.mjs \
+                      --dist packages/social-media-app/frontend/dist
                   node scripts/prepare-cloudflare-assets.mjs
                   node scripts/validate-owned-domains.mjs
                   git diff --exit-code

--- a/README.md
+++ b/README.md
@@ -112,7 +112,11 @@ Local validation uses the locked Wrangler toolchain:
 
 ```sh
 pnpm install --frozen-lockfile
+export VITE_SUPABASE_AUTH_ENABLED=false
+unset VITE_SUPABASE_URL VITE_SUPABASE_ANON_KEY
+node scripts/validate-cloudflare-account-auth.mjs
 pnpm run build
+node scripts/validate-cloudflare-account-auth.mjs --dist packages/social-media-app/frontend/dist
 node scripts/validate-production-bootstrap.mjs
 node scripts/prepare-cloudflare-assets.mjs
 npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler
@@ -126,3 +130,11 @@ Production configs are rendered with `--mode production`. First-party demo
 Workers are restricted to `*.apps.peerbit.org`; the legacy redirect remains on
 `peerchecker.com`. Use the separately reviewed production environment and
 verify every hostname before retiring a known-good Worker version.
+
+Giga account auth is intentionally disabled in Cloudflare preview and
+production builds. The workflows do not expose Supabase secrets, require
+`VITE_SUPABASE_AUTH_ENABLED=false`, reject any Supabase URL or publishable key
+in the built assets, publish the disabled state in `release.json`, and smoke-test
+that the deployed UI has no account entry or Supabase traffic. Enabling auth
+requires a separate reviewed change after a Peerbit-owned auth project is
+provisioned; the retired project has no users or data to migrate.

--- a/cloudflare/account-auth-policy.mjs
+++ b/cloudflare/account-auth-policy.mjs
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+export const ACCOUNT_AUTH_FLAG = "VITE_SUPABASE_AUTH_ENABLED";
+export const ACCOUNT_AUTH_CREDENTIALS = [
+    "VITE_SUPABASE_URL",
+    "VITE_SUPABASE_ANON_KEY",
+];
+export const RETIRED_SUPABASE_PROJECT_REF = "gghgdezsgisejiaofnrm";
+
+const textExtensions = new Set([".css", ".html", ".js", ".json", ".mjs"]);
+
+const configured = (value) =>
+    typeof value === "string" && value.trim().length > 0;
+
+export const assertAccountAuthDisabledEnvironment = (env) => {
+    if (env[ACCOUNT_AUTH_FLAG] !== "false") {
+        throw new Error(
+            `${ACCOUNT_AUTH_FLAG} must be exactly "false" for Cloudflare builds`
+        );
+    }
+
+    const exposedCredentials = ACCOUNT_AUTH_CREDENTIALS.filter((name) =>
+        configured(env[name])
+    );
+    if (exposedCredentials.length > 0) {
+        throw new Error(
+            `Cloudflare builds must not receive account-auth credentials: ${exposedCredentials.join(
+                ", "
+            )}`
+        );
+    }
+};
+
+export const assertAccountAuthDisabledManifest = (manifest) => {
+    const giga = manifest?.staticSites?.find((site) => site.id === "giga");
+    if (!giga) throw new Error("Cloudflare manifest is missing the Giga site");
+    if (giga.accountAuth !== "disabled") {
+        throw new Error(
+            'Giga must declare accountAuth: "disabled" in cloudflare/sites.json'
+        );
+    }
+};
+
+const walkTextFiles = (directory) => {
+    const files = [];
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+        const fullPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) files.push(...walkTextFiles(fullPath));
+        else if (entry.isFile() && textExtensions.has(path.extname(entry.name)))
+            files.push(fullPath);
+    }
+    return files;
+};
+
+export const assertAccountAuthDisabledBuild = (directory) => {
+    if (!existsSync(directory) || !statSync(directory).isDirectory()) {
+        throw new Error(`Giga build directory does not exist: ${directory}`);
+    }
+
+    const searchable = walkTextFiles(directory)
+        .map((file) => readFileSync(file, "utf8"))
+        .join("\n");
+
+    if (searchable.includes(RETIRED_SUPABASE_PROJECT_REF)) {
+        throw new Error(
+            `Giga build contains retired Supabase project ${RETIRED_SUPABASE_PROJECT_REF}`
+        );
+    }
+
+    const projectUrl = searchable.match(
+        /https:\/\/[a-z0-9-]+\.supabase\.(?:co|in)(?=[/"'`\\]|$)/i
+    )?.[0];
+    if (projectUrl) {
+        throw new Error(
+            `Giga Cloudflare build contains a Supabase project URL while account auth is disabled: ${projectUrl}`
+        );
+    }
+
+    if (searchable.includes("sb_publishable_")) {
+        throw new Error(
+            "Giga Cloudflare build contains a Supabase publishable key while account auth is disabled"
+        );
+    }
+};

--- a/cloudflare/account-auth-policy.test.mjs
+++ b/cloudflare/account-auth-policy.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+    assertAccountAuthDisabledBuild,
+    assertAccountAuthDisabledEnvironment,
+    assertAccountAuthDisabledManifest,
+    RETIRED_SUPABASE_PROJECT_REF,
+} from "./account-auth-policy.mjs";
+
+test("accepts an explicit disabled build without credentials", () => {
+    assert.doesNotThrow(() =>
+        assertAccountAuthDisabledEnvironment({
+            VITE_SUPABASE_AUTH_ENABLED: "false",
+        })
+    );
+});
+
+test("requires an explicit disabled flag", () => {
+    assert.throws(
+        () => assertAccountAuthDisabledEnvironment({}),
+        /must be exactly "false"/
+    );
+    assert.throws(
+        () =>
+            assertAccountAuthDisabledEnvironment({
+                VITE_SUPABASE_AUTH_ENABLED: "true",
+            }),
+        /must be exactly "false"/
+    );
+});
+
+test("rejects credentials even when auth is disabled", () => {
+    assert.throws(
+        () =>
+            assertAccountAuthDisabledEnvironment({
+                VITE_SUPABASE_AUTH_ENABLED: "false",
+                VITE_SUPABASE_URL: "https://example.supabase.co",
+                VITE_SUPABASE_ANON_KEY: "stale-key",
+            }),
+        /VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY/
+    );
+});
+
+test("requires the Giga manifest to declare disabled account auth", () => {
+    assert.doesNotThrow(() =>
+        assertAccountAuthDisabledManifest({
+            staticSites: [{ id: "giga", accountAuth: "disabled" }],
+        })
+    );
+    assert.throws(
+        () =>
+            assertAccountAuthDisabledManifest({
+                staticSites: [{ id: "giga" }],
+            }),
+        /accountAuth/
+    );
+});
+
+test("rejects Supabase configuration in the built assets", (t) => {
+    const directory = mkdtempSync(
+        path.join(os.tmpdir(), "peerbit-auth-build-")
+    );
+    t.after(() => rmSync(directory, { force: true, recursive: true }));
+    mkdirSync(path.join(directory, "assets"));
+    const bundle = path.join(directory, "assets", "app.js");
+
+    writeFileSync(bundle, 'console.log("account auth disabled")');
+    assert.doesNotThrow(() => assertAccountAuthDisabledBuild(directory));
+
+    writeFileSync(bundle, `const ref = "${RETIRED_SUPABASE_PROJECT_REF}"`);
+    assert.throws(
+        () => assertAccountAuthDisabledBuild(directory),
+        /retired Supabase project/
+    );
+
+    writeFileSync(
+        bundle,
+        'const url = "https://freshproject.supabase.co/auth/v1"'
+    );
+    assert.throws(
+        () => assertAccountAuthDisabledBuild(directory),
+        /contains a Supabase project URL/
+    );
+
+    writeFileSync(bundle, 'const key = "sb_publishable_example"');
+    assert.throws(
+        () => assertAccountAuthDisabledBuild(directory),
+        /contains a Supabase publishable key/
+    );
+});

--- a/cloudflare/sites.json
+++ b/cloudflare/sites.json
@@ -30,6 +30,7 @@
             "worker": "peerbit-examples-giga",
             "directory": "packages/social-media-app/frontend/dist",
             "title": "Giga",
+            "accountAuth": "disabled",
             "script": "cloudflare/cached-static-assets.mjs",
             "workerFirst": ["/turtle720.mp4"],
             "domains": ["giga.apps.peerbit.org"]

--- a/packages/file-share/frontend/tests/cloudflare-preview.e2e.spec.ts
+++ b/packages/file-share/frontend/tests/cloudflare-preview.e2e.spec.ts
@@ -44,11 +44,10 @@ test.describe("Cloudflare preview runtime smoke", () => {
                 return;
             }
             if (/\.(?:m?js)(?:\?|$)/.test(url)) javascript.add(url);
+            const contentType = response.headers()["content-type"];
             if (
                 /\.wasm(?:\?|$)/.test(url) &&
-                response
-                    .headers()
-                    ["content-type"]?.startsWith("application/wasm")
+                contentType?.startsWith("application/wasm")
             ) {
                 wasm.add(url);
             }
@@ -91,6 +90,38 @@ test.describe("Cloudflare preview runtime smoke", () => {
         );
     });
 
+    test("Giga exposes no account auth or Supabase traffic", async ({
+        page,
+    }) => {
+        test.setTimeout(180_000);
+        const origin = requiredUrl("PW_GIGA_URL");
+        const supabaseRequests: string[] = [];
+        page.on("request", (request) => {
+            const url = new URL(request.url());
+            if (
+                url.hostname.endsWith(".supabase.co") ||
+                url.hostname.endsWith(".supabase.in")
+            ) {
+                supabaseRequests.push(request.url());
+            }
+        });
+
+        await page.goto(`${origin}/?ephemeral=true&bootstrap=offline#/auth`, {
+            waitUntil: "domcontentloaded",
+            timeout: 120_000,
+        });
+        await expect(page).toHaveURL(/#\/$/, { timeout: 120_000 });
+        await expect(page.getByLabel("Email")).toHaveCount(0);
+
+        const profile = page.getByTestId("header-profile-area");
+        await expect(profile).toBeVisible({ timeout: 120_000 });
+        await profile.locator("button").first().click();
+        await expect(
+            page.getByRole("menuitem", { name: /^(?:Sign in|Account)$/ })
+        ).toHaveCount(0);
+        expect(supabaseRequests).toEqual([]);
+    });
+
     test("file-share boots and connects to an authoritative relay", async ({
         page,
         request,
@@ -123,7 +154,7 @@ test.describe("Cloudflare preview runtime smoke", () => {
                             const hooks = (window as any)
                                 .__peerbitFileShareTestHooks;
                             return hooks?.getDiagnostics
-                                ? await hooks.getDiagnostics()
+                                ? hooks.getDiagnostics()
                                 : null;
                         });
                         return Boolean(

--- a/packages/social-media-app/frontend/.env.example
+++ b/packages/social-media-app/frontend/.env.example
@@ -2,7 +2,10 @@
 #
 # Vite only exposes variables prefixed with VITE_ to the browser bundle.
 # Never put a Supabase "service role" key in here.
+# Auth is opt-in. Enabling it requires a deliberately provisioned Peerbit-owned
+# project; Cloudflare preview and production builds always keep it disabled.
 
+VITE_SUPABASE_AUTH_ENABLED=false
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 

--- a/packages/social-media-app/frontend/src/Header.tsx
+++ b/packages/social-media-app/frontend/src/Header.tsx
@@ -146,21 +146,23 @@ export const Header = (props: HeaderProps) => {
                                                 >
                                                     Share Profile
                                                 </DropdownMenu.Item> */}
-                                                <DropdownMenu.Item
-                                                    className="menu-item"
-                                                    onSelect={() =>
-                                                        navigate(AUTH, {})
-                                                    }
-                                                >
-                                                    <div className="flex items-center gap-2">
-                                                        <MdSwitchAccount />
-                                                        <span>
-                                                            {auth.user
-                                                                ? "Account"
-                                                                : "Sign in"}
-                                                        </span>
-                                                    </div>
-                                                </DropdownMenu.Item>
+                                                {auth.enabled && (
+                                                    <DropdownMenu.Item
+                                                        className="menu-item"
+                                                        onSelect={() =>
+                                                            navigate(AUTH, {})
+                                                        }
+                                                    >
+                                                        <div className="flex items-center gap-2">
+                                                            <MdSwitchAccount />
+                                                            <span>
+                                                                {auth.user
+                                                                    ? "Account"
+                                                                    : "Sign in"}
+                                                            </span>
+                                                        </div>
+                                                    </DropdownMenu.Item>
+                                                )}
                                                 <DropdownMenu.Item
                                                     className="menu-item"
                                                     onSelect={() =>

--- a/packages/social-media-app/frontend/src/auth/AuthRoutes.tsx
+++ b/packages/social-media-app/frontend/src/auth/AuthRoutes.tsx
@@ -1,8 +1,12 @@
 import { Navigate, Route, Routes } from "react-router";
 import { AuthScreen } from "./AuthScreen";
 import { UpdatePasswordScreen } from "./UpdatePasswordScreen";
+import { useAuth } from "./useAuth";
 
 export const AuthRoutes = () => {
+    const auth = useAuth();
+    if (!auth.enabled) return <Navigate to="/" replace />;
+
     return (
         <Routes>
             <Route path="/" element={<AuthScreen mode="sign-in" />} />

--- a/packages/social-media-app/frontend/src/supabase.ts
+++ b/packages/social-media-app/frontend/src/supabase.ts
@@ -9,15 +9,35 @@ const normalizeUrl = (value: string): string => {
     return `https://${trimmed}`;
 };
 
-export const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
+const configuredSupabaseUrl = import.meta.env.VITE_SUPABASE_URL
     ? normalizeUrl(import.meta.env.VITE_SUPABASE_URL)
     : undefined;
 
-export const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim()
+const configuredSupabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim()
     ? import.meta.env.VITE_SUPABASE_ANON_KEY.trim()
     : undefined;
 
+export const SUPABASE_AUTH_ENABLED =
+    import.meta.env.VITE_SUPABASE_AUTH_ENABLED === "true";
+
+if (
+    SUPABASE_AUTH_ENABLED &&
+    (!configuredSupabaseUrl || !configuredSupabaseAnonKey)
+) {
+    throw new Error(
+        "VITE_SUPABASE_AUTH_ENABLED=true requires VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY"
+    );
+}
+
+export const SUPABASE_URL = SUPABASE_AUTH_ENABLED
+    ? configuredSupabaseUrl
+    : undefined;
+
+export const SUPABASE_ANON_KEY = SUPABASE_AUTH_ENABLED
+    ? configuredSupabaseAnonKey
+    : undefined;
+
 export const supabase =
-    SUPABASE_URL && SUPABASE_ANON_KEY
+    SUPABASE_AUTH_ENABLED && SUPABASE_URL && SUPABASE_ANON_KEY
         ? createSupabaseClient(SUPABASE_URL, SUPABASE_ANON_KEY)
         : undefined;

--- a/packages/social-media-app/frontend/src/vite-env.d.ts
+++ b/packages/social-media-app/frontend/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMeta {
 }
 
 interface ImportMetaEnv {
+    readonly VITE_SUPABASE_AUTH_ENABLED?: "true" | "false";
     readonly VITE_SUPABASE_URL?: string;
     readonly VITE_SUPABASE_ANON_KEY?: string;
     readonly VITE_STREAMING_APP_URL?: string;

--- a/packages/social-media-app/frontend/tests/auth/authDisabled.spec.ts
+++ b/packages/social-media-app/frontend/tests/auth/authDisabled.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("account auth disabled", () => {
+    test.skip(
+        process.env.VITE_SUPABASE_AUTH_ENABLED === "true",
+        "This smoke covers builds where account auth is disabled."
+    );
+
+    test("hides account UI, redirects auth routes, and makes no Supabase requests", async ({
+        page,
+    }) => {
+        test.setTimeout(120_000);
+        const supabaseRequests: string[] = [];
+        page.on("request", (request) => {
+            const url = new URL(request.url());
+            if (
+                url.hostname.endsWith(".supabase.co") ||
+                url.hostname.endsWith(".supabase.in")
+            ) {
+                supabaseRequests.push(request.url());
+            }
+        });
+
+        await page.goto("/?ephemeral=true&bootstrap=offline#/auth");
+        await expect(page).toHaveURL(/#\/$/, { timeout: 120_000 });
+        await expect(page.getByLabel("Email")).toHaveCount(0);
+
+        const profile = page.getByTestId("header-profile-area");
+        await expect(profile).toBeVisible({ timeout: 120_000 });
+        await profile.locator("button").first().click();
+        await expect(
+            page.getByRole("menuitem", { name: /^(?:Sign in|Account)$/ })
+        ).toHaveCount(0);
+        expect(supabaseRequests).toEqual([]);
+    });
+});

--- a/packages/social-media-app/frontend/tests/auth/supabaseAuth.spec.ts
+++ b/packages/social-media-app/frontend/tests/auth/supabaseAuth.spec.ts
@@ -7,9 +7,11 @@ const TEST_EMAIL = process.env.TEST_EMAIL;
 const TEST_PASSWORD = process.env.TEST_PASSWORD;
 
 const missingEnv =
-    !TEST_EMAIL?.trim() || !TEST_PASSWORD?.trim()
-        ? "Set TEST_EMAIL and TEST_PASSWORD in packages/social-media-app/frontend/.env (not VITE_)."
-        : undefined;
+    process.env.VITE_SUPABASE_AUTH_ENABLED !== "true"
+        ? "Set VITE_SUPABASE_AUTH_ENABLED=true to run Supabase auth tests."
+        : !TEST_EMAIL?.trim() || !TEST_PASSWORD?.trim()
+          ? "Set TEST_EMAIL and TEST_PASSWORD in packages/social-media-app/frontend/.env (not VITE_)."
+          : undefined;
 
 async function openProfileMenu(page: Page) {
     const area = page.getByTestId("header-profile-area");

--- a/scripts/prepare-cloudflare-assets.mjs
+++ b/scripts/prepare-cloudflare-assets.mjs
@@ -107,7 +107,11 @@ for (const site of manifest.staticSites) {
     writeFileSync(path.join(canonicalOutput, "_headers"), HEADERS, "utf8");
     writeFileSync(
         path.join(canonicalOutput, "release.json"),
-        `${JSON.stringify({ commit, site: site.id })}\n`,
+        `${JSON.stringify({
+            commit,
+            site: site.id,
+            ...(site.accountAuth ? { accountAuth: site.accountAuth } : {}),
+        })}\n`,
         "utf8"
     );
 

--- a/scripts/validate-cloudflare-account-auth.mjs
+++ b/scripts/validate-cloudflare-account-auth.mjs
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    assertAccountAuthDisabledBuild,
+    assertAccountAuthDisabledEnvironment,
+    assertAccountAuthDisabledManifest,
+} from "../cloudflare/account-auth-policy.mjs";
+
+const repoRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    ".."
+);
+const args = process.argv.slice(2);
+if (args.length !== 0 && (args.length !== 2 || args[0] !== "--dist")) {
+    throw new Error(
+        "Usage: validate-cloudflare-account-auth.mjs [--dist DIRECTORY]"
+    );
+}
+
+assertAccountAuthDisabledEnvironment(process.env);
+assertAccountAuthDisabledManifest(
+    JSON.parse(
+        readFileSync(path.join(repoRoot, "cloudflare/sites.json"), "utf8")
+    )
+);
+
+if (args.length === 2) {
+    assertAccountAuthDisabledBuild(path.resolve(repoRoot, args[1]));
+}
+
+console.log(
+    `Giga Cloudflare account auth is explicitly disabled${
+        args.length === 2 ? " and the build contains no Supabase project" : ""
+    }.`
+);

--- a/scripts/verify-cloudflare-sites.mjs
+++ b/scripts/verify-cloudflare-sites.mjs
@@ -109,6 +109,11 @@ for (const site of target === "legacy-redirect" ? [] : manifest.staticSites) {
             const release = await releaseResponse.json();
             if (release.site !== site.id)
                 throw new Error(`${origin}: wrong release site id`);
+            if (site.accountAuth && release.accountAuth !== site.accountAuth) {
+                throw new Error(
+                    `${origin}: expected account auth ${site.accountAuth}, found ${release.accountAuth}`
+                );
+            }
             if (expectedCommit && release.commit !== expectedCommit) {
                 throw new Error(
                     `${origin}: expected release ${expectedCommit}, found ${release.commit}`


### PR DESCRIPTION
## Summary

- fail closed unless auth is explicitly enabled with complete Supabase configuration
- force Cloudflare builds to disable account auth and reject stale credentials/URLs in generated assets
- hide account UI and redirect auth routes while preserving owned `*.apps.peerbit.org` hosting

## Validation

- full monorepo build
- Cloudflare policy tests (8/8)
- generated bundle auth/config scan
- Chromium auth-disabled smoke (1/1)
- frozen install and clean diff checks