### PR TITLE
Authenticate Giga iframe messaging and capabilities

### DIFF
--- a/.changeset/secure-giga-frames.md
+++ b/.changeset/secure-giga-frames.md
@@ -1,0 +1,6 @@
+---
+"@giga-app/app-service": patch
+"@giga-app/sdk": patch
+---
+
+Authenticate Giga iframe messages by exact source and origin, validate their runtime schema, require rendered and original iframe URLs to share one normalized origin, remove stale listeners before source-change layout effects, restrict child-driven navigation to safe same-origin URLs, and grant each strictly resolved curated embed only its explicit iframe permissions or resizing capability.

--- a/packages/social-media-app/app-sdk/src/AppProvider.tsx
+++ b/packages/social-media-app/app-sdk/src/AppProvider.tsx
@@ -7,7 +7,7 @@ import React, {
 } from "react";
 import { usePeer } from "@peerbit/react";
 import { IframeNavigationEmitter } from "./navigation-emitter";
-import { AppClient, AppMessage } from "./client-host";
+import { AppClient, resolveParentOrigin } from "./client-host";
 
 export interface AppProviderProps {
     children: React.ReactNode;
@@ -16,7 +16,8 @@ export interface AppProviderProps {
      */
     navigation?: "emit-all" | "none";
     /**
-     * Optional override for targetOrigin if not available in PeerContext.
+     * Optional parent origin override. When omitted, the embedding origin is
+     * derived from document.referrer. Wildcard origins are not accepted.
      */
     targetOrigin?: string;
 
@@ -68,9 +69,13 @@ export const AppProvider = ({
 }: AppProviderProps) => {
     const peerContext = usePeer();
 
-    // `@peerbit/react` no longer exposes iframe proxy targetOrigin on the peer context.
-    // Keep a simple override for embedding use-cases.
-    const targetOrigin = targetOriginProp || "*";
+    // `@peerbit/react` no longer exposes iframe proxy targetOrigin on the peer
+    // context. The referrer contains the embedding origin under the iframe's
+    // strict-origin-when-cross-origin policy.
+    const targetOrigin = resolveParentOrigin(
+        targetOriginProp,
+        window.parent === window ? "" : document.referrer
+    );
 
     // Create a ref for an AppClient instance to send events.
     const statusClientRef = useRef<AppClient | null>(null);
@@ -83,40 +88,38 @@ export const AppProvider = ({
     // Manage theme state sent by the parent.
     const [theme, setTheme] = useState<"light" | "dark">("light");
 
-    // Initialize our status client and emit the initial loading state.
+    // Initialize one authenticated message channel for all parent events.
     useEffect(() => {
-        if (targetOrigin && !statusClientRef.current) {
-            statusClientRef.current = new AppClient({
-                targetOrigin,
-                onResize: () => {
-                    // No-op for status events.
-                },
-                useThemeClasses: themeOptions?.useClasses,
-            });
+        if (!targetOrigin) {
+            statusClientRef.current = null;
+            return;
         }
-        if (statusClientRef.current) {
-            statusClientRef.current.send({
-                type: "loading",
-                state: peerContext.loading ? "loading" : "loaded",
-            });
-        }
-    }, [targetOrigin, peerContext.loading]);
 
-    // Listen for preview events from the parent.
-    useEffect(() => {
-        const handleEvent = (event: MessageEvent) => {
-            const data = event.data as AppMessage;
-            if (data.type === "preview") {
-                setPreviewState(data.state);
-            } else if (data.type === "theme") {
-                setTheme(data.theme);
+        const client = new AppClient({
+            targetOrigin,
+            onResize: () => {
+                // No-op for status events.
+            },
+            onPreview: (event) => setPreviewState(event.data.state),
+            onTheme: (event) => setTheme(event.data.theme),
+            useThemeClasses: themeOptions?.useClasses,
+        });
+        statusClientRef.current = client;
+        return () => {
+            client.stop();
+            if (statusClientRef.current === client) {
+                statusClientRef.current = null;
             }
         };
-        window.addEventListener("message", handleEvent);
-        return () => {
-            window.removeEventListener("message", handleEvent);
-        };
-    }, []);
+    }, [targetOrigin, themeOptions?.useClasses]);
+
+    // Emit loading changes only after the authenticated channel exists.
+    useEffect(() => {
+        statusClientRef.current?.send({
+            type: "loading",
+            state: peerContext.loading ? "loading" : "loaded",
+        });
+    }, [targetOrigin, peerContext.loading, themeOptions?.useClasses]);
 
     const setLoading = (loading: boolean) => {
         if (statusClientRef.current) {

--- a/packages/social-media-app/app-sdk/src/HostProvider.tsx
+++ b/packages/social-media-app/app-sdk/src/HostProvider.tsx
@@ -1,7 +1,8 @@
 import React, {
+    useCallback,
     createContext,
     useContext,
-    useEffect,
+    useLayoutEffect,
     useMemo,
     useRef,
     useState,
@@ -11,6 +12,7 @@ import {
     AppMessage,
     ResizeMessage,
     NavigationEvent,
+    normalizeMatchingAppOrigin,
 } from "./client-host";
 import IFrameResizer from "./IFrameResizer";
 import { useHostRegistry } from "./HostRegistryProvider"; // import the registry hook
@@ -35,6 +37,19 @@ export interface HostProviderProps {
      * The original source of the iframe. Before any navigation.
      */
     iframeOriginalSource: string;
+
+    /**
+     * The URL currently rendered by the iframe. Supplying it lets the host
+     * reject an origin mismatch and reset readiness for document navigations.
+     * It defaults to iframeOriginalSource for backwards compatibility.
+     */
+    iframeSource?: string;
+
+    /**
+     * Enable iframe-resizer only after the host has explicitly trusted the
+     * embedded app and its child integration.
+     */
+    enableResizer?: boolean;
 }
 
 export interface HostContextType {
@@ -61,51 +76,85 @@ export const useHost = () => {
 
 export const HostProvider: React.FC<HostProviderProps> = ({
     iframeOriginalSource,
+    iframeSource,
     children,
     onResize,
     onNavigate,
+    enableResizer = false,
 }) => {
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
     const hostRef = useRef<AppHost | null>(null);
     const { registerHost, unregisterHost } = useHostRegistry();
-    const registeredFn = useRef<((args: any) => any) | undefined>(undefined);
-    const [ready, setReady] = useState(false);
+    const currentSource = iframeSource ?? iframeOriginalSource;
+    const targetOrigin = normalizeMatchingAppOrigin(
+        currentSource,
+        iframeOriginalSource
+    );
+    const documentUrl = new URL(currentSource);
+    // A fragment navigation retains the same Window/document and readiness.
+    documentUrl.hash = "";
+    const documentSource = documentUrl.href;
+    const configuration = useMemo(
+        () => ({
+            targetOrigin,
+            documentSource,
+            onResize,
+            onNavigate,
+            enableResizer,
+        }),
+        [targetOrigin, documentSource, onResize, onNavigate, enableResizer]
+    );
+    const [activeHost, setActiveHost] = useState<{
+        configuration: typeof configuration;
+        host: AppHost;
+        send: (message: AppMessage) => void;
+    } | null>(null);
+    const [readyHost, setReadyHost] = useState<AppHost | null>(null);
 
-    useEffect(() => {
-        if (!iframeRef.current) return;
-        hostRef.current = new AppHost({
-            iframeOriginalSource,
-            iframe: iframeRef.current,
+    // Install and tear down the authenticated listener in the layout phase.
+    // React destroys the prior layout effect before descendants can emit
+    // messages for the newly committed source, closing the passive-effect
+    // window where a departing document could reach stale callbacks.
+    useLayoutEffect(() => {
+        const iframe = iframeRef.current;
+        if (!iframe) return;
+
+        const host = new AppHost({
+            iframeOriginalSource: configuration.targetOrigin,
+            iframe,
             onResize:
-                onResize ||
+                configuration.onResize ||
                 ((message) => console.log("AppHost resize:", message)),
             onNavigate:
-                onNavigate ||
+                configuration.onNavigate ||
                 ((message) => console.log("AppHost navigate:", message)),
             onReady: () => {
-                setReady(true);
+                if (hostRef.current === host) {
+                    setReadyHost(host);
+                }
             },
         });
-        // Register this host's send function.
-        if (hostRef.current) {
-            registeredFn.current = hostRef.current.send.bind(hostRef.current);
-            registerHost(registeredFn.current);
-        }
+        const send = host.send.bind(host);
+        hostRef.current = host;
+        registerHost(send);
+        setActiveHost({ configuration, host, send });
 
         return () => {
-            if (hostRef.current) {
-                registeredFn.current && unregisterHost(registeredFn.current);
-                hostRef.current.stop();
+            unregisterHost(send);
+            host.stop();
+            if (hostRef.current === host) {
                 hostRef.current = null;
             }
         };
-    }, [iframeRef.current]);
+    }, [configuration, registerHost, unregisterHost]);
 
-    const send = hostRef.current
-        ? (message: AppMessage) => {
-              hostRef.current?.send(message);
-          }
-        : undefined;
+    // A prop change invalidates the old host during render, before effects run.
+    // This prevents children from observing stale readiness or sending through
+    // the previous origin/callback configuration.
+    const currentHost =
+        activeHost?.configuration === configuration ? activeHost : undefined;
+    const send = currentHost?.send;
+    const ready = currentHost !== undefined && readyHost === currentHost.host;
 
     const context = useMemo(() => {
         return {
@@ -114,21 +163,32 @@ export const HostProvider: React.FC<HostProviderProps> = ({
         };
     }, [send, ready]);
 
+    const handleResizerResize = useCallback(
+        (evt: { height: number; width: number }) => {
+            onResize?.({
+                height: evt.height,
+                width: evt.width,
+                type: "size",
+            });
+        },
+        [onResize]
+    );
+
+    const iframe = children(iframeRef);
+
     return (
         <HostContext.Provider value={context}>
-            <IFrameResizer
-                license="GPLv3"
-                iframeRef={iframeRef}
-                onResize={(evt) => {
-                    onResize?.({
-                        height: evt.height,
-                        width: evt.width,
-                        type: "size",
-                    });
-                }}
-            >
-                {children(iframeRef)}
-            </IFrameResizer>
+            {enableResizer ? (
+                <IFrameResizer
+                    license="GPLv3"
+                    iframeRef={iframeRef}
+                    onResize={handleResizerResize}
+                >
+                    {iframe}
+                </IFrameResizer>
+            ) : (
+                iframe
+            )}
         </HostContext.Provider>
     );
 };

--- a/packages/social-media-app/app-sdk/src/IFrameResizer.tsx
+++ b/packages/social-media-app/app-sdk/src/IFrameResizer.tsx
@@ -30,7 +30,10 @@ const IFrameResizer: React.FC<IFrameResizerProps> = ({
                          `[iframe-resizer/react][${iframe?.id}] Resized to ${data.height}px`
                      ); */
                 },
-                onClosed: () => {
+                // The child "close" protocol is only a request. It can be
+                // spoofed by another same-origin window, so never let it
+                // remove React-owned DOM.
+                onBeforeClose: () => {
                     /*  console.warn(
                          `[iframe-resizer/react][${iframe?.id}] Close event ignored. To remove the iframe update your React component.`
                      ); */
@@ -44,7 +47,7 @@ const IFrameResizer: React.FC<IFrameResizerProps> = ({
                 instance.iFrameResizer.disconnect()
             );
         };
-    }, []);
+    }, [iframeRef, license, onResize]);
 
     return <>{children}</>;
 };

--- a/packages/social-media-app/app-sdk/src/__tests__/HostProvider.dom.test.ts
+++ b/packages/social-media-app/app-sdk/src/__tests__/HostProvider.dom.test.ts
@@ -1,0 +1,335 @@
+import React from "react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HostProvider, useHost } from "../HostProvider";
+import { HostRegistryProvider } from "../HostRegistryProvider";
+import { NavigationEvent } from "../client-host";
+
+const resizeMocks = vi.hoisted(() => ({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+}));
+
+vi.mock("@iframe-resizer/parent", () => ({
+    default: resizeMocks.connect,
+}));
+
+const HostStatus = () => {
+    const { ready } = useHost();
+    return React.createElement(
+        "output",
+        { "data-testid": "host-ready" },
+        String(ready)
+    );
+};
+
+const hostTree = (properties: {
+    origin: string;
+    source?: string;
+    onNavigate: (message: NavigationEvent) => void;
+    enableResizer?: boolean;
+}) =>
+    React.createElement(
+        HostRegistryProvider,
+        null,
+        React.createElement(HostProvider, {
+            iframeOriginalSource: properties.origin,
+            iframeSource: properties.source ?? properties.origin,
+            onNavigate: properties.onNavigate,
+            enableResizer: properties.enableResizer,
+            children: (iframeRef) =>
+                React.createElement(
+                    React.Fragment,
+                    null,
+                    React.createElement("iframe", {
+                        ref: iframeRef,
+                        title: "embedded-app",
+                    }),
+                    React.createElement(HostStatus)
+                ),
+        })
+    );
+
+const dispatchFromIframe = (
+    iframe: HTMLIFrameElement,
+    origin: string,
+    data: unknown
+) => {
+    if (!iframe.contentWindow) {
+        throw new Error("Test iframe has no contentWindow");
+    }
+    act(() => {
+        dispatchFromIframeNow(iframe, origin, data);
+    });
+};
+
+const dispatchFromIframeNow = (
+    iframe: HTMLIFrameElement,
+    origin: string,
+    data: unknown
+) => {
+    if (!iframe.contentWindow) {
+        throw new Error("Test iframe has no contentWindow");
+    }
+    globalThis.dispatchEvent(
+        new MessageEvent("message", {
+            data,
+            origin,
+            source: iframe.contentWindow,
+        })
+    );
+};
+
+const DepartingDocumentMessage = (properties: {
+    iframeRef: React.RefObject<HTMLIFrameElement | null>;
+    origin?: string;
+}) => {
+    React.useLayoutEffect(() => {
+        const iframe = properties.iframeRef.current;
+        if (!iframe || !properties.origin) {
+            return;
+        }
+        dispatchFromIframeNow(iframe, properties.origin, {
+            type: "navigate",
+            to: `${properties.origin}/departing-document`,
+        });
+    }, [properties.iframeRef, properties.origin]);
+    return null;
+};
+
+const sourceChangeRaceTree = (properties: {
+    origin: string;
+    source: string;
+    onNavigate: (message: NavigationEvent) => void;
+    departingOrigin?: string;
+}) =>
+    React.createElement(
+        HostRegistryProvider,
+        null,
+        React.createElement(HostProvider, {
+            iframeOriginalSource: properties.origin,
+            iframeSource: properties.source,
+            onNavigate: properties.onNavigate,
+            children: (iframeRef) =>
+                React.createElement(
+                    React.Fragment,
+                    null,
+                    React.createElement("iframe", {
+                        ref: iframeRef,
+                        title: "racing-embedded-app",
+                    }),
+                    React.createElement(DepartingDocumentMessage, {
+                        iframeRef,
+                        origin: properties.departingOrigin,
+                    })
+                ),
+        })
+    );
+
+beforeEach(() => {
+    resizeMocks.connect.mockReset();
+    resizeMocks.disconnect.mockReset();
+    resizeMocks.connect.mockReturnValue([
+        { iFrameResizer: { disconnect: resizeMocks.disconnect } },
+    ]);
+});
+
+afterEach(() => {
+    cleanup();
+});
+
+describe("HostProvider lifecycle", () => {
+    it("removes the departing source listener before descendant layout effects", () => {
+        const firstNavigate = vi.fn();
+        const secondNavigate = vi.fn();
+        const view = render(
+            sourceChangeRaceTree({
+                origin: "https://stream.peerbit.org",
+                source: "https://stream.peerbit.org/watch/1",
+                onNavigate: firstNavigate,
+            })
+        );
+
+        view.rerender(
+            sourceChangeRaceTree({
+                origin: "https://chat.peerbit.org",
+                source: "https://chat.peerbit.org/room/2",
+                onNavigate: secondNavigate,
+                departingOrigin: "https://stream.peerbit.org",
+            })
+        );
+
+        expect(firstNavigate).not.toHaveBeenCalled();
+        expect(secondNavigate).not.toHaveBeenCalled();
+    });
+
+    it("invalidates readiness and callbacks when the normalized origin changes", async () => {
+        const firstNavigate = vi.fn();
+        const secondNavigate = vi.fn();
+        const view = render(
+            hostTree({
+                origin: "https://stream.peerbit.org/initial",
+                onNavigate: firstNavigate,
+            })
+        );
+        const iframe = screen.getByTitle("embedded-app") as HTMLIFrameElement;
+
+        dispatchFromIframe(iframe, "https://stream.peerbit.org", {
+            type: "ready",
+        });
+        await waitFor(() =>
+            expect(screen.getByTestId("host-ready").textContent).toBe("true")
+        );
+
+        view.rerender(
+            hostTree({
+                origin: "https://chat.peerbit.org/next",
+                onNavigate: secondNavigate,
+            })
+        );
+        expect(screen.getByTestId("host-ready").textContent).toBe("false");
+
+        dispatchFromIframe(iframe, "https://stream.peerbit.org", {
+            type: "ready",
+        });
+        expect(screen.getByTestId("host-ready").textContent).toBe("false");
+
+        dispatchFromIframe(iframe, "https://chat.peerbit.org", {
+            type: "ready",
+        });
+        await waitFor(() =>
+            expect(screen.getByTestId("host-ready").textContent).toBe("true")
+        );
+
+        dispatchFromIframe(iframe, "https://chat.peerbit.org", {
+            type: "navigate",
+            to: "https://chat.peerbit.org/room/2",
+        });
+        expect(firstNavigate).not.toHaveBeenCalled();
+        expect(secondNavigate).toHaveBeenCalledOnce();
+    });
+
+    it("keeps the active host for raw URLs with the same normalized origin", async () => {
+        const onNavigate = vi.fn();
+        const view = render(
+            hostTree({
+                origin: "https://STREAM.peerbit.org:443/first",
+                source: "https://stream.peerbit.org/loaded",
+                onNavigate,
+            })
+        );
+        const iframe = screen.getByTitle("embedded-app") as HTMLIFrameElement;
+
+        dispatchFromIframe(iframe, "https://stream.peerbit.org", {
+            type: "ready",
+        });
+        await waitFor(() =>
+            expect(screen.getByTestId("host-ready").textContent).toBe("true")
+        );
+
+        view.rerender(
+            hostTree({
+                origin: "https://stream.peerbit.org/second",
+                source: "https://stream.peerbit.org/loaded",
+                onNavigate,
+            })
+        );
+        expect(screen.getByTestId("host-ready").textContent).toBe("true");
+    });
+
+    it("rebinds changed callbacks and resets readiness on the same origin", async () => {
+        const firstNavigate = vi.fn();
+        const secondNavigate = vi.fn();
+        const view = render(
+            hostTree({
+                origin: "https://stream.peerbit.org",
+                source: "https://stream.peerbit.org/loaded",
+                onNavigate: firstNavigate,
+            })
+        );
+        const iframe = screen.getByTitle("embedded-app") as HTMLIFrameElement;
+
+        dispatchFromIframe(iframe, "https://stream.peerbit.org", {
+            type: "ready",
+        });
+        await waitFor(() =>
+            expect(screen.getByTestId("host-ready").textContent).toBe("true")
+        );
+
+        view.rerender(
+            hostTree({
+                origin: "https://stream.peerbit.org/next",
+                source: "https://stream.peerbit.org/loaded",
+                onNavigate: secondNavigate,
+            })
+        );
+        expect(screen.getByTestId("host-ready").textContent).toBe("false");
+
+        dispatchFromIframe(iframe, "https://stream.peerbit.org", {
+            type: "ready",
+        });
+        dispatchFromIframe(iframe, "https://stream.peerbit.org", {
+            type: "navigate",
+            to: "https://stream.peerbit.org/watch/2",
+        });
+        expect(firstNavigate).not.toHaveBeenCalled();
+        expect(secondNavigate).toHaveBeenCalledOnce();
+    });
+
+    it("resets readiness when the rendered document URL changes", async () => {
+        const onNavigate = vi.fn();
+        const view = render(
+            hostTree({
+                origin: "https://stream.peerbit.org",
+                source: "https://stream.peerbit.org/watch/1",
+                onNavigate,
+            })
+        );
+        const iframe = screen.getByTitle("embedded-app") as HTMLIFrameElement;
+
+        dispatchFromIframe(iframe, "https://stream.peerbit.org", {
+            type: "ready",
+        });
+        await waitFor(() =>
+            expect(screen.getByTestId("host-ready").textContent).toBe("true")
+        );
+
+        view.rerender(
+            hostTree({
+                origin: "https://stream.peerbit.org",
+                source: "https://stream.peerbit.org/watch/2",
+                onNavigate,
+            })
+        );
+        expect(screen.getByTestId("host-ready").textContent).toBe("false");
+
+        dispatchFromIframe(iframe, "https://stream.peerbit.org", {
+            type: "ready",
+        });
+        await waitFor(() =>
+            expect(screen.getByTestId("host-ready").textContent).toBe("true")
+        );
+    });
+
+    it("does not start iframe-resizer unless explicitly enabled", async () => {
+        const disabled = render(
+            hostTree({
+                origin: "https://arbitrary.example",
+                onNavigate: vi.fn(),
+            })
+        );
+        expect(resizeMocks.connect).not.toHaveBeenCalled();
+        disabled.unmount();
+
+        const enabled = render(
+            hostTree({
+                origin: "https://stream.peerbit.org",
+                onNavigate: vi.fn(),
+                enableResizer: true,
+            })
+        );
+        await waitFor(() => expect(resizeMocks.connect).toHaveBeenCalledOnce());
+        enabled.unmount();
+        expect(resizeMocks.disconnect).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/social-media-app/app-sdk/src/__tests__/IFrameResizer.protocol.dom.test.ts
+++ b/packages/social-media-app/app-sdk/src/__tests__/IFrameResizer.protocol.dom.test.ts
@@ -1,0 +1,78 @@
+import React from "react";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import IFrameResizer from "../IFrameResizer";
+
+afterEach(() => {
+    cleanup();
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+});
+
+describe("iframe-resizer close protocol", () => {
+    it("never lets child close messages remove React-owned frames", async () => {
+        const iframeRef = React.createRef<HTMLIFrameElement>();
+        render(
+            React.createElement(
+                IFrameResizer,
+                {
+                    license: "GPLv3",
+                    iframeRef,
+                    onResize: vi.fn(),
+                },
+                React.createElement("iframe", {
+                    ref: iframeRef,
+                    src: `${window.location.origin}/app`,
+                    srcDoc: "<!doctype html><title>owned app</title>",
+                    title: "resized-app",
+                })
+            )
+        );
+
+        const iframe = iframeRef.current;
+        const embeddedWindow = iframe?.contentWindow;
+        if (!iframe || !embeddedWindow) {
+            throw new Error("Test iframe has no contentWindow");
+        }
+        // Happy DOM models srcdoc as an opaque origin. Avoid its asynchronous
+        // target-origin error; the parent protocol listener below is real.
+        vi.spyOn(embeddedWindow, "postMessage").mockImplementation(() => {});
+
+        await waitFor(() => {
+            expect(
+                (
+                    iframeRef.current as
+                        | (HTMLIFrameElement & { iframeResizer?: unknown })
+                        | null
+                )?.iframeResizer
+            ).toBeDefined();
+        });
+
+        const sameOriginWindow = document.createElement("iframe");
+        sameOriginWindow.src = `${window.location.origin}/other-app`;
+        sameOriginWindow.srcdoc =
+            "<!doctype html><title>other owned app</title>";
+        document.body.appendChild(sameOriginWindow);
+        const distinctWindow = sameOriginWindow.contentWindow;
+        if (!distinctWindow) {
+            throw new Error("Second test iframe has no contentWindow");
+        }
+        expect(Object.is(distinctWindow, embeddedWindow)).toBe(false);
+
+        const requestClose = (source: Window) => {
+            window.dispatchEvent(
+                new MessageEvent("message", {
+                    data: `[iFrameSizer]${iframe.id}:0:0:close`,
+                    origin: window.location.origin,
+                    source,
+                })
+            );
+            expect(document.body.contains(iframe)).toBe(true);
+        };
+
+        // Exercise the actual v5 wire protocol from both the embedded window
+        // and a different window that shares its allowed origin.
+        requestClose(embeddedWindow);
+        requestClose(distinctWindow);
+    });
+});

--- a/packages/social-media-app/app-sdk/src/__tests__/client-host.dom.test.ts
+++ b/packages/social-media-app/app-sdk/src/__tests__/client-host.dom.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+    AppClient,
+    AppHost,
+    isAppMessage,
+    isSafeNavigationTarget,
+    normalizeAppOrigin,
+    normalizeMatchingAppOrigin,
+    resolveParentOrigin,
+    resolveIframeCapabilities,
+} from "../client-host";
+
+vi.mock("@iframe-resizer/child", () => ({}));
+
+const dispatchMessage = (properties: {
+    data: unknown;
+    origin: string;
+    source: MessageEventSource;
+}) => {
+    globalThis.dispatchEvent(
+        new MessageEvent("message", {
+            data: properties.data,
+            origin: properties.origin,
+            source: properties.source,
+        })
+    );
+};
+
+const createIframe = () => {
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    if (!iframe.contentWindow) {
+        throw new Error("Test iframe has no contentWindow");
+    }
+    return iframe;
+};
+
+afterEach(() => {
+    document.documentElement.classList.remove("dark");
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+});
+
+describe("app message schema", () => {
+    it("accepts only the closed runtime schema", () => {
+        expect(isAppMessage({ type: "ready" })).toBe(true);
+        expect(isAppMessage({ type: "theme", theme: "dark" })).toBe(true);
+        expect(
+            isAppMessage({ type: "navigate", to: "https://app.example/a" })
+        ).toBe(true);
+
+        expect(isAppMessage(null)).toBe(false);
+        expect(isAppMessage({ type: "ready", forged: true })).toBe(false);
+        expect(isAppMessage({ type: "theme", theme: "sepia" })).toBe(false);
+        expect(
+            isAppMessage({ type: "size", width: Infinity, height: 10 })
+        ).toBe(false);
+    });
+});
+
+describe("app origin and navigation policy", () => {
+    it("normalizes concrete HTTPS and local-development origins", () => {
+        expect(normalizeAppOrigin("https://app.example/path?q=1")).toBe(
+            "https://app.example"
+        );
+        expect(normalizeAppOrigin("http://stream.test:5801/path")).toBe(
+            "http://stream.test:5801"
+        );
+        expect(() => normalizeAppOrigin("*")).toThrow();
+        expect(() => normalizeAppOrigin("http://app.example")).toThrow();
+        expect(() =>
+            normalizeAppOrigin("https://user:password@app.example")
+        ).toThrow();
+        expect(() => normalizeAppOrigin("data:text/plain,hello")).toThrow();
+    });
+
+    it("derives the parent origin without a wildcard fallback", () => {
+        expect(
+            resolveParentOrigin(undefined, "https://giga.peerbit.org/post/1")
+        ).toBe("https://giga.peerbit.org");
+        expect(resolveParentOrigin(undefined, "")).toBeUndefined();
+        expect(
+            resolveParentOrigin(undefined, "http://untrusted.example/post/1")
+        ).toBeUndefined();
+        expect(() => resolveParentOrigin("*", "")).toThrow();
+    });
+
+    it("rejects forged original-source metadata for a different loaded origin", () => {
+        expect(() =>
+            normalizeMatchingAppOrigin(
+                "https://attacker.example/phish",
+                "https://stream.peerbit.org"
+            )
+        ).toThrow("must remain on its original app origin");
+        expect(() =>
+            normalizeMatchingAppOrigin(
+                "https://stream.peerbit.org",
+                "https://attacker.example/forged-original"
+            )
+        ).toThrow("must remain on its original app origin");
+    });
+
+    it("compares normalized origins instead of raw iframe URLs", () => {
+        expect(
+            normalizeMatchingAppOrigin(
+                "https://STREAM.peerbit.org:443/watch?id=1",
+                "https://stream.peerbit.org/"
+            )
+        ).toBe("https://stream.peerbit.org");
+    });
+
+    it("defaults arbitrary frames to no privileged capabilities", () => {
+        expect(
+            resolveIframeCapabilities({
+                trusted: false,
+                permissions: ["camera", "microphone", "fullscreen"],
+                resizerRequested: true,
+                resizerAllowed: true,
+            })
+        ).toEqual({ permissions: [], resizer: false });
+
+        // Registry trust plus persisted metadata is not enough. The curated
+        // app must explicitly opt in after proving it bundles the child.
+        expect(
+            resolveIframeCapabilities({
+                trusted: true,
+                permissions: ["fullscreen"],
+                resizerRequested: true,
+            })
+        ).toEqual({ permissions: ["fullscreen"], resizer: false });
+
+        expect(
+            resolveIframeCapabilities({
+                trusted: true,
+                permissions: ["fullscreen"],
+                resizerRequested: false,
+                resizerAllowed: true,
+            })
+        ).toEqual({ permissions: ["fullscreen"], resizer: false });
+
+        expect(
+            resolveIframeCapabilities({
+                trusted: true,
+                permissions: ["fullscreen"],
+                resizerRequested: true,
+                resizerAllowed: true,
+            })
+        ).toEqual({ permissions: ["fullscreen"], resizer: true });
+    });
+
+    it("allows only absolute, credential-free, same-origin navigation", () => {
+        const origin = "https://stream.peerbit.org";
+        expect(
+            isSafeNavigationTarget(
+                "https://stream.peerbit.org/watch?id=1#live",
+                origin
+            )
+        ).toBe(true);
+        expect(isSafeNavigationTarget("/watch", origin)).toBe(false);
+        expect(
+            isSafeNavigationTarget("https://attacker.example/watch", origin)
+        ).toBe(false);
+        expect(
+            isSafeNavigationTarget("http://stream.peerbit.org/watch", origin)
+        ).toBe(false);
+        expect(
+            isSafeNavigationTarget(
+                "https://user:password@stream.peerbit.org/watch",
+                origin
+            )
+        ).toBe(false);
+        expect(isSafeNavigationTarget("javascript:alert(1)", origin)).toBe(
+            false
+        );
+    });
+});
+
+describe("AppHost message trust", () => {
+    const setupHost = () => {
+        const iframe = createIframe();
+        const onNavigate = vi.fn();
+        const onReady = vi.fn();
+        const host = new AppHost({
+            iframeOriginalSource: "https://stream.peerbit.org",
+            iframe,
+            onResize: vi.fn(),
+            onNavigate,
+            onReady,
+        });
+        return { host, iframe, onNavigate, onReady };
+    };
+
+    it("rejects a valid message from the wrong origin", () => {
+        const { host, iframe, onReady } = setupHost();
+        dispatchMessage({
+            data: { type: "ready" },
+            origin: "https://attacker.example",
+            source: iframe.contentWindow!,
+        });
+        expect(onReady).not.toHaveBeenCalled();
+        host.stop();
+    });
+
+    it("rejects a valid message from the wrong window", () => {
+        const { host, onReady } = setupHost();
+        const attackerIframe = createIframe();
+        dispatchMessage({
+            data: { type: "ready" },
+            origin: "https://stream.peerbit.org",
+            source: attackerIframe.contentWindow!,
+        });
+        expect(onReady).not.toHaveBeenCalled();
+        host.stop();
+    });
+
+    it("accepts the expected iframe only and rejects malformed data", () => {
+        const { host, iframe, onReady } = setupHost();
+        dispatchMessage({
+            data: { type: "ready", forged: true },
+            origin: "https://stream.peerbit.org",
+            source: iframe.contentWindow!,
+        });
+        expect(onReady).not.toHaveBeenCalled();
+
+        dispatchMessage({
+            data: { type: "ready" },
+            origin: "https://stream.peerbit.org",
+            source: iframe.contentWindow!,
+        });
+        expect(onReady).toHaveBeenCalledOnce();
+        host.stop();
+    });
+
+    it("forwards only safe same-origin navigation", () => {
+        const { host, iframe, onNavigate } = setupHost();
+        const sendNavigation = (to: string) =>
+            dispatchMessage({
+                data: { type: "navigate", to },
+                origin: "https://stream.peerbit.org",
+                source: iframe.contentWindow!,
+            });
+
+        sendNavigation("https://attacker.example/phish");
+        sendNavigation("javascript:alert(1)");
+        sendNavigation("http://stream.peerbit.org/downgrade");
+        expect(onNavigate).not.toHaveBeenCalled();
+
+        sendNavigation("https://stream.peerbit.org/watch/abc#live");
+        expect(onNavigate).toHaveBeenCalledOnce();
+        expect(onNavigate).toHaveBeenCalledWith({
+            type: "navigate",
+            to: "https://stream.peerbit.org/watch/abc#live",
+        });
+        host.stop();
+    });
+});
+
+describe("AppClient message trust", () => {
+    it("applies parent events only from the expected source and origin", () => {
+        vi.spyOn(globalThis.parent, "postMessage").mockImplementation(
+            () => undefined
+        );
+        const onTheme = vi.fn();
+        const client = new AppClient({
+            targetOrigin: "https://giga.peerbit.org",
+            onResize: vi.fn(),
+            onTheme,
+            useThemeClasses: true,
+        });
+        const attackerIframe = createIframe();
+
+        dispatchMessage({
+            data: { type: "theme", theme: "dark" },
+            origin: "https://attacker.example",
+            source: globalThis.parent,
+        });
+        dispatchMessage({
+            data: { type: "theme", theme: "dark" },
+            origin: "https://giga.peerbit.org",
+            source: attackerIframe.contentWindow!,
+        });
+        expect(onTheme).not.toHaveBeenCalled();
+        expect(document.documentElement.classList.contains("dark")).toBe(false);
+
+        dispatchMessage({
+            data: { type: "theme", theme: "dark" },
+            origin: "https://giga.peerbit.org",
+            source: globalThis.parent,
+        });
+        expect(onTheme).toHaveBeenCalledOnce();
+        expect(document.documentElement.classList.contains("dark")).toBe(true);
+        client.stop();
+    });
+});

--- a/packages/social-media-app/app-sdk/src/client-host.ts
+++ b/packages/social-media-app/app-sdk/src/client-host.ts
@@ -46,25 +46,229 @@ export type AppMessage =
     | ThemeEvent
     | ReadyEvent;
 
+const MAX_NAVIGATION_URL_LENGTH = 8_192;
+const MAX_FRAME_DIMENSION = 100_000;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === "object" && value !== null && !Array.isArray(value);
+
+const hasExactKeys = (
+    value: Record<string, unknown>,
+    keys: readonly string[]
+) => {
+    const actualKeys = Object.keys(value);
+    return (
+        actualKeys.length === keys.length &&
+        keys.every((key) => Object.prototype.hasOwnProperty.call(value, key))
+    );
+};
+
+/**
+ * postMessage data is untrusted even when TypeScript knows the sender's type.
+ * Keep the wire format deliberately small and reject unknown properties.
+ */
+export const isAppMessage = (value: unknown): value is AppMessage => {
+    if (!isRecord(value) || typeof value.type !== "string") {
+        return false;
+    }
+
+    switch (value.type) {
+        case "size":
+            return (
+                hasExactKeys(value, ["type", "width", "height"]) &&
+                typeof value.width === "number" &&
+                Number.isFinite(value.width) &&
+                value.width >= 0 &&
+                value.width <= MAX_FRAME_DIMENSION &&
+                typeof value.height === "number" &&
+                Number.isFinite(value.height) &&
+                value.height >= 0 &&
+                value.height <= MAX_FRAME_DIMENSION
+            );
+        case "navigate":
+            return (
+                hasExactKeys(value, ["type", "to"]) &&
+                typeof value.to === "string" &&
+                value.to.length > 0 &&
+                value.to.length <= MAX_NAVIGATION_URL_LENGTH
+            );
+        case "ready":
+            return hasExactKeys(value, ["type"]);
+        case "loading":
+            return (
+                hasExactKeys(value, ["type", "state"]) &&
+                (value.state === "loading" || value.state === "loaded")
+            );
+        case "fullscreen":
+            return (
+                hasExactKeys(value, ["type", "state"]) &&
+                (value.state === "enter" || value.state === "exit")
+            );
+        case "preview":
+            return (
+                hasExactKeys(value, ["type", "state"]) &&
+                (value.state === "thumbnail" || value.state === "full")
+            );
+        case "theme":
+            return (
+                hasExactKeys(value, ["type", "theme"]) &&
+                (value.theme === "light" || value.theme === "dark")
+            );
+        default:
+            return false;
+    }
+};
+
+const isLocalDevelopmentHostname = (hostname: string) =>
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "0.0.0.0" ||
+    hostname === "::1" ||
+    hostname === "[::1]" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".test");
+
+/** Normalize an app URL to the only origin that may exchange messages. */
+export const normalizeAppOrigin = (value: string): string => {
+    if (value.trim() === "" || value === "*" || value === "null") {
+        throw new TypeError("A concrete app origin is required");
+    }
+
+    const url = new URL(value);
+    const secure =
+        url.protocol === "https:" ||
+        (url.protocol === "http:" && isLocalDevelopmentHostname(url.hostname));
+    if (
+        !secure ||
+        url.origin === "null" ||
+        url.username !== "" ||
+        url.password !== ""
+    ) {
+        throw new TypeError(
+            "App messaging requires a credential-free HTTPS origin (HTTP is limited to local development origins)"
+        );
+    }
+    return url.origin;
+};
+
+/**
+ * Resolve the single origin used by both the rendered iframe and its
+ * authenticated message channel. Persisted iframe metadata is untrusted: an
+ * attacker must not be able to pair a privileged original source with a
+ * different URL that the browser actually loads.
+ */
+export const normalizeMatchingAppOrigin = (
+    currentSource: string,
+    originalSource: string
+): string => {
+    const currentOrigin = normalizeAppOrigin(currentSource);
+    const originalOrigin = normalizeAppOrigin(originalSource);
+
+    if (currentOrigin !== originalOrigin) {
+        throw new TypeError(
+            "The iframe source must remain on its original app origin"
+        );
+    }
+
+    return originalOrigin;
+};
+
+export interface IframeCapabilities {
+    permissions: readonly string[];
+    resizer: boolean;
+}
+
+/**
+ * Capabilities are granted only to an app selected from the host's curated
+ * registry. Arbitrary frames remain usable, but receive neither Permissions
+ * Policy grants nor the iframe-resizer control channel.
+ */
+export const resolveIframeCapabilities = (properties: {
+    trusted: boolean;
+    permissions?: readonly string[];
+    resizerRequested?: boolean;
+    resizerAllowed?: boolean;
+}): IframeCapabilities => ({
+    permissions: properties.trusted ? (properties.permissions ?? []) : [],
+    resizer:
+        properties.trusted &&
+        properties.resizerAllowed === true &&
+        properties.resizerRequested === true,
+});
+
+export const resolveParentOrigin = (
+    explicitOrigin: string | undefined,
+    referrer: string
+): string | undefined => {
+    const explicit = explicitOrigin?.trim();
+    if (explicit) {
+        return normalizeAppOrigin(explicit);
+    }
+
+    if (!referrer.trim()) {
+        return undefined;
+    }
+    try {
+        return normalizeAppOrigin(referrer);
+    } catch {
+        // An absent/opaque/insecure referrer cannot establish a trust boundary.
+        return undefined;
+    }
+};
+
+/**
+ * Child-driven navigation is restricted to an absolute URL on the app's
+ * original origin. This prevents a trusted iframe from turning a persisted
+ * Giga frame into a javascript:, credential-bearing, or cross-origin URL.
+ */
+export const isSafeNavigationTarget = (
+    value: string,
+    expectedOrigin: string
+): boolean => {
+    try {
+        const destination = new URL(value);
+        return (
+            normalizeAppOrigin(destination.href) === expectedOrigin &&
+            destination.username === "" &&
+            destination.password === ""
+        );
+    } catch {
+        return false;
+    }
+};
+
 export class AppClient {
     private listener: (message: MessageEvent) => void;
+    private parentWindow: Window;
+    private targetOrigin: string;
     constructor(
         readonly properties: {
             targetOrigin: string;
             onResize: (event: MessageEvent<ResizeMessage>) => void;
             onTheme?: (event: MessageEvent<ThemeEvent>) => void;
+            onPreview?: (event: MessageEvent<PreviewEvent>) => void;
             useThemeClasses?: boolean;
         }
     ) {
+        this.targetOrigin = normalizeAppOrigin(properties.targetOrigin);
+        this.parentWindow = globalThis.parent;
         import("@iframe-resizer/child");
         this.listener = (message) => {
-            const data = message.data as AppMessage;
+            if (
+                message.source !== this.parentWindow ||
+                message.origin !== this.targetOrigin ||
+                !isAppMessage(message.data)
+            ) {
+                return;
+            }
+
+            const data = message.data;
             // For now, we only handle size events (and others can be handled by custom listeners).
             if (data.type === "size") {
-                properties.onResize(message);
+                properties.onResize(message as MessageEvent<ResizeMessage>);
             }
             if (data.type === "theme") {
-                properties.onTheme?.(message);
+                properties.onTheme?.(message as MessageEvent<ThemeEvent>);
                 if (properties.useThemeClasses) {
                     if (data.theme === "dark") {
                         document.documentElement.classList.add("dark");
@@ -73,6 +277,9 @@ export class AppClient {
                     }
                 }
             }
+            if (data.type === "preview") {
+                properties.onPreview?.(message as MessageEvent<PreviewEvent>);
+            }
         };
         globalThis.addEventListener("message", this.listener);
 
@@ -80,10 +287,10 @@ export class AppClient {
     }
 
     send(message: AppMessage) {
-        (globalThis.top || globalThis).postMessage(
-            message,
-            this.properties.targetOrigin
-        );
+        if (!isAppMessage(message)) {
+            throw new TypeError("Invalid app message");
+        }
+        this.parentWindow.postMessage(message, this.targetOrigin);
     }
 
     stop() {
@@ -105,14 +312,26 @@ export class AppHost {
             // Optionally, you can add onFullscreen or onPreview handlers here as well.
         }
     ) {
-        this.targetOrigin = new URL(properties.iframeOriginalSource).origin;
+        this.targetOrigin = normalizeAppOrigin(properties.iframeOriginalSource);
 
         this.listener = (message) => {
-            const data = message.data as AppMessage;
+            if (
+                !properties.iframe.contentWindow ||
+                message.source !== properties.iframe.contentWindow ||
+                message.origin !== this.targetOrigin ||
+                !isAppMessage(message.data)
+            ) {
+                return;
+            }
+
+            const data = message.data;
             /* if (data.type === "size") { // Handled by the iframeresizer lib
                 properties.onResize(message.data);
-            } else  */ if (data.type === "navigate") {
-                properties.onNavigate(message.data);
+            } else  */ if (
+                data.type === "navigate" &&
+                isSafeNavigationTarget(data.to, this.targetOrigin)
+            ) {
+                properties.onNavigate(data);
             } else if (data.type === "ready") {
                 properties.onReady();
             }
@@ -123,6 +342,9 @@ export class AppHost {
     }
 
     send(message: AppMessage) {
+        if (!isAppMessage(message)) {
+            throw new TypeError("Invalid app message");
+        }
         if (!this.properties.iframe.contentWindow) {
             throw new Error("Missing content window");
         }

--- a/packages/social-media-app/app-sdk/src/index.ts
+++ b/packages/social-media-app/app-sdk/src/index.ts
@@ -1,3 +1,8 @@
 export * from "./AppProvider";
 export * from "./HostProvider";
 export * from "./HostRegistryProvider";
+export {
+    normalizeMatchingAppOrigin,
+    resolveIframeCapabilities,
+} from "./client-host";
+export type { NavigationEvent } from "./client-host";

--- a/packages/social-media-app/app-sdk/tsconfig.json
+++ b/packages/social-media-app/app-sdk/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../../tsconfig.json",
     "include": ["src"],
+    "exclude": ["src/__tests__"],
     "compilerOptions": {
         "noEmit": false,
         "outDir": "lib/esm",

--- a/packages/social-media-app/app-service/src/__tests__/apps.test.ts
+++ b/packages/social-media-app/app-service/src/__tests__/apps.test.ts
@@ -79,6 +79,18 @@ describe("index", () => {
         );
     });
 
+    it("normalizes a Kick channel URL without producing a double slash", async () => {
+        const { search } = getApps({
+            host: "www.host.com",
+            mode: "development",
+        });
+        const response = await search("https://www.kick.com/maki95");
+        expect(response).to.have.length(1);
+        expect(response[0].url).to.eq(
+            "https://player.kick.com/maki95?autoplay=true"
+        );
+    });
+
     it("figjam", async () => {
         const { search } = getApps({
             host: "www.host.com",
@@ -89,7 +101,7 @@ describe("index", () => {
         );
         expect(response).to.have.length(1);
         expect(response[0].url).to.eq(
-            "https://embed.figma.com/board/xyz123/jamjam?node-id=0-1&embed-host=share"
+            "https://embed.figma.com/board/xyz123?node-id=0-1&embed-host=share"
         );
     });
 
@@ -119,6 +131,141 @@ describe("index", () => {
             isReady: true,
         });
         expect((await search("chess"))[0].url).to.eq(chess);
+    });
+
+    describe("strict curated iframe URL resolution", () => {
+        const host = "www.host.com";
+        const apps = getApps({ host, mode: "development" });
+
+        const resolvesSearchResult = async (
+            query: string,
+            expectedUrl: string,
+            expectedPermissions: readonly string[]
+        ) => {
+            const result = await apps.search(query);
+            expect(result).to.have.length(1);
+            expect(result[0].url).to.eq(expectedUrl);
+            expect(
+                apps.resolveCuratedWebApp(result[0].url)?.iframePermissions
+            ).to.deep.eq(expectedPermissions);
+        };
+
+        it("resolves transformed Twitch embeds with only playback capabilities", async () => {
+            await resolvesSearchResult(
+                "https://www.twitch.tv/xqc",
+                "https://player.twitch.tv/?channel=xqc&parent=www.host.com",
+                ["autoplay", "fullscreen", "picture-in-picture"]
+            );
+        });
+
+        it("resolves transformed Kick embeds with only playback capabilities", async () => {
+            await resolvesSearchResult(
+                "https://www.kick.com/maki95",
+                "https://player.kick.com/maki95?autoplay=true",
+                ["autoplay", "fullscreen", "picture-in-picture"]
+            );
+        });
+
+        it("resolves transformed FigJam embeds with board capabilities", async () => {
+            await resolvesSearchResult(
+                "https://www.figma.com/board/xyz123/jamjam?node-id=0-1&p=f",
+                "https://embed.figma.com/board/xyz123?node-id=0-1&embed-host=share",
+                ["clipboard-write", "fullscreen"]
+            );
+        });
+
+        it("resolves transformed YouTube embeds and drops unrelated watch parameters", async () => {
+            await resolvesSearchResult(
+                "https://www.youtube.com/watch?v=eBDRsSgeloE&list=attacker",
+                "https://www.youtube.com/embed/eBDRsSgeloE",
+                [
+                    "autoplay",
+                    "encrypted-media",
+                    "fullscreen",
+                    "picture-in-picture",
+                ]
+            );
+        });
+
+        it("preserves the existing exact Stream and Chess policies", () => {
+            expect(
+                apps.resolveCuratedWebApp("https://stream.test:5801")
+                    ?.iframePermissions
+            ).to.deep.eq([
+                "autoplay",
+                "camera",
+                "clipboard-write",
+                "display-capture",
+                "fullscreen",
+                "microphone",
+            ]);
+            expect(
+                apps.resolveCuratedWebApp("https://chess.test:5806")
+                    ?.iframePermissions
+            ).to.deep.eq([]);
+            expect(
+                apps.resolveCuratedWebApp("https://stream.test:5801")
+                    ?.iframeResizer
+            ).to.eq(true);
+            expect(
+                apps.resolveCuratedWebApp("https://chess.test:5806")
+                    ?.iframeResizer
+            ).to.eq(true);
+            expect(apps.resolveCuratedWebApp("https://stream.test:5802")).to.eq(
+                undefined
+            );
+            expect(
+                apps.resolveCuratedWebApp("https://stream.test:5801/watch")
+            ).to.eq(undefined);
+        });
+
+        it("rejects attacker origins, credentials, non-HTTPS URLs, and unexpected ports", () => {
+            for (const url of [
+                "https://player.kick.com.attacker.example/maki95?autoplay=true",
+                "https://player.kick.com@attacker.example/maki95?autoplay=true",
+                "https://user:pass@player.kick.com/maki95?autoplay=true",
+                "http://player.kick.com/maki95?autoplay=true",
+                "https://player.kick.com:444/maki95?autoplay=true",
+                "https://www.youtube.com.attacker.example/embed/eBDRsSgeloE",
+                "https://embed.figma.com.attacker.example/board/xyz123/jamjam?embed-host=share",
+                "https://player.twitch.tv.attacker.example/?channel=xqc&parent=www.host.com",
+            ]) {
+                expect(apps.resolveCuratedWebApp(url), url).to.eq(undefined);
+            }
+        });
+
+        it("rejects Kick host, path, query, and fragment abuse", () => {
+            for (const url of [
+                "https://kick.com/maki95?autoplay=true",
+                "https://player.kick.com/?autoplay=true",
+                "https://player.kick.com/maki95/second?autoplay=true",
+                "https://player.kick.com/maki95%2Fsecond?autoplay=true",
+                "https://player.kick.com/maki95?autoplay=false",
+                "https://player.kick.com/maki95?autoplay=true&extra=1",
+                "https://player.kick.com/maki95?autoplay=true#other",
+            ]) {
+                expect(apps.resolveCuratedWebApp(url), url).to.eq(undefined);
+            }
+        });
+
+        it("rejects malformed Twitch, YouTube, and FigJam embed shapes", () => {
+            for (const url of [
+                "https://player.twitch.tv/watch?channel=xqc&parent=www.host.com",
+                "https://player.twitch.tv/?channel=xqc&parent=wrong.host.com",
+                "https://player.twitch.tv/?channel=xqc&parent=www.host.com&extra=1",
+                "https://www.youtube.com/watch?v=eBDRsSgeloE",
+                "https://www.youtube.com/embed/eBDRsSgeloE/second",
+                "https://www.youtube.com/embed/eBDRsSgeloE?autoplay=1",
+                "https://embed.figma.com/file/xyz123/jamjam?embed-host=share",
+                "https://embed.figma.com/board/xyz123/jamjam?embed-host=share",
+                "https://embed.figma.com/board/xyz123/slug%252F..%252Fsecret?embed-host=share",
+                "https://embed.figma.com/board/xyz123/slug%25252F..%25252Fsecret?embed-host=share",
+                "https://embed.figma.com/board/xyz123?embed-host=share&extra=1",
+                "https://embed.figma.com/board/xyz123%2Fsecond?embed-host=share",
+            ]) {
+                expect(apps.resolveCuratedWebApp(url), url).to.eq(undefined);
+            }
+        });
     });
 
     describe("getStatus implementations", () => {
@@ -151,6 +298,12 @@ describe("index", () => {
                 host
             );
             expect(status.isReady).to.be.true;
+            expect(twitchApp.iframePermissions).to.deep.eq([
+                "autoplay",
+                "fullscreen",
+                "picture-in-picture",
+            ]);
+            expect(twitchApp.iframeResizer).not.to.eq(true);
         });
         it("Twitch: invalid getStatus (missing parent)", () => {
             if (!twitchApp) throw new Error("Twitch app not found");
@@ -171,6 +324,7 @@ describe("index", () => {
                 host
             );
             expect(status.isReady).to.be.true;
+            expect(kickApp.iframeResizer).not.to.eq(true);
         });
         it("Kick: invalid getStatus (no username provided)", () => {
             if (!kickApp) throw new Error("Kick app not found");
@@ -180,7 +334,7 @@ describe("index", () => {
             );
             expect(status.isReady).to.be.false;
             expect("info" in status && status.info).to.contain(
-                "No username provided"
+                "Invalid Kick embed URL"
             );
         });
 
@@ -189,10 +343,15 @@ describe("index", () => {
         it("FigJam: valid getStatus", () => {
             if (!figjamApp) throw new Error("FigJam app not found");
             const status = figjamApp.getStatus(
-                "https://embed.figma.com/board/xyz123/jamjam?node-id=0-1&embed-host=share",
+                "https://embed.figma.com/board/xyz123?node-id=0-1&embed-host=share",
                 host
             );
             expect(status.isReady).to.be.true;
+            expect(figjamApp.iframePermissions).to.deep.eq([
+                "clipboard-write",
+                "fullscreen",
+            ]);
+            expect(figjamApp.iframeResizer).not.to.eq(true);
         });
         it("FigJam: invalid getStatus", () => {
             if (!figjamApp) throw new Error("FigJam app not found");
@@ -227,13 +386,13 @@ describe("index", () => {
             );
             expect(status.isReady).to.be.true;
         });
-        it("YouTube: valid getStatus for watch URL", () => {
+        it("YouTube: rejects an untransformed watch URL", () => {
             if (!youtubeApp) throw new Error("YouTube app not found");
             const status = youtubeApp.getStatus(
                 "https://www.youtube.com/watch?v=eBDRsSgeloE",
                 host
             );
-            expect(status.isReady).to.be.true;
+            expect(status.isReady).to.be.false;
         });
         it("YouTube: invalid getStatus with missing id", () => {
             if (!youtubeApp) throw new Error("YouTube app not found");
@@ -243,8 +402,18 @@ describe("index", () => {
             );
             expect(status.isReady).to.be.false;
             expect("info" in status && status.info).to.contain(
-                "Missing video id"
+                "Invalid YouTube video URL"
             );
+        });
+
+        it("YouTube: grants only playback capabilities", () => {
+            expect(youtubeApp.iframePermissions).to.deep.eq([
+                "autoplay",
+                "encrypted-media",
+                "fullscreen",
+                "picture-in-picture",
+            ]);
+            expect(youtubeApp.iframeResizer).not.to.eq(true);
         });
 
         // --- Generic Video Stream ---
@@ -255,6 +424,14 @@ describe("index", () => {
             const validUrl = "https://stream.test:5801";
             const status = videoApp.getStatus(validUrl, host);
             expect(status.isReady).to.be.true;
+            expect(videoApp.iframePermissions).to.deep.eq([
+                "autoplay",
+                "camera",
+                "clipboard-write",
+                "display-capture",
+                "fullscreen",
+                "microphone",
+            ]);
         });
         it("Generic Video: invalid getStatus", () => {
             if (!videoApp) throw new Error("Video app not found");
@@ -276,6 +453,7 @@ describe("index", () => {
             const validUrl = "https://chess.test:5806";
             const status = chessApp.getStatus(validUrl, host);
             expect(status.isReady).to.be.true;
+            expect(chessApp.iframePermissions).to.deep.eq([]);
         });
         it("Chess: invalid getStatus", () => {
             if (!chessApp) throw new Error("Chess app not found");

--- a/packages/social-media-app/app-service/src/apps.ts
+++ b/packages/social-media-app/app-service/src/apps.ts
@@ -59,6 +59,19 @@ export interface CuratedAppNative extends CuratedAppCommon {
 // Define a common interface for curated apps.
 export interface CuratedWebApp extends CuratedAppCommon {
     type: "web";
+    /** Permissions Policy features granted to this app's iframe. */
+    iframePermissions?: readonly CuratedWebAppPermission[];
+    /**
+     * Whether this first-party app is known to bundle the iframe-resizer child
+     * protocol. Persisted IFrameContent metadata is only a request; the host
+     * must also grant this capability from the curated registry.
+     */
+    iframeResizer?: boolean;
+    /**
+     * Match an iframe URL using this app's exact embed policy. Search matching
+     * is deliberately fuzzy for usability; capability matching must not be.
+     */
+    isTrustedIframeUrl?: (url: string, host: string) => boolean;
     //  transformer function to turn the raw query (and host) into a URL (and optional title)
     transformer?: (
         query: string,
@@ -69,6 +82,143 @@ export interface CuratedWebApp extends CuratedAppCommon {
         host: string
     ) => { isReady: true } | { isReady: false; info: string };
 }
+
+export type CuratedWebAppPermission =
+    | "autoplay"
+    | "camera"
+    | "clipboard-write"
+    | "display-capture"
+    | "encrypted-media"
+    | "fullscreen"
+    | "microphone"
+    | "picture-in-picture";
+
+const USERNAME_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+const YOUTUBE_VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+const parseThirdPartyEmbedUrl = (
+    value: string,
+    expectedHostname: string
+): URL | undefined => {
+    try {
+        const url = new URL(value);
+        if (
+            url.protocol !== "https:" ||
+            url.hostname !== expectedHostname ||
+            url.port !== "" ||
+            url.username !== "" ||
+            url.password !== ""
+        ) {
+            return undefined;
+        }
+        return url;
+    } catch {
+        return undefined;
+    }
+};
+
+const hasExactSearchEntries = (
+    url: URL,
+    expected: readonly (readonly [string, string])[]
+): boolean => {
+    const actual = [...url.searchParams.entries()];
+    return (
+        actual.length === expected.length &&
+        expected.every(
+            ([expectedKey, expectedValue]) =>
+                actual.filter(
+                    ([key, value]) =>
+                        key === expectedKey && value === expectedValue
+                ).length === 1
+        )
+    );
+};
+
+const isTrustedTwitchIframeUrl = (value: string, host: string): boolean => {
+    const url = parseThirdPartyEmbedUrl(value, "player.twitch.tv");
+    if (!url || url.pathname !== "/" || url.hash !== "") {
+        return false;
+    }
+    const channel = url.searchParams.get("channel");
+    return (
+        channel !== null &&
+        USERNAME_PATTERN.test(channel) &&
+        hasExactSearchEntries(url, [
+            ["channel", channel],
+            ["parent", host],
+        ])
+    );
+};
+
+const isTrustedKickIframeUrl = (value: string): boolean => {
+    const url = parseThirdPartyEmbedUrl(value, "player.kick.com");
+    if (!url || url.hash !== "") {
+        return false;
+    }
+    const pathMatch = /^\/([A-Za-z0-9_-]{1,64})$/.exec(url.pathname);
+    return (
+        pathMatch !== null &&
+        USERNAME_PATTERN.test(pathMatch[1]) &&
+        hasExactSearchEntries(url, [["autoplay", "true"]])
+    );
+};
+
+const isTrustedFigJamIframeUrl = (value: string): boolean => {
+    const url = parseThirdPartyEmbedUrl(value, "embed.figma.com");
+    if (!url || url.hash !== "") {
+        return false;
+    }
+
+    // FigJam's human-readable slug is cosmetic. Trusted embed URLs omit it so
+    // encoded path separators and dot segments never enter the allowlist.
+    const pathMatch = /^\/board\/([A-Za-z0-9_-]{1,128})$/.exec(url.pathname);
+    if (!pathMatch) {
+        return false;
+    }
+
+    const nodeIds = url.searchParams.getAll("node-id");
+    const expected: [string, string][] = [["embed-host", "share"]];
+    if (
+        nodeIds.length === 1 &&
+        nodeIds[0].length > 0 &&
+        nodeIds[0].length <= 256
+    ) {
+        expected.push(["node-id", nodeIds[0]]);
+    } else if (nodeIds.length !== 0) {
+        return false;
+    }
+    return hasExactSearchEntries(url, expected);
+};
+
+const isTrustedYouTubeIframeUrl = (value: string): boolean => {
+    const url = parseThirdPartyEmbedUrl(value, "www.youtube.com");
+    if (!url || url.search !== "" || url.hash !== "") {
+        return false;
+    }
+    const pathMatch = /^\/embed\/([A-Za-z0-9_-]{1,128})$/.exec(url.pathname);
+    return pathMatch !== null && YOUTUBE_VIDEO_ID_PATTERN.test(pathMatch[1]);
+};
+
+const isExactConfiguredIframeUrl = (
+    value: string,
+    expectedValue: string
+): boolean => {
+    try {
+        const valueUrl = new URL(value);
+        const expectedUrl = new URL(expectedValue);
+        return (
+            valueUrl.protocol === "https:" &&
+            valueUrl.username === "" &&
+            valueUrl.password === "" &&
+            expectedUrl.protocol === "https:" &&
+            expectedUrl.username === "" &&
+            expectedUrl.password === "" &&
+            valueUrl.href === expectedUrl.href
+        );
+    } catch {
+        return false;
+    }
+};
 
 // ─────────────────────────────────────────────────────────────
 // Native apps – note the addition of isNative in the manifest.
@@ -105,10 +255,12 @@ export const curatedWebApps: (
     mode?: string,
     appUrls?: CuratedAppUrls
 ) => CuratedWebApp[] = (mode?: string, appUrls?: CuratedAppUrls) => [
-    // Twitch – already has a getStatus implementation.
+    // Twitch
     {
         type: "web",
         match: ["https://twitch.tv/", "https://www.twitch.tv/", "twitch"],
+        iframePermissions: ["autoplay", "fullscreen", "picture-in-picture"],
+        isTrustedIframeUrl: isTrustedTwitchIframeUrl,
         transformer: (query: string, host: string) => {
             const lower = query.toLowerCase();
             let channel = "";
@@ -127,7 +279,10 @@ export const curatedWebApps: (
                 return { url: "https://twitch.tv" };
             } else {
                 return {
-                    url: `https://player.twitch.tv/?channel=${channel}&parent=${host}`,
+                    url: `https://player.twitch.tv/?${new URLSearchParams({
+                        channel,
+                        parent: host,
+                    })}`,
                     title: `Twitch Channel ${channel}`,
                 };
             }
@@ -140,10 +295,7 @@ export const curatedWebApps: (
             icon: "https://assets.twitch.tv/assets/favicon-32-e29e246c157142c94346.png",
         }),
         getStatus(url, host) {
-            if (
-                url.startsWith("https://player.twitch.tv/?channel=") &&
-                url.endsWith(`&parent=${host}`)
-            ) {
+            if (isTrustedTwitchIframeUrl(url, host)) {
                 return { isReady: true };
             } else {
                 return {
@@ -157,6 +309,8 @@ export const curatedWebApps: (
     {
         type: "web",
         match: ["https://kick.com", "https://www.kick.com", "kick"],
+        iframePermissions: ["autoplay", "fullscreen", "picture-in-picture"],
+        isTrustedIframeUrl: isTrustedKickIframeUrl,
         transformer: (query: string) => {
             const lower = query.toLowerCase();
             let username = "";
@@ -167,50 +321,67 @@ export const curatedWebApps: (
             ];
             for (const prefix of prefixes) {
                 if (lower.startsWith(prefix)) {
-                    username = query.substring(prefix.length).trim();
+                    username = query
+                        .substring(prefix.length)
+                        .trim()
+                        .replace(/^\/+|\/+$/g, "");
                     break;
                 }
             }
-            return { url: `https://player.kick.com/${username}?autoplay=true` };
+            return {
+                url: `https://player.kick.com/${encodeURIComponent(
+                    username
+                )}?autoplay=true`,
+            };
         },
         manifest: new SimpleWebManifest({
             url: "https://kick.com",
             title: "Kick",
             icon: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Kick_logo.svg/200px-Kick_logo.svg.png",
         }),
-        getStatus(url, host) {
-            try {
-                const urlObj = new URL(url);
-                // Remove leading/trailing slashes from the pathname.
-                const username = urlObj.pathname.replace(/^\/+|\/+$/g, "");
-                if (!username) {
-                    return {
-                        isReady: false,
-                        info: "No username provided. Please provide a valid Kick username. Example: https://player.kick.com/yourUsername?autoplay=true",
-                    };
-                }
+        getStatus(url) {
+            if (isTrustedKickIframeUrl(url)) {
                 return { isReady: true };
-            } catch (e) {
-                return {
-                    isReady: false,
-                    info: "Invalid URL format for Kick. Example: https://player.kick.com/yourUsername?autoplay=true",
-                };
             }
+            return {
+                isReady: false,
+                info: "Invalid Kick embed URL. Please provide a single valid username. Example: https://player.kick.com/yourUsername?autoplay=true",
+            };
         },
     },
     // FigJam (Figma board)
     {
         type: "web",
         match: ["https://www.figma.com/board/", "figma", "figjam"],
+        iframePermissions: ["clipboard-write", "fullscreen"],
+        isTrustedIframeUrl: isTrustedFigJamIframeUrl,
         transformer: (query: string) => {
             try {
                 const urlObj = new URL(query);
-                const pathname = urlObj.pathname; // e.g., /board/UVuAdACJVPBgW7XOqxiDWv/GigaJam
+                const pathMatch =
+                    /^\/board\/([A-Za-z0-9_-]{1,128})(?:\/[^/]*)?$/.exec(
+                        urlObj.pathname
+                    );
+                if (
+                    urlObj.protocol !== "https:" ||
+                    urlObj.hostname !== "www.figma.com" ||
+                    urlObj.port !== "" ||
+                    urlObj.username !== "" ||
+                    urlObj.password !== "" ||
+                    !pathMatch
+                ) {
+                    return { url: query };
+                }
+                const boardId = pathMatch[1];
                 const nodeId = urlObj.searchParams.get("node-id");
-                const search = nodeId
-                    ? `?node-id=${nodeId}&embed-host=share`
-                    : "";
-                return { url: `https://embed.figma.com${pathname}${search}` };
+                const search = new URLSearchParams();
+                if (nodeId) {
+                    search.set("node-id", nodeId);
+                }
+                search.set("embed-host", "share");
+                return {
+                    url: `https://embed.figma.com/board/${boardId}?${search}`,
+                };
             } catch (e) {
                 return { url: query };
             }
@@ -221,10 +392,8 @@ export const curatedWebApps: (
             metaDescription: "Figma FigJam Board",
             icon: "https://static.figma.com/app/icon/1/favicon.svg",
         }),
-        getStatus(url, host) {
-            const prefix = "https://embed.figma.com/board/";
-            // If the URL is exactly the prefix, it's missing board details and is invalid.
-            if (url.startsWith(prefix) && url.length > prefix.length) {
+        getStatus(url) {
+            if (isTrustedFigJamIframeUrl(url)) {
                 return { isReady: true };
             } else {
                 return {
@@ -235,26 +404,40 @@ export const curatedWebApps: (
         },
     },
     // YouTube
-    // YouTube
     {
         type: "web",
         match: [
             "https://www.youtube.com/watch?v=",
             "https://youtube.com/watch?v=",
         ],
+        iframePermissions: [
+            "autoplay",
+            "encrypted-media",
+            "fullscreen",
+            "picture-in-picture",
+        ],
+        isTrustedIframeUrl: isTrustedYouTubeIframeUrl,
         transformer: (query: string) => {
-            const prefixes = [
-                "https://www.youtube.com/watch?v=",
-                "https://youtube.com/watch?v=",
-            ];
-            for (const prefix of prefixes) {
-                if (query.startsWith(prefix)) {
+            try {
+                const url = new URL(query);
+                if (
+                    url.protocol === "https:" &&
+                    (url.hostname === "www.youtube.com" ||
+                        url.hostname === "youtube.com") &&
+                    url.port === "" &&
+                    url.username === "" &&
+                    url.password === "" &&
+                    url.pathname === "/watch"
+                ) {
+                    const videoId = url.searchParams.get("v") ?? "";
                     return {
-                        url: `https://www.youtube.com/embed/${query.substring(
-                            prefix.length
+                        url: `https://www.youtube.com/embed/${encodeURIComponent(
+                            videoId
                         )}`,
                     };
                 }
+            } catch {
+                // Return the input so getStatus can surface the validation error.
             }
             return { url: query };
         },
@@ -264,41 +447,8 @@ export const curatedWebApps: (
             metaDescription: "YouTube videos",
             icon: "https://www.gstatic.com/youtube/img/branding/favicon/favicon_144x144_v2.png",
         }),
-        getStatus(url, host) {
-            // Handle YouTube watch URLs
-            if (url.startsWith("https://www.youtube.com/watch?v=")) {
-                const id = url.substring(
-                    "https://www.youtube.com/watch?v=".length
-                );
-                if (id.trim().length === 0) {
-                    return {
-                        isReady: false,
-                        info: "Invalid YouTube video URL. Missing video id. Example: https://www.youtube.com/watch?v=VIDEO_ID",
-                    };
-                }
-                return { isReady: true };
-            }
-            if (url.startsWith("https://youtube.com/watch?v=")) {
-                const id = url.substring("https://youtube.com/watch?v=".length);
-                if (id.trim().length === 0) {
-                    return {
-                        isReady: false,
-                        info: "Invalid YouTube video URL. Missing video id. Example: https://youtube.com/watch?v=VIDEO_ID",
-                    };
-                }
-                return { isReady: true };
-            }
-            // Handle embed URLs
-            if (url.startsWith("https://www.youtube.com/embed/")) {
-                const id = url.substring(
-                    "https://www.youtube.com/embed/".length
-                );
-                if (id.trim().length === 0) {
-                    return {
-                        isReady: false,
-                        info: "Invalid YouTube video URL. Missing video id. Example: https://www.youtube.com/embed/VIDEO_ID",
-                    };
-                }
+        getStatus(url) {
+            if (isTrustedYouTubeIframeUrl(url)) {
                 return { isReady: true };
             }
             return {
@@ -311,6 +461,20 @@ export const curatedWebApps: (
     {
         type: "web",
         match: ["video", "stream", "live-stream", "livestream"],
+        // Streaming deliberately retains the capture capabilities it uses.
+        iframePermissions: [
+            "autoplay",
+            "camera",
+            "clipboard-write",
+            "display-capture",
+            "fullscreen",
+            "microphone",
+        ],
+        // The owned streaming frontend renders @giga-app/sdk's AppProvider,
+        // which bundles @iframe-resizer/child.
+        iframeResizer: true,
+        isTrustedIframeUrl: (url) =>
+            isExactConfiguredIframeUrl(url, STREAMING_APP(mode, appUrls)),
         manifest: new SimpleWebManifest({
             url: STREAMING_APP(mode, appUrls),
             title: "Video",
@@ -318,7 +482,7 @@ export const curatedWebApps: (
         }),
         getStatus(url, host) {
             const expectedUrl = STREAMING_APP(mode, appUrls);
-            if (url === expectedUrl) {
+            if (isExactConfiguredIframeUrl(url, expectedUrl)) {
                 return { isReady: true };
             } else {
                 return {
@@ -332,6 +496,12 @@ export const curatedWebApps: (
     {
         type: "web",
         match: ["chess"],
+        iframePermissions: [],
+        // The owned chess frontend renders @giga-app/sdk's AppProvider, which
+        // bundles @iframe-resizer/child.
+        iframeResizer: true,
+        isTrustedIframeUrl: (url) =>
+            isExactConfiguredIframeUrl(url, CHESS_APP(mode, appUrls)),
         manifest: new SimpleWebManifest({
             url: CHESS_APP(mode, appUrls),
             title: "Chess",
@@ -339,7 +509,7 @@ export const curatedWebApps: (
         }),
         getStatus(url, host) {
             const expectedUrl = CHESS_APP(mode, appUrls);
-            if (url === expectedUrl) {
+            if (isExactConfiguredIframeUrl(url, expectedUrl)) {
                 return { isReady: true };
             } else {
                 return {
@@ -359,6 +529,19 @@ const allCuratedApps = (
     ...nativeApps,
     ...curatedWebApps(mode, appUrls),
 ];
+
+/**
+ * Resolve a browser-controlled iframe URL against the exact policies of the
+ * curated registry. This is intentionally separate from fuzzy search matching.
+ */
+export const resolveCuratedWebApp = (properties: {
+    apps: readonly CuratedWebApp[];
+    url: string;
+    host: string;
+}): CuratedWebApp | undefined =>
+    properties.apps.find((app) =>
+        app.isTrustedIframeUrl?.(properties.url, properties.host)
+    );
 
 // ─────────────────────────────────────────────────────────────
 // Helper to find a matching curated app.
@@ -400,8 +583,12 @@ export const getApps = (properties: {
 }): {
     curated: CuratedAppCommon[];
     search: (appOrUrl: string) => Promise<SimpleWebManifest[]>;
+    resolveCuratedWebApp: (url: string) => CuratedWebApp | undefined;
 } => {
     const curated = allCuratedApps(properties.mode, properties.appUrls);
+    const curatedWeb = curated.filter(
+        (app): app is CuratedWebApp => app.type === "web"
+    );
     const search = async (urlOrName: string | undefined) => {
         const result: Map<string, SimpleWebManifest> = new Map();
 
@@ -517,5 +704,14 @@ export const getApps = (properties: {
         }
         return [...result.values()];
     };
-    return { search, curated };
+    return {
+        search,
+        curated,
+        resolveCuratedWebApp: (url) =>
+            resolveCuratedWebApp({
+                apps: curatedWeb,
+                url,
+                host: properties.host,
+            }),
+    };
 };

--- a/packages/social-media-app/frontend/src/content/Frame.tsx
+++ b/packages/social-media-app/frontend/src/content/Frame.tsx
@@ -9,15 +9,28 @@ import { useNavigate } from "react-router";
 import { EditableStaticContent } from "./native/NativeContent";
 import { useApps } from "./useApps";
 import { CuratedWebApp } from "@giga-app/app-service";
-import { HostProvider as GigaHost, HostProvider, useHost } from "@giga-app/sdk";
+import {
+    HostProvider,
+    NavigationEvent,
+    normalizeMatchingAppOrigin,
+    resolveIframeCapabilities,
+    useHost,
+} from "@giga-app/sdk";
 import { useCanvas } from "../canvas/CanvasWrapper";
 import { StaticMarkdownText } from "@giga-app/interface";
 import { useThemeContext } from "../theme/useTheme";
+
+// Scripts and same-origin are required by the curated Peerbit apps for
+// storage, media capture, and the authenticated postMessage channel. Omitted
+// capabilities include top navigation, downloads, pointer lock, and modals.
+const IFRAME_SANDBOX =
+    "allow-forms allow-popups allow-presentation allow-same-origin allow-scripts";
 
 const ThemedIframe = (properties: {
     src: string;
     onLoad: (evt: SyntheticEvent<HTMLIFrameElement, Event>) => void;
     iframeRef: React.RefObject<HTMLIFrameElement>;
+    permissions?: readonly string[];
 }) => {
     const { send, ready } = useHost();
     const { theme } = useThemeContext();
@@ -42,7 +55,13 @@ const ThemedIframe = (properties: {
                 border: 0,
             }}
             src={properties.src || undefined}
-            allow="camera; microphone;  display-capture; fullscreen; autoplay; clipboard-write;"
+            allow={
+                properties.permissions?.length
+                    ? properties.permissions.join("; ")
+                    : undefined
+            }
+            sandbox={IFRAME_SANDBOX}
+            referrerPolicy="strict-origin-when-cross-origin"
         ></iframe>
     );
 };
@@ -202,11 +221,75 @@ export const Frame = (properties: {
 
     const onResize = useCallback(() => {}, []);
 
+    const onIframeNavigate = useCallback(
+        async (evt: NavigationEvent) => {
+            await mutate(
+                (element) => {
+                    const currentUrl = (element.content as IFrameContent).src;
+                    if (currentUrl === evt.to) {
+                        return false;
+                    }
+                    (element.content as IFrameContent).src = evt.to;
+                    return true;
+                },
+                {
+                    filter(rect) {
+                        return rect.idString === properties.element.idString;
+                    },
+                }
+            );
+        },
+        [mutate, properties.element.idString]
+    );
+
     const renderContent = ({ previewLines }: { previewLines?: number }) => {
         // For iframes, continue to use the iframe as before.
         if (properties.element.content instanceof IFrameContent) {
-            const src = (properties.element.content as IFrameContent).src;
+            const iframeContent = properties.element.content;
+            const src = iframeContent.src;
+
+            let targetOrigin: string;
+            try {
+                // This check must happen before resolving any privileged
+                // capabilities or rendering the browser-controlled source.
+                targetOrigin = normalizeMatchingAppOrigin(
+                    src,
+                    iframeContent.orgSrc
+                );
+            } catch {
+                return (
+                    <div
+                        role="alert"
+                        className="p-4 border rounded-md flex flex-col items-center justify-center"
+                    >
+                        <p className="font-medium mb-2 text-center">
+                            This embedded app was blocked because its current
+                            URL does not match its original app origin.
+                        </p>
+                        <p className="text-sm italic mb-2">
+                            Current URL: {src}
+                        </p>
+                    </div>
+                );
+            }
+
             const curatedWebApp = getCuratedWebApp(src);
+            const originalCuratedWebApp = getCuratedWebApp(
+                iframeContent.orgSrc
+            );
+            // Both the immutable original source and the URL the browser will
+            // load must independently satisfy the same exact embed policy.
+            // Fuzzy search matches are never a trust decision.
+            const trustedCuratedWebApp =
+                curatedWebApp === originalCuratedWebApp
+                    ? originalCuratedWebApp
+                    : undefined;
+            const capabilities = resolveIframeCapabilities({
+                trusted: trustedCuratedWebApp !== undefined,
+                permissions: trustedCuratedWebApp?.iframePermissions,
+                resizerRequested: iframeContent.resizer,
+                resizerAllowed: trustedCuratedWebApp?.iframeResizer,
+            });
             if (curatedWebApp) {
                 const status = curatedWebApp.getStatus(
                     src,
@@ -219,35 +302,17 @@ export const Frame = (properties: {
 
             return (
                 <HostProvider
-                    iframeOriginalSource={properties.element.content.orgSrc}
-                    onNavigate={async (evt) => {
-                        await mutate(
-                            (element) => {
-                                const currentUrl = (
-                                    element.content as IFrameContent
-                                ).src;
-                                if (currentUrl === evt.to) {
-                                    return false;
-                                }
-                                (element.content as IFrameContent).src = evt.to;
-                                return true;
-                            },
-                            {
-                                filter(rect) {
-                                    return (
-                                        rect.idString ===
-                                        properties.element.idString
-                                    );
-                                },
-                            }
-                        );
-                    }}
+                    iframeOriginalSource={targetOrigin}
+                    iframeSource={src}
+                    onNavigate={onIframeNavigate}
+                    enableResizer={capabilities.resizer}
                 >
                     {(iframeRef) => (
                         <ThemedIframe
                             iframeRef={iframeRef}
                             onLoad={properties.onLoad}
                             src={src}
+                            permissions={capabilities.permissions}
                         ></ThemedIframe>
                     )}
                 </HostProvider>

--- a/packages/social-media-app/frontend/src/content/useApps.tsx
+++ b/packages/social-media-app/frontend/src/content/useApps.tsx
@@ -69,12 +69,6 @@ export const AppProvider = ({ children }: { children: JSX.Element }) => {
             ) as CuratedAppNative[],
         []
     );
-    const allCuratedWebApps = useMemo(
-        () =>
-            allApps.curated.filter((x) => x.type === "web") as CuratedWebApp[],
-        []
-    );
-
     const { peer } = usePeer();
     const [, forceUpdate] = useReducer((x) => x + 1, 0);
     // Ensure AppPreview is included in the bundle by assigning it to our ref.
@@ -94,8 +88,7 @@ export const AppProvider = ({ children }: { children: JSX.Element }) => {
             history: historyDB,
             getCuratedNativeApp: (url: string) =>
                 nativeApps.find((x) => x.manifest.url === url),
-            getCuratedWebApp: (url: string) =>
-                allCuratedWebApps.find((x) => x.manifest.url === url),
+            getCuratedWebApp: allApps.resolveCuratedWebApp,
             search,
             resolve: async (url: string) => {
                 // Check our current list first.
@@ -114,7 +107,7 @@ export const AppProvider = ({ children }: { children: JSX.Element }) => {
                 return undefined;
             },
         }),
-        [apps, historyDB, nativeApps, allCuratedWebApps]
+        [apps, historyDB, nativeApps, search]
     );
 
     return <AppContext.Provider value={memo}>{children}</AppContext.Provider>;


### PR DESCRIPTION
## Summary

- authenticate iframe messages by exact source window and normalized origin with closed schemas and bounded same-origin navigation
- require current/original source agreement before granting explicit least-privilege per-app capabilities
- restrict iframe-resizer to owned Stream/Chess integrations and block its close protocol
- canonicalize transformed Twitch, YouTube, Kick, and FigJam embeds; reject encoded-path/origin tricks
- rebind host listeners during layout cleanup so stale origins cannot race source changes

## Validation

- independent final security audit: no P0/P1/P2 findings
- focused security/lifecycle tests (53/53)
- SDK, app-service, Giga, Chess, and Stream builds/TypeScript
- real iframe-resizer v5 close-wire regression
- Prettier and clean diff checks
- audited patch ID preserved across rebase onto current master