### PR TITLE
fix: repair example test discovery and remote indexes

### DIFF
--- a/.changeset/blog-indexed-authors.md
+++ b/.changeset/blog-indexed-authors.md
@@ -1,0 +1,7 @@
+---
+"@peerbit/blog-sdk": patch
+---
+
+Carry indexed post authors in remote query results so non-replicating readers
+can search posts and resolve their authors without requiring the source log head
+locally.

--- a/.changeset/stable-index-variants.md
+++ b/.changeset/stable-index-variants.md
@@ -1,0 +1,6 @@
+---
+"@peerbit/example-many-chat-rooms": patch
+---
+
+Give the room index projection a stable serialization variant so persisted
+indexes can be reopened with current Peerbit releases.

--- a/packages/blog-platform/library/src/__tests__/index.integration.test.ts
+++ b/packages/blog-platform/library/src/__tests__/index.integration.test.ts
@@ -33,7 +33,7 @@ describe("index", () => {
             await platform.posts.put(post);
 
             const result = await platform.getPostAuthor(post.id);
-            expect(result).to.eq(peer.identity.publicKey);
+            expect(result.equals(peer.identity.publicKey)).toBe(true);
             const myPosts = await platform.getMyPosts();
             expect(myPosts).to.have.length(1);
 
@@ -57,6 +57,14 @@ describe("index", () => {
                 })
             );
             expect(foundPost).to.have.length(1);
+
+            const remoteHead = (foundPost[0] as any).__context.head;
+            expect(await viewer.posts.log.log.get(remoteHead)).toBeUndefined();
+            expect(
+                (await viewer.getPostAuthor(post.id)).equals(
+                    peer.identity.publicKey
+                )
+            ).toBe(true);
         });
     });
 

--- a/packages/blog-platform/library/src/index.ts
+++ b/packages/blog-platform/library/src/index.ts
@@ -168,13 +168,17 @@ export class BlogPosts extends Program<Args> {
                     return true; // Anyone can query
                 },
                 type: PostIndexable,
-                transform: async (post, ctx) => {
+                includeIndexed: true,
+                transform: (post, ctx, facts) => {
+                    const author = facts?.entryPublicKeys?.[0];
+                    if (!author) {
+                        throw new Error("Missing signer for indexed blog post");
+                    }
                     return new PostIndexable(
                         post,
                         ctx.created,
                         ctx.modified,
-                        (await this.posts.log.log.get(ctx.head))!.signatures[0]
-                            .publicKey
+                        author
                     );
                 },
             },
