### PR TITLE
fix: restore and smoke-test hosted app runtimes

### DIFF
--- a/.changeset/fix-music-library-index-variants.md
+++ b/.changeset/fix-music-library-index-variants.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/music-library-utils": patch
+---
+
+Add stable variants for the music library's document and index models so its programs open reliably in production bundles.

--- a/.changeset/fix-music-library-index-variants.md
+++ b/.changeset/fix-music-library-index-variants.md
@@ -2,4 +2,4 @@
 "@peerbit/music-library-utils": patch
 ---
 
-Add stable variants for the music library's document and index models so its programs open reliably in production bundles.
+Add stable variants for the music library's local index projections so its programs open reliably without changing stored document encodings.

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -48,6 +48,12 @@ jobs:
                   export SHORT_SHA="${GITHUB_SHA::7}"
                   pnpm run build
 
+            - name: Install Playwright Chromium
+              run: pnpm exec playwright install --with-deps chromium
+
+            - name: Smoke-test every hosted frontend
+              run: pnpm run test:hosted-apps
+
             - name: Prepare and validate Cloudflare assets
               env:
                   COMMIT_HASH: ${{ github.sha }}

--- a/.github/workflows/cloudflare-production.yml
+++ b/.github/workflows/cloudflare-production.yml
@@ -52,7 +52,7 @@ jobs:
               with:
                   run_install: false
 
-            - name: Build and validate every frontend
+            - name: Build every frontend
               env:
                   COMMIT_HASH: ${{ github.sha }}
               run: |