@@ -228,12 +232,21 @@ export class BlogPosts extends Program<Args> {
     }
 
     async getPostAuthor(id: string) {
-        // TODO typechecking
-        const head = (await this.posts.index.getDetailed(id))![0].results[0]
-            .context.head;
-        const key = (await this.posts.log.log.get(head))!.signatures[0]
-            .publicKey;
-        return key;
+        const responses = await this.posts.index.getDetailed(id, {
+            resolve: false,
+        });
+        for (const response of responses ?? []) {
+            for (const result of response.results) {
+                const entry = result.entries.find(
+                    (candidate) => candidate.hash === result.context.head
+                );
+                const author = entry?.signatures[0]?.publicKey;
+                if (author) {
+                    return author;
+                }
+            }
+        }
+        throw new Error(`Post author not found: ${id}`);
     }
 
     async getAlias(publicKey: PublicSignKey) {

--- a/packages/many-chat-rooms/library/src/__tests__/index.spec.ts
+++ b/packages/many-chat-rooms/library/src/__tests__/index.spec.ts
@@ -2,6 +2,7 @@ import { Peerbit } from "peerbit";
 import { waitFor, waitForResolved } from "@peerbit/time";
 import { Lobby, Post, Room } from "../index.js";
 import { expect } from "chai";
+import { afterEach, beforeEach, describe, it } from "vitest";
 
 const loobyConfig = {
     id: new Uint8Array([

--- a/packages/many-chat-rooms/library/src/__tests__/index.spec.ts
+++ b/packages/many-chat-rooms/library/src/__tests__/index.spec.ts
@@ -3,6 +3,9 @@ import { waitFor, waitForResolved } from "@peerbit/time";
 import { Lobby, Post, Room } from "../index.js";
 import { expect } from "chai";
 import { afterEach, beforeEach, describe, it } from "vitest";
+import * as fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 const loobyConfig = {
     id: new Uint8Array([
@@ -48,6 +51,39 @@ describe("many-chat-rooms", () => {
 
         // Check registry size
         expect(await lobby.rooms.index.getSize()).to.eq(1);
+    });
+
+    it("reopens its room index from persisted state", async () => {
+        const directory = await fs.mkdtemp(
+            path.join(os.tmpdir(), "peerbit-many-chat-rooms-")
+        );
+        const id = new Uint8Array(loobyConfig.id);
+
+        try {
+            const firstPeer = await Peerbit.create({ directory });
+            try {
+                const lobby = await firstPeer.open(new Lobby({ id }), {
+                    args: { replicate: false },
+                });
+                await lobby.rooms.put(new Room({ name: "persisted-room" }));
+            } finally {
+                await firstPeer.stop();
+            }
+
+            const secondPeer = await Peerbit.create({ directory });
+            try {
+                const lobby = await secondPeer.open(new Lobby({ id }), {
+                    args: { replicate: false },
+                });
+                expect(
+                    (await lobby.rooms.index.get("persisted-room"))?.name
+                ).to.eq("persisted-room");
+            } finally {
+                await secondPeer.stop();
+            }
+        } finally {
+            await fs.rm(directory, { recursive: true, force: true });
+        }
     });
 
     it("should peer get same rooms", async () => {

--- a/packages/many-chat-rooms/library/src/index.ts
+++ b/packages/many-chat-rooms/library/src/index.ts
@@ -94,6 +94,7 @@ export class Room extends Program<Args> {
     }
 }
 
+@variant("peerbit_example_many_chat_rooms_room_indexable")
 class RoomIndexable {
     @field({ type: "string" })
     name: string;

--- a/packages/media-streaming/streaming-utils/package.json
+++ b/packages/media-streaming/streaming-utils/package.json
@@ -37,6 +37,8 @@
     },
     "devDependencies": {
         "@peerbit/test-utils": "^3.1.0",
+        "@types/sinon": "^20.0.0",
+        "sinon": "^21.0.0",
         "typescript": "^5.6.3"
     },
     "dependencies": {

--- a/packages/name-service/library/src/__tests__/index.integration.test.ts
+++ b/packages/name-service/library/src/__tests__/index.integration.test.ts
@@ -3,6 +3,9 @@ import { Name, Names } from "../index.js";
 import { Ed25519Keypair, PreHash } from "@peerbit/crypto";
 import { randomBytes } from "@peerbit/crypto";
 import { describe, beforeAll, afterAll, test, it, expect } from "vitest";
+import * as fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 describe("index", () => {
     let peer: Peerbit;
@@ -44,5 +47,36 @@ describe("index", () => {
         });
         expect((await names.getName(peer.identity.publicKey))?.name).to.eq("a");
         expect((await names.getName(kp.publicKey))?.name).to.eq("a");
+    });
+
+    it("reopens its index from persisted state", async () => {
+        const directory = await fs.mkdtemp(
+            path.join(os.tmpdir(), "peerbit-name-service-")
+        );
+        const id = randomBytes(32);
+        let publicKey: Ed25519Keypair["publicKey"];
+
+        try {
+            const firstPeer = await Peerbit.create({ directory });
+            try {
+                publicKey = firstPeer.identity.publicKey;
+                const names = await firstPeer.open(new Names({ id }));
+                await names.names.put(new Name(publicKey, "persisted"));
+            } finally {
+                await firstPeer.stop();
+            }
+
+            const secondPeer = await Peerbit.create({ directory });
+            try {
+                const names = await secondPeer.open(new Names({ id }));
+                expect((await names.getName(publicKey))?.name).to.eq(
+                    "persisted"
+                );
+            } finally {
+                await secondPeer.stop();
+            }
+        } finally {
+            await fs.rm(directory, { recursive: true, force: true });
+        }
     });
 });

--- a/packages/name-service/library/src/__tests__/index.integration.test.ts
+++ b/packages/name-service/library/src/__tests__/index.integration.test.ts
@@ -2,7 +2,7 @@ import { Peerbit } from "peerbit";
 import { Name, Names } from "../index.js";
 import { Ed25519Keypair, PreHash } from "@peerbit/crypto";
 import { randomBytes } from "@peerbit/crypto";
-import { describe, beforeAll, afterAll, test, expect } from "vitest";
+import { describe, beforeAll, afterAll, test, it, expect } from "vitest";
 
 describe("index", () => {
     let peer: Peerbit;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -761,6 +761,12 @@ importers:
       '@peerbit/test-utils':
         specifier: ^3.1.0
         version: 3.1.3(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.10)(react@19.2.4))
+      '@types/sinon':
+        specifier: ^20.0.0
+        version: 20.0.0
+      sinon:
+        specifier: ^21.0.0
+        version: 21.1.2
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -3961,6 +3967,12 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@sinonjs/fake-timers@15.4.0':
+    resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
+
+  '@sinonjs/samsam@10.0.2':
+    resolution: {integrity: sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==}
+
   '@sqlite.org/sqlite-wasm@3.51.1-build2':
     resolution: {integrity: sha512-lVPTBlFsEijJ3wuoIbMfC9QMZKfL8huHN8D/lijNKoVxPqUDNvDtXse0wafe7USSmyfKAMb1JZ3ISSr/Vgbn5w==}
     hasBin: true
@@ -4385,6 +4397,12 @@ packages:
 
   '@types/serve-static@1.15.10':
     resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
+
+  '@types/sinon@20.0.0':
+    resolution: {integrity: sha512-etYGUC6IEevDGSWvR9WrECRA01ucR2/Oi9XMBUAdV0g4bLkNf4HlZWGiGlDOq5lgwXRwcV+PSeKgFcW4QzzYOg==}
+
+  '@types/sinonjs__fake-timers@15.0.1':
+    resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -5408,6 +5426,10 @@ packages:
 
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
+    engines: {node: '>=0.3.1'}
+
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -7858,6 +7880,9 @@ packages:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
 
+  sinon@21.1.2:
+    resolution: {integrity: sha512-FS6mN+/bx7e2ajpXkEmOcWB6xBzWiuNoAQT18/+a20SS4U7FSYl8Ms7N6VTUxN/1JAjkx7aXp+THMC8xdpp0gA==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -8242,6 +8267,10 @@ packages:
 
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
 
   type-fest@0.20.2:
@@ -12640,6 +12669,15 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@sinonjs/fake-timers@15.4.0':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/samsam@10.0.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      type-detect: 4.1.0
+
   '@sqlite.org/sqlite-wasm@3.51.1-build2': {}
 
   '@stablelib/binary@2.0.1':
@@ -13103,6 +13141,12 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 20.19.30
       '@types/send': 0.17.6
+
+  '@types/sinon@20.0.0':
+    dependencies:
+      '@types/sinonjs__fake-timers': 15.0.1
+
+  '@types/sinonjs__fake-timers@15.0.1': {}
 
   '@types/stack-utils@2.0.3': {}
 
@@ -14289,6 +14333,8 @@ snapshots:
   devalue@5.6.2: {}
 
   diff@4.0.4: {}
+
+  diff@8.0.4: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -17303,6 +17349,13 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
+  sinon@21.1.2:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 15.4.0
+      '@sinonjs/samsam': 10.0.2
+      diff: 8.0.4
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -17737,6 +17790,8 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-detect@4.0.8: {}
+
+  type-detect@4.1.0: {}
 
   type-fest@0.20.2: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,7 +32,7 @@ const NODE = defineConfig({
         exclude: [
             "**/src/__tests__/**/*.dom.test.ts",
             "**/src/__tests__/**/*.dom.spec.ts",
-            "node_modules",
+            "**/node_modules/**",
             "**/frontend/**",
             "**/*.timestamp-*.mjs",
         ],
@@ -65,7 +65,11 @@ const JSDOM = defineConfig({
             "**/src/__tests__/**/*.dom.test.ts",
             "**/src/__tests__/**/*.dom.spec.ts",
         ],
-        exclude: ["node_modules", "**/frontend/**", "**/*.timestamp-*.mjs"],
+        exclude: [
+            "**/node_modules/**",
+            "**/frontend/**",
+            "**/*.timestamp-*.mjs",
+        ],
         setupFiles: ["vitest.setup.ts", "vitest.setup.dom.ts"],
     },
 });


### PR DESCRIPTION
Repairs the examples root Node test surface and the real runtime defects it exposed.

- excludes nested node_modules trees so Vitest no longer recollects dependency workspaces
- scopes Sinon to streaming-utils and imports Vitest globals explicitly
- gives the many-chat room index projection a stable persisted variant
- adds persisted close/reopen regressions for name-service and many-chat
- resolves Blog authors from signed/indexed query facts so remote non-replicating readers no longer dereference a missing local head
- adds a remote-reader regression proving the source head is absent locally

Validation:
- frozen install
- affected name-service, many-chat, and Blog builds
- focused suite: 4 files, 17 passed
- root Node discovery: 18 real source test files, no nested dependency duplicates
- root Node run now has exactly one remaining failure: MediaStream live one chunk, isolated to core strict-range routing and fixed in a separate core branch