@@ -61,6 +61,17 @@ jobs:
                   node --test cloudflare/*.test.mjs
                   export SHORT_SHA="${GITHUB_SHA::7}"
                   pnpm run build
+
+            - name: Install locked Chromium for hosted-app validation
+              run: pnpm exec playwright install --with-deps chromium
+
+            - name: Smoke-test every hosted app
+              run: pnpm run test:hosted-apps
+
+            - name: Validate Cloudflare production bundles
+              env:
+                  COMMIT_HASH: ${{ github.sha }}
+              run: |
                   node scripts/prepare-cloudflare-assets.mjs
                   node scripts/validate-owned-domains.mjs
                   git diff --exit-code

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "test:vitest": "pnpm run build && vitest run",
         "test:vitest:watch": "vitest",
         "test:vitest:quick": "vitest run",
+        "test:hosted-apps": "node scripts/validate-hosted-app-runtime.mjs",
         "vitest": "vitest",
         "shared-fs:install:macos": "scripts/install-shared-fs-macos.sh",
         "scaleway:start": "node scripts/github-scaleway-runner.mjs start",
@@ -71,6 +72,7 @@
     "devDependencies": {
         "@changesets/cli": "^2.29.7",
         "@peerbit/stream-interface": "^6.0.11",
+        "@playwright/test": "1.58.0",
         "@testing-library/dom": "10.4.1",
         "@testing-library/react": "16.3.0",
         "@types/chai": "^4.3.18",

--- a/packages/collaborative-learning/frontend/src/database.ts
+++ b/packages/collaborative-learning/frontend/src/database.ts
@@ -2,6 +2,7 @@ import { Program } from "@peerbit/program";
 import { Documents } from "@peerbit/document";
 import { field, variant } from "@dao-xyz/borsh";
 
+@variant("collaborative_learning_model")
 export class Model {
     @field({ type: "string" })
     id: string;

--- a/packages/collaborative-learning/frontend/src/database.ts
+++ b/packages/collaborative-learning/frontend/src/database.ts
@@ -2,7 +2,6 @@ import { Program } from "@peerbit/program";
 import { Documents } from "@peerbit/document";
 import { field, variant } from "@dao-xyz/borsh";
 
-@variant("collaborative_learning_model")
 export class Model {
     @field({ type: "string" })
     id: string;
@@ -28,21 +27,46 @@ export class Model {
     }
 }
 
+@variant("collaborative_learning_model_indexable")
+class ModelIndexable {
+    @field({ type: "string" })
+    id: string;
+
+    @field({ type: "string" })
+    configJSON: string;
+
+    @field({ type: Uint8Array })
+    weights: Uint8Array;
+
+    constructor(model: Model) {
+        this.id = model.id;
+        this.configJSON = model.configJSON;
+        this.weights = model.weights;
+    }
+
+    get config() {
+        return JSON.parse(this.configJSON);
+    }
+}
+
 @variant("models")
 export class ModelDatabase extends Program {
     @field({ type: Uint8Array })
     id: Uint8Array;
 
     @field({ type: Documents })
-    models: Documents<Model>;
+    models: Documents<Model, ModelIndexable>;
 
     constructor(properties: { id: Uint8Array }) {
         super();
         this.id = properties.id;
-        this.models = new Documents({ id: this.id });
+        this.models = new Documents<Model, ModelIndexable>({ id: this.id });
     }
 
     open(): Promise<void> {
-        return this.models.open({ type: Model });
+        return this.models.open({
+            type: Model,
+            index: { type: ModelIndexable },
+        });
     }
 }

--- a/packages/collaborative-learning/frontend/vite.config.ts
+++ b/packages/collaborative-learning/frontend/vite.config.ts
@@ -7,11 +7,11 @@ export default defineConfig({
     plugins: [react(), peerbit()],
     optimizeDeps: {
         esbuildOptions: {
-            target: "esnext",
+            target: "es2022",
         },
     },
     build: {
-        target: "esnext",
+        target: "es2022",
     },
     define: {
         APP_VERSION: JSON.stringify(process.env.npm_package_version),

--- a/packages/media-streaming/music-library/music-library-utils/src/__tests__/index.test.ts
+++ b/packages/media-streaming/music-library/music-library-utils/src/__tests__/index.test.ts
@@ -1,0 +1,41 @@
+import { expect } from "chai";
+import { afterEach, beforeEach, describe, it } from "vitest";
+import { Peerbit } from "peerbit";
+import { ImageItems, NamedItems, StoraOfLibraries } from "../index.js";
+
+describe("music library indexes", () => {
+    let peer: Peerbit;
+
+    beforeEach(async () => {
+        peer = await Peerbit.create();
+    });
+
+    afterEach(async () => {
+        await peer.stop();
+    });
+
+    it("opens every indexed program and persists its local records", async () => {
+        const libraries = await peer.open(new StoraOfLibraries(), {
+            args: { replicate: false },
+        });
+        const names = await peer.open(new NamedItems(), {
+            args: { replicate: false },
+        });
+        const images = await peer.open(new ImageItems(), {
+            args: { replicate: false },
+        });
+
+        expect(await libraries.libraries.index.getSize()).to.equal(0);
+
+        const itemId = new Uint8Array([1, 2, 3, 4]);
+        await names.setName(itemId, "Test track");
+        await images.setImage(itemId, new Uint8Array([5, 6, 7]), 1, 1);
+
+        expect((await names.documents.index.get(itemId))?.name).to.equal(
+            "Test track"
+        );
+        expect((await images.documents.index.get(itemId))?.id).to.deep.equal(
+            itemId
+        );
+    });
+});

--- a/packages/media-streaming/music-library/music-library-utils/src/__tests__/index.test.ts
+++ b/packages/media-streaming/music-library/music-library-utils/src/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { Peerbit } from "peerbit";
+import { isPutOperation } from "@peerbit/document";
 import { ImageItems, NamedItems, StoraOfLibraries } from "../index.js";
 
 describe("music library indexes", () => {
@@ -14,7 +15,7 @@ describe("music library indexes", () => {
         await peer.stop();
     });
 
-    it("opens every indexed program and persists its local records", async () => {
+    it("keeps stored encodings compatible and restores indexes after reopen", async () => {
         const libraries = await peer.open(new StoraOfLibraries(), {
             args: { replicate: false },
         });
@@ -37,5 +38,51 @@ describe("music library indexes", () => {
         expect((await images.documents.index.get(itemId))?.id).to.deep.equal(
             itemId
         );
+
+        const nameEntry = (await names.documents.log.log.toArray())[0];
+        const nameOperation = await nameEntry.getPayloadValue();
+        if (!isPutOperation(nameOperation)) {
+            throw new Error("Expected the stored name to be a put operation");
+        }
+        expect(nameOperation.data).to.deep.equal(
+            new Uint8Array([
+                4, 0, 0, 0, 1, 2, 3, 4, 10, 0, 0, 0, 84, 101, 115, 116, 32, 116,
+                114, 97, 99, 107,
+            ])
+        );
+
+        const imageEntry = (await images.documents.log.log.toArray())[0];
+        const imageOperation = await imageEntry.getPayloadValue();
+        if (!isPutOperation(imageOperation)) {
+            throw new Error("Expected the stored image to be a put operation");
+        }
+        expect(imageOperation.data).to.deep.equal(
+            new Uint8Array([
+                4, 0, 0, 0, 1, 2, 3, 4, 3, 0, 0, 0, 5, 6, 7, 1, 0, 0, 0, 1, 0,
+                0, 0,
+            ])
+        );
+
+        await libraries.close();
+        await names.close();
+        await images.close();
+
+        const reopenedLibraries = await peer.open(new StoraOfLibraries(), {
+            args: { replicate: false },
+        });
+        const reopenedNames = await peer.open(new NamedItems(), {
+            args: { replicate: false },
+        });
+        const reopenedImages = await peer.open(new ImageItems(), {
+            args: { replicate: false },
+        });
+
+        expect(await reopenedLibraries.libraries.index.getSize()).to.equal(0);
+        expect(
+            (await reopenedNames.documents.index.get(itemId))?.name
+        ).to.equal("Test track");
+        expect(
+            (await reopenedImages.documents.index.get(itemId))?.id
+        ).to.deep.equal(itemId);
     });
 });

--- a/packages/media-streaming/music-library/music-library-utils/src/index.ts
+++ b/packages/media-streaming/music-library/music-library-utils/src/index.ts
@@ -111,7 +111,6 @@ export class StoraOfLibraries extends Program {
     }
 }
 
-@variant("music_named_item")
 class NamedItem {
     @id({ type: Uint8Array })
     id: Uint8Array;
@@ -125,17 +124,31 @@ class NamedItem {
     }
 }
 
+@variant("music_named_item_indexable")
+class NamedItemIndexable {
+    @id({ type: Uint8Array })
+    id: Uint8Array;
+
+    @field({ type: "string" })
+    name: string;
+
+    constructor(props: NamedItem) {
+        this.id = props.id;
+        this.name = props.name;
+    }
+}
+
 type ReplicationArgs = { replicate?: boolean };
 
 /* ─────────────── program ─────────────── */
 @variant("named-items")
 export class NamedItems extends Program<ReplicationArgs> {
     @field({ type: Documents })
-    documents: Documents<NamedItem>;
+    documents: Documents<NamedItem, NamedItemIndexable>;
 
     constructor(props?: { id?: Uint8Array }) {
         super();
-        this.documents = new Documents<NamedItem>({
+        this.documents = new Documents<NamedItem, NamedItemIndexable>({
             id:
                 props?.id ??
                 sha256Sync(new TextEncoder().encode("named-items")),
@@ -153,13 +166,12 @@ export class NamedItems extends Program<ReplicationArgs> {
             keep: "self",
             replicate: args?.replicate ? { factor: 1 } : false,
             index: {
-                type: NamedItem,
+                type: NamedItemIndexable,
             },
         });
     }
 }
 
-@variant("music_image_item")
 class ImageItem {
     @id({ type: Uint8Array })
     id: Uint8Array;

--- a/packages/media-streaming/music-library/music-library-utils/src/index.ts
+++ b/packages/media-streaming/music-library/music-library-utils/src/index.ts
@@ -4,6 +4,7 @@ import { Program } from "@peerbit/program";
 import { Documents, DocumentsChange, id } from "@peerbit/document";
 import { MediaStreamDBs } from "@peerbit/media-streaming";
 
+@variant("music_media_stream_dbs_indexable")
 class MediaStreamDBsIndexable {
     @id({ type: fixedArray("u8", 32) })
     id: Uint8Array;
@@ -110,6 +111,7 @@ export class StoraOfLibraries extends Program {
     }
 }
 
+@variant("music_named_item")
 class NamedItem {
     @id({ type: Uint8Array })
     id: Uint8Array;
@@ -157,6 +159,7 @@ export class NamedItems extends Program<ReplicationArgs> {
     }
 }
 
+@variant("music_image_item")
 class ImageItem {
     @id({ type: Uint8Array })
     id: Uint8Array;
@@ -183,6 +186,7 @@ class ImageItem {
     }
 }
 
+@variant("music_indexed_image_item")
 class IndexedImageItem {
     @id({ type: Uint8Array })
     id: Uint8Array;

--- a/packages/name-service/library/src/index.ts
+++ b/packages/name-service/library/src/index.ts
@@ -18,6 +18,7 @@ export class Name {
     }
 }
 
+@variant("peerbit_example_name_service_indexed_name")
 class IndexedName {
     @field({ type: Uint8Array })
     id: Uint8Array;

--- a/packages/one-chat-room/frontend/src/Room.tsx
+++ b/packages/one-chat-room/frontend/src/Room.tsx
@@ -250,7 +250,19 @@ export const Room = () => {
             <CircularProgress size={20} />
         </Box>
     ) : (
-        <Grid container direction="column" sx={{ height: "100vh" }}>
+        <Grid
+            container
+            direction="column"
+            sx={{ height: "100vh" }}
+            data-testid={
+                room.program &&
+                !room.program.closed &&
+                names.program &&
+                !names.program.closed
+                    ? "chat-room-ready"
+                    : undefined
+            }
+        >
             <Grid
                 item
                 container

--- a/packages/one-chat-room/frontend/src/database.ts
+++ b/packages/one-chat-room/frontend/src/database.ts
@@ -38,6 +38,7 @@ export class Post {
     }
 }
 
+@variant("one_chat_room_indexable_post")
 class IndexablePost {
     @field({ type: "string" })
     id: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@peerbit/stream-interface':
         specifier: ^6.0.11
         version: 6.0.11
+      '@playwright/test':
+        specifier: 1.58.0
+        version: 1.58.0
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1

--- a/scripts/validate-hosted-app-runtime.mjs
+++ b/scripts/validate-hosted-app-runtime.mjs
@@ -148,6 +148,43 @@ const serve = (directory) =>
 const isFatalConsoleMessage = (message) =>
     FATAL_CONSOLE_PATTERNS.some((pattern) => pattern.test(message));
 
+const assertChatRoomReady = async (page) => {
+    const openRoom = page.getByRole("button", {
+        name: "Open room",
+        exact: true,
+    });
+    await openRoom.waitFor({ state: "visible", timeout: ROOT_TIMEOUT_MS });
+    await page.waitForFunction(
+        () => {
+            const button = [...document.querySelectorAll("button")].find(
+                (candidate) => candidate.textContent?.trim() === "Open room"
+            );
+            return button instanceof HTMLButtonElement && !button.disabled;
+        },
+        undefined,
+        { timeout: ROOT_TIMEOUT_MS }
+    );
+    await openRoom.click();
+    await page.waitForURL((url) => url.hash.startsWith("#/k/"), {
+        timeout: ROOT_TIMEOUT_MS,
+    });
+    await page
+        .getByTestId("chat-room-ready")
+        .waitFor({ state: "visible", timeout: ROOT_TIMEOUT_MS });
+
+    const composer = page.getByRole("textbox", { name: "Send message" });
+    await composer.waitFor({ state: "visible", timeout: ROOT_TIMEOUT_MS });
+    if (!(await composer.isEnabled())) {
+        throw new Error(
+            "chat: room opened without an enabled message composer"
+        );
+    }
+};
+
+const assertSiteReady = async (site, page) => {
+    if (site.id === "chat") await assertChatRoomReady(page);
+};
+
 const smokeSite = async (browser, site, directory) => {
     const { server, origin } = await serve(directory);
     const context = await browser.newContext();
@@ -193,6 +230,7 @@ const smokeSite = async (browser, site, directory) => {
             undefined,
             { timeout: ROOT_TIMEOUT_MS }
         );
+        await assertSiteReady(site, page);
         await page.waitForTimeout(SETTLE_MS);
         if (runtimeErrors.length) {
             throw new Error(

--- a/scripts/validate-hosted-app-runtime.mjs
+++ b/scripts/validate-hosted-app-runtime.mjs
@@ -1,0 +1,239 @@
+import { execFileSync } from "node:child_process";
+import {
+    createReadStream,
+    existsSync,
+    readFileSync,
+    readdirSync,
+    statSync,
+} from "node:fs";
+import { createServer } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const repoRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    ".."
+);
+const manifest = JSON.parse(
+    readFileSync(path.join(repoRoot, "cloudflare/sites.json"), "utf8")
+);
+
+const ROOT_TIMEOUT_MS = 45_000;
+const SETTLE_MS = 5_000;
+const FATAL_CONSOLE_PATTERNS = [
+    /failed to open/i,
+    /indexed type .*missing @variant/i,
+    /missing @variant/i,
+    /uncaught (?:error|exception)/i,
+];
+const MIME_TYPES = new Map([
+    [".css", "text/css; charset=utf-8"],
+    [".html", "text/html; charset=utf-8"],
+    [".ico", "image/x-icon"],
+    [".jpeg", "image/jpeg"],
+    [".jpg", "image/jpeg"],
+    [".js", "text/javascript; charset=utf-8"],
+    [".json", "application/json; charset=utf-8"],
+    [".mjs", "text/javascript; charset=utf-8"],
+    [".mp3", "audio/mpeg"],
+    [".mp4", "video/mp4"],
+    [".png", "image/png"],
+    [".svg", "image/svg+xml"],
+    [".wasm", "application/wasm"],
+    [".webmanifest", "application/manifest+json"],
+    [".woff", "font/woff"],
+    [".woff2", "font/woff2"],
+]);
+
+const walkJavaScript = (directory) => {
+    const files = [];
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+        const candidate = path.join(directory, entry.name);
+        if (entry.isDirectory()) files.push(...walkJavaScript(candidate));
+        else if (
+            entry.isFile() &&
+            [".js", ".mjs"].includes(path.extname(entry.name))
+        ) {
+            files.push(candidate);
+        }
+    }
+    return files;
+};
+
+const validateJavaScriptSyntax = (site, directory) => {
+    const assetsDirectory = path.join(directory, "assets");
+    if (!existsSync(assetsDirectory)) {
+        throw new Error(
+            `${site.id}: build is missing its Vite assets directory`
+        );
+    }
+    for (const file of walkJavaScript(assetsDirectory)) {
+        try {
+            execFileSync(process.execPath, ["--check", file], {
+                stdio: ["ignore", "ignore", "pipe"],
+                maxBuffer: 16 * 1024 * 1024,
+            });
+        } catch (error) {
+            const detail = String(error.stderr || error.message)
+                .trim()
+                .split("\n")
+                .slice(-4)
+                .join("\n");
+            throw new Error(
+                `${site.id}: invalid JavaScript in ${path.relative(repoRoot, file)}\n${detail}`
+            );
+        }
+    }
+};
+
+const safeAssetPath = (directory, pathname) => {
+    const decoded = decodeURIComponent(pathname);
+    const candidate = path.resolve(directory, `.${decoded}`);
+    if (
+        candidate !== directory &&
+        !candidate.startsWith(`${directory}${path.sep}`)
+    ) {
+        return undefined;
+    }
+
+    if (existsSync(candidate) && statSync(candidate).isFile()) return candidate;
+    if (!path.extname(decoded)) {
+        const fallback = path.join(directory, "index.html");
+        if (existsSync(fallback)) return fallback;
+    }
+    return undefined;
+};
+
+const serve = (directory) =>
+    new Promise((resolve, reject) => {
+        const server = createServer((request, response) => {
+            let asset;
+            try {
+                asset = safeAssetPath(
+                    directory,
+                    new URL(request.url || "/", "http://localhost").pathname
+                );
+            } catch {
+                response.writeHead(400).end("Bad request");
+                return;
+            }
+            if (!asset) {
+                response.writeHead(404).end("Not found");
+                return;
+            }
+
+            response.writeHead(200, {
+                "Content-Type":
+                    MIME_TYPES.get(path.extname(asset)) ||
+                    "application/octet-stream",
+                "Cache-Control": "no-store",
+                "X-Content-Type-Options": "nosniff",
+                "Referrer-Policy": "strict-origin-when-cross-origin",
+            });
+            createReadStream(asset).pipe(response);
+        });
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+            const address = server.address();
+            if (!address || typeof address === "string") {
+                server.close();
+                reject(new Error("Failed to allocate local smoke-test port"));
+                return;
+            }
+            resolve({ server, origin: `http://127.0.0.1:${address.port}` });
+        });
+    });
+
+const isFatalConsoleMessage = (message) =>
+    FATAL_CONSOLE_PATTERNS.some((pattern) => pattern.test(message));
+
+const smokeSite = async (browser, site, directory) => {
+    const { server, origin } = await serve(directory);
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const runtimeErrors = [];
+    page.on("pageerror", (error) =>
+        runtimeErrors.push(error.stack || error.message)
+    );
+    page.on("console", (message) => {
+        if (
+            message.type() === "error" &&
+            isFatalConsoleMessage(message.text())
+        ) {
+            runtimeErrors.push(message.text());
+        }
+    });
+
+    try {
+        const response = await page.goto(origin, {
+            waitUntil: "domcontentloaded",
+            timeout: ROOT_TIMEOUT_MS,
+        });
+        if (!response || response.status() !== 200) {
+            throw new Error(
+                `${site.id}: root returned HTTP ${response?.status()}`
+            );
+        }
+        await page.waitForFunction(
+            () => {
+                const root = document.querySelector("#root");
+                if (!root) return false;
+                const style = getComputedStyle(root);
+                if (style.display === "none" || style.visibility === "hidden") {
+                    return false;
+                }
+                return Boolean(
+                    root.textContent?.trim() ||
+                    root.querySelector(
+                        "button, canvas, input, progress, svg, textarea, video"
+                    )
+                );
+            },
+            undefined,
+            { timeout: ROOT_TIMEOUT_MS }
+        );
+        await page.waitForTimeout(SETTLE_MS);
+        if (runtimeErrors.length) {
+            throw new Error(
+                `${site.id}: browser runtime error\n${runtimeErrors.join("\n")}`
+            );
+        }
+    } finally {
+        await context.close();
+        await new Promise((resolve) => server.close(resolve));
+    }
+};
+
+const sites = manifest.staticSites.map((site) => ({
+    site,
+    directory: path.resolve(repoRoot, site.directory),
+}));
+
+for (const { site, directory } of sites) {
+    if (!existsSync(path.join(directory, "index.html"))) {
+        throw new Error(
+            `${site.id}: missing built frontend at ${path.relative(repoRoot, directory)}`
+        );
+    }
+    validateJavaScriptSyntax(site, directory);
+    console.log(`${site.id}: Vite bundles parse`);
+}
+
+let browser;
+try {
+    browser = await chromium.launch({ headless: true });
+    for (const { site, directory } of sites) {
+        await smokeSite(browser, site, directory);
+        console.log(`${site.id}: Chromium startup passed`);
+    }
+} catch (error) {
+    if (/Executable doesn't exist/i.test(String(error))) {
+        throw new Error(
+            `${error}\nInstall the locked browser with: pnpm exec playwright install chromium`
+        );
+    }
+    throw error;
+} finally {
+    await browser?.close();
+}


### PR DESCRIPTION
Fixes the hosted examples that could build but fail when opened in a browser.

- preserves stored and wire encodings by adding stable variants only to index projection types
- restores Chat, collaborative-learning, name-service, and music-library program startup
- makes the Chat smoke open a real room and wait for its programs and composer
- validates all hosted bundles for syntax and launches all seven sites in locked Chromium
- runs the same runtime gate before both preview and production Cloudflare deployment
- proves music legacy bytes and indexes survive close/reopen

Validation:
- pnpm run build
- pnpm run test:hosted-apps (7/7 sites)
- music compatibility/reopen regression
- Chat and collaborative-learning direct database opens
- Cloudflare tests (23/23) and production bootstrap validation
- affected TypeScript and formatting checks