### PR TITLE
fix: harden Cloudflare production deployments

### DIFF
--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -36,6 +36,9 @@ jobs:
             - name: Install workspace dependencies
               run: pnpm install --frozen-lockfile
 
+            - name: Install locked Wrangler toolchain
+              run: npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler
+
             - name: Validate production bootstrap sources
               run: |
                   node scripts/validate-production-bootstrap.mjs
@@ -64,15 +67,12 @@ jobs:
             - name: Ensure the build did not mutate source
               run: git diff --exit-code
 
-            - name: Install locked Wrangler toolchain
-              run: npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler
-
             - name: Validate every Worker bundle
               run: |
                   node scripts/render-cloudflare-configs.mjs --mode preview
                   for config in .wrangler-config/*.jsonc; do
                       output=".wrangler-dry-run/$(basename "$config" .jsonc)"
-                      tools/wrangler/node_modules/.bin/wrangler deploy \
+                      tools/wrangler/node_modules/.bin/wrangler versions upload \
                           --config "$config" \
                           --dry-run \
                           --outdir "$output"

--- a/.github/workflows/cloudflare-production.yml
+++ b/.github/workflows/cloudflare-production.yml
@@ -22,7 +22,6 @@ on:
                 description: Type deploy-peerbit-production
                 required: true
                 type: string
-
 permissions:
     contents: read
 
@@ -56,6 +55,7 @@ jobs:
                   COMMIT_HASH: ${{ github.sha }}
               run: |
                   pnpm install --frozen-lockfile
+                  npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler
                   node scripts/validate-production-bootstrap.mjs
                   node --test cloudflare/*.test.mjs
                   export SHORT_SHA="${GITHUB_SHA::7}"
@@ -74,11 +74,10 @@ jobs:
                   node scripts/prepare-cloudflare-assets.mjs
                   node scripts/validate-owned-domains.mjs
                   git diff --exit-code
-                  npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler
                   node scripts/render-cloudflare-configs.mjs --mode production
                   for config in .wrangler-config/*.jsonc; do
                       output=".wrangler-dry-run/$(basename "$config" .jsonc)"
-                      tools/wrangler/node_modules/.bin/wrangler deploy \
+                      tools/wrangler/node_modules/.bin/wrangler versions upload \
                           --config "$config" \
                           --dry-run \
                           --outdir "$output"
@@ -111,6 +110,7 @@ jobs:
                   COMMIT_HASH: ${{ github.sha }}
               run: |
                   pnpm install --frozen-lockfile
+                  npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler
                   node scripts/validate-production-bootstrap.mjs
                   node --test cloudflare/*.test.mjs
                   export SHORT_SHA="${GITHUB_SHA::7}"
@@ -118,7 +118,6 @@ jobs:
                   node scripts/prepare-cloudflare-assets.mjs
                   node scripts/validate-owned-domains.mjs
                   git diff --exit-code
-                  npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler
                   node scripts/render-cloudflare-configs.mjs --mode production
 
             - name: Install Chromium for transactional runtime checks

--- a/README.md
+++ b/README.md
@@ -119,19 +119,72 @@ node scripts/prepare-cloudflare-assets.mjs
 npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler
 node scripts/render-cloudflare-configs.mjs --mode preview
 for config in .wrangler-config/*.jsonc; do
-    tools/wrangler/node_modules/.bin/wrangler deploy --config "$config" --dry-run
+    tools/wrangler/node_modules/.bin/wrangler versions upload --config "$config" --dry-run
 done
 ```
 
 Production configs are rendered with `--mode production`. First-party demo
-Workers are restricted to `*.apps.peerbit.org`; the legacy redirect remains on
-`peerchecker.com`. Both sets must exactly match the deployment policy.
-Production deploys run one site at a time: capture its current 100% version and
-release identity, deploy, verify the site (including the app-specific Chromium
-gate where one exists), and only then continue. A failed upload or verification
-automatically restores the captured version and verifies the captured release
-identity again. Verification child processes do not inherit the Cloudflare
-credential.
+Workers are restricted to `*.apps.peerbit.org` and must exactly match the
+deployment policy. Before any upload or promotion, production reads the
+account's Worker route inventory and every page of its custom-domain inventory
+with `Workers Scripts Read`. It accepts the custom-domain inventory only after
+two independently read, canonical complete snapshots match. The account-wide
+check requires every reviewed production Worker, including Workers outside a
+targeted release, to have no traditional routes and exactly its reviewed custom
+domain. It also reads each production Worker's live `workers.dev` and version
+Preview URL state, plus that state for every existing allowlisted preview
+Worker, and requires both flags to be disabled. It rejects retired Worker
+identities, unreviewed ownership under `*.apps.peerbit.org`, and traditional
+routes involving the managed namespace; unrelated account Workers and domains
+remain outside this policy. The full read-only policy fence runs immediately
+before and after every inactive upload. Wrangler output is captured rather than
+echoed, and an unexpected `workers.dev` URL fails closed without exposing the
+account subdomain. Production deploys capture every selected app's current 100%
+version, release identity, and immutable Worker identity. They then upload every
+new version without activating it, verify its per-invocation version tag, and
+revalidate every baseline before promoting traffic. Exact versions are promoted
+through Cloudflare's deployments API; that endpoint cannot alter routes or
+custom domains. After every runtime check, all activated apps receive a final
+exact version, version-tag, Worker-tag, public-subdomain, and attachment recheck.
+If a later promotion or verification fails, earlier versions from the invocation
+are unwound in reverse order only while each exact version, version tag, Worker
+identity, and public attachment still match. After the rollback verifier, the
+workflow repeats the full account policy and Worker-tag checks, then reads the
+active deployment last before reporting success. Verification child processes
+do not inherit the Cloudflare credential.
+
+Cloudflare's deployments API does not currently expose an atomic
+compare-and-swap precondition for the active version. The workflow revalidates
+ownership immediately before every promotion and rollback and refuses
+automatic recovery after an observed external change, but an external
+deployment in the final interval between that read and Cloudflare accepting the
+deployment POST cannot be eliminated client-side. Serialize production
+deployments through the protected GitHub environment and inspect Cloudflare
+manually if the workflow reports an ownership race.
+
+The public-subdomain API has the same unavoidable last-read interval: an
+external actor can enable `workers.dev` or Preview URLs after the final GET but
+before Cloudflare accepts a version upload. The route-free upload config sets
+both options to false, captured Wrangler output refuses to print an unexpected
+Preview URL, and the workflow rereads live state immediately afterward, but
+Cloudflare does not expose an atomic upload precondition for these settings.
+
+A deployment POST can also be accepted even when Cloudflare returns an error or
+an unusable response. Once Create Deployment has been dispatched, every
+response failure—including 4xx/5xx responses, malformed or empty bodies, and
+invalid exact-version success evidence—is therefore treated as indeterminate.
+Local validation before dispatch remains determinate. The workflow observes a
+bounded settlement window instead of trusting one baseline read, verifies the
+baseline, reads it once more, and rolls back if this invocation's tagged version
+appears. If it never appears during that window, the workflow still does not
+declare the baseline safe, because the POST could land later. Automatic
+recovery remains disabled and the workflow preserves both the primary and
+recovery diagnostics for manual inspection.
+
+A rollback POST has the same response and visibility ambiguity. Once it is
+dispatched, a later read or verifier failure is reported as failed confirmation
+of a possibly applied rollback, not as a refused rollback. Operators must inspect
+the exact active version and public attachment state before retrying.
 
 Cloudflare version rollback does not revert attached resources. Treat a change
 to the exact hostname policy as a separate provisioning migration with its own

--- a/cloudflare/deployment-safety.test.mjs
+++ b/cloudflare/deployment-safety.test.mjs
@@ -699,34 +699,64 @@ test("Worker subdomain API failures redact complete workers.dev references", asy
     const accountId = "d".repeat(32);
     const apiToken = "redact-this-token";
     const longTail = "x".repeat(600);
+    const httpError = (reference) =>
+        new Response(
+            JSON.stringify({
+                success: false,
+                errors: [
+                    {
+                        code: 10000,
+                        message: `${reference} token ${apiToken} account ${accountId} ${longTail}`,
+                    },
+                ],
+            }),
+            { status: 403 }
+        );
     const fixtures = [
         {
             name: "HTTP error payload",
             reference:
                 "https://v-worker.private-account-slug.workers.dev/path?x=1",
-            request: (reference) =>
-                new Response(
-                    JSON.stringify({
-                        success: false,
-                        errors: [
-                            {
-                                code: 10000,
-                                message: `${reference} token ${apiToken} account ${accountId} ${longTail}`,
-                            },
-                        ],
-                    }),
-                    { status: 403 }
-                ),
+            privateParts: ["v-worker", "private-account-slug", "/path?x=1"],
+            request: httpError,
         },
         {
             name: "mixed-case transport error",
             reference:
                 "HTTPS://V-WorKer.Private-Account-Slug.WoRkErS.DeV:8787/Private-Path?Secret-Query=1#Private-Fragment",
+            privateParts: [
+                "v-worker",
+                "private-account-slug",
+                "8787",
+                "private-path",
+                "secret-query",
+                "private-fragment",
+            ],
             request: (reference) => {
                 throw new Error(
                     `${reference} token ${apiToken} account ${accountId} ${longTail}`
                 );
             },
+        },
+        {
+            name: "terminal dot before URL path",
+            reference:
+                "https://v-worker.private-account-slug.workers.dev./path?x=1#f",
+            privateParts: ["v-worker", "private-account-slug", "/path?x=1#f"],
+            request: httpError,
+        },
+        {
+            name: "bare hostname with terminal dot",
+            reference: "v-worker.private-account-slug.workers.dev.",
+            privateParts: ["v-worker", "private-account-slug"],
+            request: httpError,
+        },
+        {
+            name: "terminal dot before numeric port",
+            reference:
+                "https://v-worker.private-account-slug.workers.dev.:8787/path",
+            privateParts: ["v-worker", "private-account-slug", "8787", "/path"],
+            request: httpError,
         },
     ];
 
@@ -751,12 +781,7 @@ test("Worker subdomain API failures redact complete workers.dev references", asy
             assert.doesNotMatch(normalizedMessage, /workers\.dev/i);
             for (const privateValue of [
                 fixture.reference,
-                "v-worker",
-                "private-account-slug",
-                "8787",
-                "private-path",
-                "secret-query",
-                "private-fragment",
+                ...fixture.privateParts,
                 apiToken,
                 accountId,
             ]) {
@@ -769,6 +794,47 @@ test("Worker subdomain API failures redact complete workers.dev references", asy
             }
             assert.equal(failure.details.indeterminateMutation, false);
         });
+    }
+});
+
+test("Worker subdomain API diagnostics preserve non-workers.dev boundaries", async () => {
+    const visibleReferences = [
+        "notworkers.dev",
+        "workers.dev.evil",
+        "workers.dev-example.com",
+        "workers.devil",
+    ];
+    const api = createCloudflareWorkersApi({
+        accountId: "d".repeat(32),
+        apiToken: "test-token_123",
+        request: async () =>
+            new Response(
+                JSON.stringify({
+                    success: false,
+                    errors: [
+                        {
+                            message: visibleReferences.join(" "),
+                        },
+                    ],
+                }),
+                { status: 400 }
+            ),
+    });
+    let failure;
+    try {
+        await api.getWorkerSubdomain("peerbit-examples-files");
+    } catch (error) {
+        failure = error;
+    }
+
+    assert.ok(failure instanceof CloudflareWorkersApiError);
+    const normalizedMessage = failure.details.errors[0].message;
+    assert.doesNotMatch(
+        normalizedMessage,
+        /\[REDACTED_WORKERS_DEV_REFERENCE\]/
+    );
+    for (const reference of visibleReferences) {
+        assert.equal(normalizedMessage.includes(reference), true);
     }
 });
 

--- a/cloudflare/deployment-safety.test.mjs
+++ b/cloudflare/deployment-safety.test.mjs
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import test from "node:test";
 import {
     loadCloudflareDeploymentData,
@@ -9,20 +11,72 @@ import {
     validateRenderedCloudflareConfig,
 } from "../scripts/cloudflare-deployment-policy.mjs";
 import {
-    deployProductionEntries,
+    createRouteFreeWranglerConfig,
+    deployProductionEntries as deployProductionEntriesWithPolicy,
+    parseWranglerVersionUploadOutput,
+    parseProductionDeploymentArgs,
     productionSmokeEnvironment,
     readBaselineReleaseCommit,
     readSingleVersionDeployment,
+    removeTemporaryWranglerOutput,
+    runCloudflareCapturedJson,
+    runCloudflareLogged,
+    runWranglerVersionUpload,
     withoutCloudflareDeploymentCredentials,
 } from "../scripts/deploy-cloudflare-production.mjs";
+import {
+    CloudflareWorkersApiError,
+    createCloudflareWorkersApi,
+    redactCloudflareCredentials,
+} from "../scripts/cloudflare-workers-api.mjs";
 
 const clone = (value) => structuredClone(value);
 const COMMIT = "a".repeat(40);
 const OLD_COMMIT = "b".repeat(40);
 const OLD_VERSION = "11111111-1111-4111-8111-111111111111";
 const NEW_VERSION = "22222222-2222-4222-8222-222222222222";
+const ZONE_ID = "e".repeat(32);
+const WORKER_TAGS = new Map([
+    ["files", "files-tag-11111111"],
+    ["stream", "stream-tag-22222222"],
+]);
+const CLOUDFLARE_CREDENTIALS = {
+    CLOUDFLARE_ACCOUNT_ID: "account-id-secret",
+    CLOUDFLARE_API_TOKEN: "api-token-secret",
+    CLOUDFLARE_API_KEY: "api-key-secret",
+    CLOUDFLARE_EMAIL: "email-secret",
+    CLOUDFLARE_ACCESS_CLIENT_ID: "access-client-id-secret",
+    CLOUDFLARE_ACCESS_CLIENT_SECRET: "access-client-secret",
+    CLOUDFLARE_SERVICE_TOKEN_ID: "service-token-id-secret",
+    CLOUDFLARE_SERVICE_TOKEN_SECRET: "service-token-secret",
+    CF_ACCOUNT_ID: "legacy-account-secret",
+    CF_API_TOKEN: "legacy-token-secret",
+    CF_API_KEY: "legacy-key-secret",
+    CF_EMAIL: "legacy-email-secret",
+    CF_API_BASE_URL: "legacy-base-url-secret",
+    WRANGLER_CF_AUTHORIZATION_TOKEN: "wrangler-cf-auth-secret",
+    WRANGLER_R2_SQL_AUTH_TOKEN: "r2-sql-secret",
+};
 const deployment = (versionId, percentage = 100) => ({
     versions: [{ version_id: versionId, percentage }],
+});
+const workerDomain = (id, overrides = {}) => ({
+    id: "domain-" + id,
+    hostname: id + ".apps.peerbit.org",
+    service: "peerbit-examples-" + id,
+    environment: "production",
+    zoneId: ZONE_ID,
+    zoneName: "peerbit.org",
+    ...overrides,
+});
+const rawWorkerDomain = (id, overrides = {}) => ({
+    id: "domain-" + id,
+    hostname: id + ".example.com",
+    service: "unrelated-worker-" + id,
+    environment: "production",
+    zone_id: ZONE_ID,
+    zone_name: "example.com",
+    ...overrides,
 });
 
 test("production Workers and hostnames are an exact reviewed allowlist", () => {
@@ -78,6 +132,18 @@ test("preview and production Worker identities cannot overlap", () => {
         () => validateCloudflareDeploymentPolicy(manifest, crossed),
         /preview and production Workers must differ/
     );
+});
+
+test("reviewed Worker identities stay inside the managed namespace", () => {
+    const { manifest, policy } = loadCloudflareDeploymentData();
+    for (const field of ["productionWorker", "previewWorker"]) {
+        const changed = clone(policy);
+        changed.entries[0][field] = "unrelated-account-worker";
+        assert.throws(
+            () => validateCloudflareDeploymentPolicy(manifest, changed),
+            /inside the reviewed peerbit-examples- namespace/
+        );
+    }
 });
 
 test("public previews are disabled", () => {
@@ -212,14 +278,220 @@ test("deployment status must provide one rollbackable version at 100%", () => {
     );
 });
 
+const wranglerVersionUploadRecord = (overrides = {}) =>
+    JSON.stringify({
+        type: "version-upload",
+        version: 1,
+        worker_name: "peerbit-examples-files",
+        worker_tag: WORKER_TAGS.get("files"),
+        version_id: NEW_VERSION,
+        worker_name_overridden: false,
+        ...overrides,
+    });
+
+test("Wrangler structured output provides exact inactive-version ownership evidence", () => {
+    assert.deepEqual(
+        parseWranglerVersionUploadOutput(
+            `${JSON.stringify({ type: "wrangler-session", version: 1 })}\n${wranglerVersionUploadRecord()}\n`,
+            "peerbit-examples-files"
+        ),
+        {
+            workerName: "peerbit-examples-files",
+            workerTag: WORKER_TAGS.get("files"),
+            versionId: NEW_VERSION,
+        }
+    );
+    for (const [output, pattern] of [
+        ["", /exactly one version-upload record/],
+        ["null", /not valid NDJSON/],
+        [
+            `${wranglerVersionUploadRecord()}\n${wranglerVersionUploadRecord()}`,
+            /exactly one version-upload record/,
+        ],
+        [
+            wranglerVersionUploadRecord({
+                worker_name: "peerbit-examples-stream",
+            }),
+            /invalid deployment ownership evidence/,
+        ],
+        [
+            wranglerVersionUploadRecord({ worker_tag: "bad tag" }),
+            /invalid deployment ownership evidence/,
+        ],
+        [
+            wranglerVersionUploadRecord({ version_id: "not-a-version" }),
+            /invalid deployment ownership evidence/,
+        ],
+        [
+            wranglerVersionUploadRecord({ worker_name_overridden: true }),
+            /unsupported identity metadata/,
+        ],
+    ]) {
+        assert.throws(
+            () =>
+                parseWranglerVersionUploadOutput(
+                    output,
+                    "peerbit-examples-files"
+                ),
+            pattern
+        );
+    }
+
+    const accountSlug = "private-account-slug";
+    let previewFailure;
+    try {
+        parseWranglerVersionUploadOutput(
+            wranglerVersionUploadRecord({
+                preview_url: `https://version-files.${accountSlug}.workers.dev`,
+            }),
+            "peerbit-examples-files"
+        );
+    } catch (error) {
+        previewFailure = error;
+    }
+    assert.ok(previewFailure instanceof Error);
+    assert.match(previewFailure.message, /unexpected workers\.dev/);
+    assert.doesNotMatch(previewFailure.message, new RegExp(accountSlug));
+});
+
 test("verification children do not receive Cloudflare deployment credentials", () => {
     assert.deepEqual(
         withoutCloudflareDeploymentCredentials({
             PATH: "/bin",
-            CLOUDFLARE_API_TOKEN: "secret",
-            CLOUDFLARE_ACCOUNT_ID: "account",
+            PW_BASE_URL: "https://files.apps.peerbit.org",
+            ...CLOUDFLARE_CREDENTIALS,
         }),
-        { PATH: "/bin" }
+        {
+            PATH: "/bin",
+            PW_BASE_URL: "https://files.apps.peerbit.org",
+        }
+    );
+    const failure = redactCloudflareCredentials(
+        `failed for ${Object.values(CLOUDFLARE_CREDENTIALS).join(" ")}`,
+        CLOUDFLARE_CREDENTIALS
+    );
+    for (const secret of Object.values(CLOUDFLARE_CREDENTIALS)) {
+        assert.doesNotMatch(failure, new RegExp(secret));
+    }
+    assert.equal(
+        failure.match(/\[REDACTED\]/g)?.length,
+        Object.keys(CLOUDFLARE_CREDENTIALS).length
+    );
+    const longFailure = redactCloudflareCredentials(
+        `${"x".repeat(600)} ${CLOUDFLARE_CREDENTIALS.CLOUDFLARE_API_TOKEN}`,
+        CLOUDFLARE_CREDENTIALS
+    );
+    assert.ok(longFailure.length > 600);
+    assert.doesNotMatch(longFailure, /api-token-secret/);
+    assert.match(longFailure, /\[REDACTED\]$/);
+
+    const accountId = "0123456789abcdef0123456789abcdef";
+    const overlappingToken = `${accountId}-TOKEN-SUFFIX`;
+    assert.equal(
+        redactCloudflareCredentials(overlappingToken, {
+            CLOUDFLARE_ACCOUNT_ID: accountId,
+            CLOUDFLARE_API_TOKEN: overlappingToken,
+            CF_API_TOKEN: overlappingToken,
+        }),
+        "[REDACTED]"
+    );
+});
+
+test("credentialed Wrangler logs and spawn errors never expose Cloudflare credentials", () => {
+    const secretText = Object.values(CLOUDFLARE_CREDENTIALS).join(" ");
+    let stdout = "";
+    let stderr = "";
+    assert.throws(
+        () =>
+            runCloudflareLogged(
+                "/tools/wrangler",
+                ["deploy"],
+                CLOUDFLARE_CREDENTIALS,
+                {
+                    run: () => ({
+                        stdout: `stdout ${secretText}`,
+                        stderr: `stderr ${secretText}`,
+                        status: 1,
+                    }),
+                    writeStdout: (value) => {
+                        stdout += value;
+                    },
+                    writeStderr: (value) => {
+                        stderr += value;
+                    },
+                }
+            ),
+        /wrangler deploy exited 1/
+    );
+    for (const secret of Object.values(CLOUDFLARE_CREDENTIALS)) {
+        assert.doesNotMatch(stdout, new RegExp(secret));
+        assert.doesNotMatch(stderr, new RegExp(secret));
+    }
+
+    let spawnFailure;
+    try {
+        runCloudflareLogged(
+            "/tools/wrangler",
+            ["deploy"],
+            CLOUDFLARE_CREDENTIALS,
+            {
+                run: () => ({
+                    stdout: "",
+                    stderr: "",
+                    error: new Error(`spawn failed ${secretText}`),
+                }),
+            }
+        );
+    } catch (error) {
+        spawnFailure = error;
+    }
+    assert.ok(spawnFailure instanceof Error);
+    for (const secret of Object.values(CLOUDFLARE_CREDENTIALS)) {
+        assert.doesNotMatch(spawnFailure.message, new RegExp(secret));
+    }
+});
+
+test("temporary Wrangler output cleanup never masks the deployment result", () => {
+    let warning = "";
+    assert.doesNotThrow(() =>
+        removeTemporaryWranglerOutput(
+            "/tmp/private-output",
+            CLOUDFLARE_CREDENTIALS,
+            {
+                remove: () => {
+                    throw new Error(
+                        `cleanup failed ${CLOUDFLARE_CREDENTIALS.CLOUDFLARE_API_TOKEN}`
+                    );
+                },
+                writeWarning: (value) => {
+                    warning = value;
+                },
+            }
+        )
+    );
+    assert.match(
+        warning,
+        /could not remove temporary Wrangler deployment output/
+    );
+    assert.match(warning, /\[REDACTED\]/);
+    assert.doesNotMatch(
+        warning,
+        new RegExp(CLOUDFLARE_CREDENTIALS.CLOUDFLARE_API_TOKEN)
+    );
+
+    assert.doesNotThrow(() =>
+        removeTemporaryWranglerOutput(
+            "/tmp/private-output",
+            {},
+            {
+                remove: () => {
+                    throw new Error("cleanup failed");
+                },
+                writeWarning: () => {
+                    throw new Error("stderr unavailable");
+                },
+            }
+        )
     );
 });
 
@@ -264,47 +536,985 @@ test("captures a full baseline release commit from the production app", async ()
     );
 });
 
+test("Cloudflare Workers API lists the configured account exactly", async () => {
+    const accountId = "c".repeat(32);
+    const apiToken = "test-token_123";
+    const workerName = "peerbit-examples-files";
+    const requests = [];
+    const api = createCloudflareWorkersApi({
+        accountId,
+        apiToken,
+        request: async (url, init) => {
+            requests.push({ url, init });
+            return new Response(
+                JSON.stringify({
+                    success: true,
+                    result: [
+                        {
+                            id: workerName,
+                            tag: WORKER_TAGS.get("files"),
+                            routes: [],
+                        },
+                        {
+                            id: "unrelated-account-worker",
+                            tag: "unrelated-worker-tag",
+                            routes: [],
+                        },
+                    ],
+                }),
+                { status: 200 }
+            );
+        },
+    });
+
+    assert.deepEqual(
+        [...(await api.listWorkerScripts())],
+        [
+            [workerName, { tag: WORKER_TAGS.get("files"), routes: [] }],
+            [
+                "unrelated-account-worker",
+                { tag: "unrelated-worker-tag", routes: [] },
+            ],
+        ]
+    );
+
+    const scriptsUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/scripts`;
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].url, scriptsUrl);
+    assert.equal(requests[0].init.method, "GET");
+    assert.equal(requests[0].init.headers.Authorization, `Bearer ${apiToken}`);
+
+    assert.throws(
+        () =>
+            createCloudflareWorkersApi({
+                accountId: "wrong-account",
+                apiToken,
+            }),
+        /exactly 32 hexadecimal characters/
+    );
+});
+
+test("Cloudflare Workers API reads exact workers.dev and Preview URL state", async () => {
+    const accountId = "c".repeat(32);
+    const apiToken = "test-token_123";
+    const workerName = "peerbit-examples-files";
+    const requests = [];
+    const api = createCloudflareWorkersApi({
+        accountId,
+        apiToken,
+        request: async (url, init) => {
+            requests.push({ url, init });
+            return new Response(
+                JSON.stringify({
+                    success: true,
+                    result: { enabled: false, previews_enabled: false },
+                }),
+                { status: 200 }
+            );
+        },
+    });
+
+    assert.deepEqual(await api.getWorkerSubdomain(workerName), {
+        enabled: false,
+        previewsEnabled: false,
+    });
+    assert.equal(requests.length, 1);
+    assert.equal(
+        requests[0].url,
+        `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/scripts/${workerName}/subdomain`
+    );
+    assert.equal(requests[0].init.method, "GET");
+    assert.equal("body" in requests[0].init, false);
+    assert.equal(requests[0].init.headers.Authorization, `Bearer ${apiToken}`);
+});
+
+test("Worker subdomain API ambiguity and authorization failures fail closed", async () => {
+    const accountId = "c".repeat(32);
+    const apiToken = "test-token_123";
+    const responses = [
+        () => new Response("{", { status: 200 }),
+        () =>
+            new Response(JSON.stringify({ success: true }), {
+                status: 200,
+            }),
+        () =>
+            new Response(
+                JSON.stringify({
+                    success: true,
+                    result: { enabled: false },
+                }),
+                { status: 200 }
+            ),
+        () =>
+            new Response(
+                JSON.stringify({
+                    success: true,
+                    result: {
+                        enabled: false,
+                        previews_enabled: "false",
+                    },
+                }),
+                { status: 200 }
+            ),
+        () =>
+            new Response(
+                JSON.stringify({
+                    success: true,
+                    result: {
+                        enabled: false,
+                        previews_enabled: false,
+                        account_subdomain: "must-not-be-accepted",
+                    },
+                }),
+                { status: 200 }
+            ),
+        () =>
+            new Response(
+                JSON.stringify({
+                    success: false,
+                    errors: [{ code: 10000, message: "unauthorized" }],
+                }),
+                { status: 403 }
+            ),
+    ];
+
+    for (const request of responses) {
+        const api = createCloudflareWorkersApi({
+            accountId,
+            apiToken,
+            request,
+        });
+        await assert.rejects(
+            api.getWorkerSubdomain("peerbit-examples-files"),
+            (error) =>
+                error instanceof CloudflareWorkersApiError &&
+                error.details.operation.includes(
+                    "workers.dev and Preview URL state"
+                )
+        );
+    }
+});
+
+test("Cloudflare Workers API exhausts read-only custom-domain pagination", async () => {
+    const accountId = "c".repeat(32);
+    const apiToken = "test-token_123";
+    const requests = [];
+    const rawDomains = [
+        {
+            id: "domain-files",
+            hostname: "FILES.APPS.PEERBIT.ORG",
+            service: "peerbit-examples-files",
+            environment: "production",
+            zone_id: ZONE_ID,
+            zone_name: "peerbit.org",
+        },
+        {
+            id: "domain-stream",
+            hostname: "stream.apps.peerbit.org",
+            service: "peerbit-examples-stream",
+            environment: "production",
+            zone_id: ZONE_ID,
+            zone_name: "peerbit.org",
+        },
+    ];
+    const api = createCloudflareWorkersApi({
+        accountId,
+        apiToken,
+        request: async (url, init) => {
+            requests.push({ url, init });
+            const page = Number(new URL(url).searchParams.get("page"));
+            return new Response(
+                JSON.stringify({
+                    success: true,
+                    result: [rawDomains[page - 1]],
+                    result_info: {
+                        count: 1,
+                        page,
+                        per_page: 1,
+                        total_count: 2,
+                        total_pages: 2,
+                    },
+                }),
+                { status: 200 }
+            );
+        },
+    });
+
+    assert.deepEqual(await api.listWorkerDomains(), [
+        workerDomain("files"),
+        workerDomain("stream"),
+    ]);
+    assert.deepEqual(
+        requests.map(({ url, init }) => [url, init.method]),
+        [
+            [
+                `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/domains?page=1&per_page=100`,
+                "GET",
+            ],
+            [
+                `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/domains?page=2&per_page=100`,
+                "GET",
+            ],
+            [
+                `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/domains?page=1&per_page=100`,
+                "GET",
+            ],
+            [
+                `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/domains?page=2&per_page=100`,
+                "GET",
+            ],
+        ]
+    );
+    for (const { init } of requests) {
+        assert.equal(init.headers.Authorization, `Bearer ${apiToken}`);
+        assert.equal("body" in init, false);
+    }
+});
+
+test("custom-domain pagination discards a constant-total hybrid snapshot", async () => {
+    const accountId = "c".repeat(32);
+    const apiToken = "test-token_123";
+    const alpha = rawWorkerDomain("alpha");
+    const bravo = rawWorkerDomain("bravo");
+    const charlie = rawWorkerDomain("charlie");
+    const delta = rawWorkerDomain("delta");
+    const echo = rawWorkerDomain("echo");
+    const snapshots = [
+        [
+            [alpha, bravo],
+            [delta, echo],
+        ],
+        [
+            [bravo, charlie],
+            [delta, echo],
+        ],
+        [
+            [bravo, charlie],
+            [delta, echo],
+        ],
+    ];
+    let requests = 0;
+    const api = createCloudflareWorkersApi({
+        accountId,
+        apiToken,
+        request: async (url) => {
+            const page = Number(new URL(url).searchParams.get("page"));
+            const snapshot = snapshots[Math.floor(requests / 2)];
+            requests += 1;
+            return new Response(
+                JSON.stringify({
+                    success: true,
+                    result: snapshot[page - 1],
+                    result_info: {
+                        count: 2,
+                        page,
+                        per_page: 2,
+                        total_count: 4,
+                        total_pages: 2,
+                    },
+                }),
+                { status: 200 }
+            );
+        },
+    });
+
+    assert.deepEqual(
+        (await api.listWorkerDomains()).map(({ id }) => id),
+        ["domain-bravo", "domain-charlie", "domain-delta", "domain-echo"]
+    );
+    assert.equal(requests, 6);
+});
+
+test("custom-domain pagination fails closed when complete snapshots keep churning", async () => {
+    const accountId = "c".repeat(32);
+    const apiToken = "test-token_123";
+    const alpha = rawWorkerDomain("alpha");
+    const bravo = rawWorkerDomain("bravo");
+    const charlie = rawWorkerDomain("charlie");
+    const delta = rawWorkerDomain("delta");
+    const echo = rawWorkerDomain("echo");
+    const snapshots = [
+        [
+            [alpha, bravo],
+            [delta, echo],
+        ],
+        [
+            [bravo, charlie],
+            [delta, echo],
+        ],
+    ];
+    let requests = 0;
+    const api = createCloudflareWorkersApi({
+        accountId,
+        apiToken,
+        request: async (url) => {
+            const page = Number(new URL(url).searchParams.get("page"));
+            const snapshot = snapshots[Math.floor(requests / 2) % 2];
+            requests += 1;
+            return new Response(
+                JSON.stringify({
+                    success: true,
+                    result: snapshot[page - 1],
+                    result_info: {
+                        count: 2,
+                        page,
+                        per_page: 2,
+                        total_count: 4,
+                        total_pages: 2,
+                    },
+                }),
+                { status: 200 }
+            );
+        },
+    });
+
+    await assert.rejects(
+        api.listWorkerDomains(),
+        /did not remain stable across complete snapshots/
+    );
+    assert.equal(requests, 6);
+});
+
+test("custom-domain pagination and API ambiguity fail closed", async () => {
+    const accountId = "c".repeat(32);
+    const apiToken = "test-token_123";
+    const responses = [
+        () =>
+            new Response(
+                JSON.stringify({
+                    success: false,
+                    errors: [{ code: 10000, message: "forbidden" }],
+                }),
+                { status: 403 }
+            ),
+        () =>
+            new Response(JSON.stringify({ success: true, result: [] }), {
+                status: 200,
+            }),
+        (url) => {
+            const page = Number(new URL(url).searchParams.get("page"));
+            return new Response(
+                JSON.stringify({
+                    success: true,
+                    result: [
+                        {
+                            id: "domain-" + page,
+                            hostname: "duplicate.apps.peerbit.org",
+                            service: "peerbit-examples-files",
+                            environment: "production",
+                            zone_id: ZONE_ID,
+                            zone_name: "peerbit.org",
+                        },
+                    ],
+                    result_info: {
+                        count: 1,
+                        page,
+                        per_page: 1,
+                        total_count: 2,
+                        total_pages: 2,
+                    },
+                }),
+                { status: 200 }
+            );
+        },
+        () =>
+            new Response(
+                JSON.stringify({
+                    success: true,
+                    result: [
+                        rawWorkerDomain("retired", {
+                            hostname: "retired.apps.peerbit.org.",
+                        }),
+                    ],
+                    result_info: {
+                        count: 1,
+                        page: 1,
+                        per_page: 100,
+                        total_count: 1,
+                        total_pages: 1,
+                    },
+                }),
+                { status: 200 }
+            ),
+    ];
+
+    for (const request of responses) {
+        const api = createCloudflareWorkersApi({
+            accountId,
+            apiToken,
+            request,
+        });
+        await assert.rejects(
+            api.listWorkerDomains(),
+            (error) =>
+                error instanceof CloudflareWorkersApiError &&
+                error.details.operation === "list account Worker custom domains"
+        );
+    }
+});
+
+test("attachment inventory source contract is account-scoped and read-only", () => {
+    const source = readFileSync(
+        path.join(repoRoot, "scripts/cloudflare-workers-api.mjs"),
+        "utf8"
+    );
+    assert.match(
+        source,
+        /const domainsUrl = `\$\{CLOUDFLARE_API_BASE_URL\}\/accounts\/\$\{accountId\}\/workers\/domains`/
+    );
+    const domainsStart = source.indexOf("listWorkerDomains: async");
+    const domainsEnd = source.indexOf(
+        "getCurrentDeployment: async",
+        domainsStart
+    );
+    const domainInventory = source.slice(domainsStart, domainsEnd);
+    assert.ok(domainsStart >= 0 && domainsEnd > domainsStart);
+    assert.match(domainInventory, /domainsUrl/);
+    assert.doesNotMatch(domainInventory, /method\s*:|body\s*:/);
+    const subdomainStart = source.indexOf("getWorkerSubdomain: async");
+    const subdomainEnd = source.indexOf(
+        "getCurrentDeployment: async",
+        subdomainStart
+    );
+    const subdomainInventory = source.slice(subdomainStart, subdomainEnd);
+    assert.ok(subdomainStart >= 0 && subdomainEnd > subdomainStart);
+    assert.match(subdomainInventory, /\/subdomain/);
+    assert.doesNotMatch(subdomainInventory, /method\s*:|body\s*:/);
+    assert.match(source, /for \(const route of script\.routes\)/);
+    assert.doesNotMatch(source, /\/zones\/\$\{[^}]+\}\/workers\/routes/);
+});
+
+test("Cloudflare Workers API reads versions and changes traffic only through deployments", async () => {
+    const accountId = "c".repeat(32);
+    const apiToken = "test-token_123";
+    const workerName = "peerbit-examples-files";
+    const requests = [];
+    const api = createCloudflareWorkersApi({
+        accountId,
+        apiToken,
+        request: async (url, init) => {
+            requests.push({ url, init });
+            const isPost = init.method === "POST";
+            if (url.endsWith("/versions/" + NEW_VERSION)) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: {
+                            id: NEW_VERSION,
+                            annotations: { "workers/tag": "invocation-tag" },
+                        },
+                    }),
+                    { status: 200 }
+                );
+            }
+            if (url.endsWith("/deployments") && !isPost) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: { deployments: [deployment(OLD_VERSION)] },
+                    }),
+                    { status: 200 }
+                );
+            }
+            if (url.endsWith("/deployments") && isPost) {
+                const body = JSON.parse(init.body);
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: {
+                            id: "44444444-4444-4444-8444-444444444444",
+                            strategy: "percentage",
+                            versions: body.versions,
+                        },
+                    }),
+                    { status: 200 }
+                );
+            }
+            return new Response("not found", { status: 404 });
+        },
+    });
+
+    assert.equal(
+        (await api.getWorkerVersion(workerName, NEW_VERSION)).id,
+        NEW_VERSION
+    );
+    assert.deepEqual(
+        await api.getCurrentDeployment(workerName),
+        deployment(OLD_VERSION)
+    );
+    assert.deepEqual(
+        await api.createDeployment({
+            workerName,
+            versionId: NEW_VERSION,
+            message: "promote exact version",
+        }),
+        {
+            id: "44444444-4444-4444-8444-444444444444",
+            strategy: "percentage",
+            versions: [{ version_id: NEW_VERSION, percentage: 100 }],
+        }
+    );
+    assert.equal(
+        (
+            await api.createDeployment({
+                workerName,
+                versionId: OLD_VERSION,
+                message: "rollback exact version",
+            })
+        ).versions[0].version_id,
+        OLD_VERSION
+    );
+
+    const resourceRoot = `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/scripts/${workerName}`;
+    assert.deepEqual(
+        requests.map(({ url, init }) => [url, init.method]),
+        [
+            [resourceRoot + "/versions/" + NEW_VERSION, "GET"],
+            [resourceRoot + "/deployments", "GET"],
+            [resourceRoot + "/deployments", "POST"],
+            [resourceRoot + "/deployments", "POST"],
+        ]
+    );
+    const promotion = JSON.parse(requests[2].init.body);
+    assert.deepEqual(promotion, {
+        strategy: "percentage",
+        versions: [{ version_id: NEW_VERSION, percentage: 100 }],
+        annotations: {
+            "workers/message": "promote exact version",
+            "workers/triggered_by": "peerbit-production-workflow",
+        },
+    });
+    for (const { url } of requests) {
+        assert.doesNotMatch(url, /routes|domains|subdomain|zones/);
+    }
+});
+
+const ambiguousDeploymentResponseCases = [
+    {
+        name: "well-formed 400 response",
+        status: 400,
+        response: () =>
+            new Response(
+                JSON.stringify({
+                    success: false,
+                    errors: [{ code: 1000, message: "request rejected" }],
+                }),
+                { status: 400 }
+            ),
+    },
+    {
+        name: "500 response",
+        status: 500,
+        response: () =>
+            new Response(
+                JSON.stringify({
+                    success: false,
+                    errors: [{ code: 1001, message: "internal error" }],
+                }),
+                { status: 500 }
+            ),
+    },
+    {
+        name: "malformed 200 response",
+        status: 200,
+        response: () => new Response("{", { status: 200 }),
+    },
+    {
+        name: "empty 200 response",
+        status: 200,
+        response: () => new Response("", { status: 200 }),
+    },
+    {
+        name: "invalid exact-version 200 evidence",
+        status: 200,
+        response: () =>
+            new Response(
+                JSON.stringify({
+                    success: true,
+                    result: {
+                        id: "44444444-4444-4444-8444-444444444444",
+                        strategy: "percentage",
+                        versions: [
+                            { version_id: OLD_VERSION, percentage: 100 },
+                        ],
+                    },
+                }),
+                { status: 200 }
+            ),
+    },
+];
+
+const captureAmbiguousDeploymentResponse = async (response) => {
+    const accountId = "c".repeat(32);
+    const apiToken = "test-token_123";
+    let requestInit;
+    const api = createCloudflareWorkersApi({
+        accountId,
+        apiToken,
+        request: async (_url, init) => {
+            requestInit = init;
+            return response();
+        },
+    });
+    let failure;
+    try {
+        await api.createDeployment({
+            workerName: "peerbit-examples-files",
+            versionId: NEW_VERSION,
+            message: "promote exact version",
+        });
+    } catch (error) {
+        failure = error;
+    }
+    return { failure, requestInit };
+};
+
+test("every Create Deployment response failure is indeterminate after POST dispatch", async (t) => {
+    for (const fixture of ambiguousDeploymentResponseCases) {
+        await t.test(fixture.name, async () => {
+            const { failure, requestInit } =
+                await captureAmbiguousDeploymentResponse(fixture.response);
+            assert.ok(failure instanceof CloudflareWorkersApiError);
+            assert.equal(failure.details.status, fixture.status);
+            assert.equal(failure.details.indeterminateMutation, true);
+            assert.equal(failure.indeterminateMutation, true);
+            assert.equal(requestInit.method, "POST");
+        });
+    }
+});
+
+test("Create Deployment local validation failures remain determinate and dispatch nothing", async () => {
+    let requests = 0;
+    const api = createCloudflareWorkersApi({
+        accountId: "c".repeat(32),
+        apiToken: "test-token_123",
+        request: async () => {
+            requests += 1;
+            return new Response("not reached", { status: 500 });
+        },
+    });
+    for (const input of [
+        {
+            workerName: "INVALID WORKER",
+            versionId: NEW_VERSION,
+            message: "valid",
+        },
+        {
+            workerName: "peerbit-examples-files",
+            versionId: "invalid-version",
+            message: "valid",
+        },
+        {
+            workerName: "peerbit-examples-files",
+            versionId: NEW_VERSION,
+            message: "",
+        },
+    ]) {
+        await assert.rejects(api.createDeployment(input), (error) => {
+            assert.equal(
+                error instanceof CloudflareWorkersApiError &&
+                    error.indeterminateMutation === true,
+                false
+            );
+            return true;
+        });
+    }
+    assert.equal(requests, 0);
+});
+
+test("a status-less deployment POST failure is classified as indeterminate", async () => {
+    const accountId = "c".repeat(32);
+    const apiToken = "do-not-leak-this-token";
+    const api = createCloudflareWorkersApi({
+        accountId,
+        apiToken,
+        request: async () => {
+            throw new Error(`socket closed after request ${apiToken}`);
+        },
+    });
+    let failure;
+    try {
+        await api.createDeployment({
+            workerName: "peerbit-examples-files",
+            versionId: NEW_VERSION,
+            message: "promote exact version",
+        });
+    } catch (error) {
+        failure = error;
+    }
+    assert.ok(failure instanceof CloudflareWorkersApiError);
+    assert.equal(failure.details.status, null);
+    assert.equal(failure.details.indeterminateMutation, true);
+    assert.equal(failure.indeterminateMutation, true);
+    assert.match(failure.message, /\[REDACTED\]/);
+    assert.doesNotMatch(failure.message, new RegExp(apiToken));
+});
+
+test("Cloudflare API failures are structured and redact credentials", async () => {
+    const accountId = "d".repeat(32);
+    const apiToken = "redact-this-token";
+    for (const request of [
+        async () =>
+            new Response(
+                JSON.stringify({
+                    success: false,
+                    errors: [
+                        {
+                            code: 10000,
+                            message: `authentication failed for ${apiToken} in ${accountId}`,
+                        },
+                    ],
+                }),
+                { status: 403 }
+            ),
+        async () => {
+            throw new Error(`network failed with ${apiToken} in ${accountId}`);
+        },
+    ]) {
+        const api = createCloudflareWorkersApi({
+            accountId,
+            apiToken,
+            request,
+        });
+        let failure;
+        try {
+            await api.listWorkerScripts();
+        } catch (error) {
+            failure = error;
+        }
+        assert.ok(failure instanceof CloudflareWorkersApiError);
+        assert.doesNotMatch(failure.message, new RegExp(apiToken));
+        assert.doesNotMatch(failure.message, new RegExp(accountId));
+        assert.match(failure.message, /Cloudflare Workers API error/);
+        assert.equal(failure.details.operation, "list account Worker scripts");
+        assert.equal(failure.details.indeterminateMutation, false);
+        assert.ok(Array.isArray(failure.details.errors));
+    }
+});
+
+test("production CLI accepts only target and immutable commit", () => {
+    assert.deepEqual(
+        parseProductionDeploymentArgs([
+            "--target",
+            "files",
+            "--commit",
+            COMMIT,
+        ]),
+        {
+            target: "files",
+            expectedCommit: COMMIT,
+        }
+    );
+    assert.throws(
+        () =>
+            parseProductionDeploymentArgs([
+                "--target",
+                "files",
+                "--commit",
+                COMMIT,
+                "--initialize-missing-workers",
+                "true",
+            ]),
+        /Unsupported production deployment argument/
+    );
+    assert.throws(
+        () =>
+            parseProductionDeploymentArgs([
+                "--target",
+                "files",
+                "--target",
+                "stream",
+                "--commit",
+                COMMIT,
+            ]),
+        /Duplicate production deployment argument/
+    );
+    assert.throws(
+        () =>
+            parseProductionDeploymentArgs([
+                "--target",
+                "files; echo unsafe",
+                "--commit",
+                COMMIT,
+            ]),
+        /target is missing or malformed/
+    );
+    assert.throws(
+        () =>
+            parseProductionDeploymentArgs([
+                "--target",
+                "files",
+                "--commit",
+                "short",
+            ]),
+        /full Git commit hash/
+    );
+});
+
 const fixtureEntries = (ids) =>
     ids.map((id) => ({
         site: { id },
-        policy: { id, kind: "app" },
-    }));
-const fixtureConfigs = (ids) =>
-    new Map(ids.map((id) => [id, { file: `/${id}.jsonc` }]));
-
-test("production deploys and verifies each app before touching the next", async () => {
-    const events = [];
-    const current = new Map([
-        ["files", OLD_VERSION],
-        ["stream", OLD_VERSION],
-    ]);
-    await deployProductionEntries({
-        selectedEntries: fixtureEntries(["files", "stream"]),
-        configs: fixtureConfigs(["files", "stream"]),
-        expectedCommit: COMMIT,
-        log: () => {},
-        operations: {
-            status: ({ site }) => deployment(current.get(site.id)),
-            readReleaseCommit: () => OLD_COMMIT,
-            deploy: ({ site }) => {
-                events.push(`deploy:${site.id}`);
-                current.set(site.id, NEW_VERSION);
-            },
-            verify: ({ site, expectedCommit }) => {
-                events.push(`verify:${site.id}:${expectedCommit}`);
-            },
-            rollback: () => assert.fail("rollback must not run"),
+        policy: {
+            id,
+            kind: "app",
+            productionWorker: "peerbit-examples-" + id,
+            previewWorker: "peerbit-examples-" + id + "-preview",
+            productionHostnames: [id + ".apps.peerbit.org"],
         },
+    }));
+const deployProductionEntries = (options) =>
+    deployProductionEntriesWithPolicy({
+        deploymentEntries: options.selectedEntries,
+        ...options,
     });
-    assert.deepEqual(events, [
-        "deploy:files",
-        `verify:files:${COMMIT}`,
-        "deploy:stream",
-        `verify:stream:${COMMIT}`,
-    ]);
+const fixtureConfigs = (ids) =>
+    new Map(
+        ids.map((id) => [
+            id,
+            {
+                file: "/" + id + ".jsonc",
+                config: { name: "peerbit-examples-" + id },
+            },
+        ])
+    );
+const existingWorkerScripts = (...ids) =>
+    new Map(
+        ids.map((id) => [
+            "peerbit-examples-" + id,
+            { tag: WORKER_TAGS.get(id), routes: [] },
+        ])
+    );
+const deploymentEvidence = (
+    id,
+    { versionId = NEW_VERSION, workerTag = WORKER_TAGS.get(id) } = {}
+) => ({
+    workerName: "peerbit-examples-" + id,
+    workerTag,
+    versionId,
 });
 
-test("an app deploy is blocked without a baseline release commit", async () => {
+const STREAM_NEW_VERSION = "33333333-3333-4333-8333-333333333333";
+const EXTERNAL_VERSION = "55555555-5555-4555-8555-555555555555";
+const newVersionFor = (id) =>
+    id === "stream" ? STREAM_NEW_VERSION : NEW_VERSION;
+const siteIdFromWorker = (workerName) =>
+    workerName.replace("peerbit-examples-", "");
+
+const createRolloutHarness = (ids) => {
+    const current = new Map(ids.map((id) => [id, OLD_VERSION]));
+    const workerTags = new Map(ids.map((id) => [id, WORKER_TAGS.get(id)]));
+    const subdomains = new Map(
+        ids.map((id) => [
+            "peerbit-examples-" + id,
+            { enabled: false, previewsEnabled: false },
+        ])
+    );
+    const versionTags = new Map();
+    const events = [];
+    const operations = {
+        listWorkerScripts: () =>
+            new Map(
+                ids.map((id) => [
+                    "peerbit-examples-" + id,
+                    { tag: workerTags.get(id), routes: [] },
+                ])
+            ),
+        listWorkerDomains: () => ids.map((id) => workerDomain(id)),
+        getWorkerSubdomain: (workerName) =>
+            structuredClone(subdomains.get(workerName)),
+        status: ({ site }) => deployment(current.get(site.id)),
+        readReleaseCommit: () => OLD_COMMIT,
+        upload: ({ site, versionTag, renderedConfig }) => {
+            assert.equal(renderedConfig.name, "peerbit-examples-" + site.id);
+            events.push("upload:" + site.id);
+            versionTags.set(site.id, versionTag);
+            return deploymentEvidence(site.id, {
+                versionId: newVersionFor(site.id),
+                workerTag: workerTags.get(site.id),
+            });
+        },
+        getVersion: ({ workerName, versionId }) => {
+            const id = siteIdFromWorker(workerName);
+            return {
+                id: versionId,
+                annotations: { "workers/tag": versionTags.get(id) },
+                metadata: { source: "wrangler" },
+            };
+        },
+        activate: ({ site, versionId }) => {
+            events.push("activate:" + site.id + ":" + versionId);
+            current.set(site.id, versionId);
+            return deployment(versionId);
+        },
+        verify: ({ site, expectedCommit }) => {
+            events.push("verify:" + site.id + ":" + expectedCommit);
+        },
+    };
+    return {
+        current,
+        events,
+        operations,
+        subdomains,
+        versionTags,
+        workerTags,
+    };
+};
+
+test("account-wide attachment validation requires an explicit non-empty full policy", async (t) => {
+    for (const fixture of [
+        { name: "omitted", include: false },
+        { name: "empty", include: true },
+    ]) {
+        await t.test(fixture.name, async () => {
+            let listed = false;
+            const options = {
+                selectedEntries: fixtureEntries(["files"]),
+                configs: fixtureConfigs(["files"]),
+                expectedCommit: COMMIT,
+                log: () => {},
+                operations: {
+                    listWorkerScripts: () => {
+                        listed = true;
+                        return existingWorkerScripts("files");
+                    },
+                    upload: () => assert.fail("upload must not run"),
+                    activate: () => assert.fail("activation must not run"),
+                },
+            };
+            if (fixture.include) options.deploymentEntries = [];
+            await assert.rejects(
+                deployProductionEntriesWithPolicy(options),
+                /explicit non-empty full-policy entries/
+            );
+            assert.equal(listed, false);
+        });
+    }
+});
+
+test("an empty selected entry set fails before account reads or mutations", async () => {
+    let listed = false;
+    await assert.rejects(
+        deployProductionEntriesWithPolicy({
+            selectedEntries: [],
+            deploymentEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: {
+                listWorkerScripts: () => {
+                    listed = true;
+                    return existingWorkerScripts("files");
+                },
+                upload: () => assert.fail("upload must not run"),
+                activate: () => assert.fail("activation must not run"),
+            },
+        }),
+        /non-empty selected entry set/
+    );
+    assert.equal(listed, false);
+});
+
+test("a missing production Worker fails closed before every mutation", async () => {
     await assert.rejects(
         deployProductionEntries({
             selectedEntries: fixtureEntries(["files"]),
@@ -312,21 +1522,21 @@ test("an app deploy is blocked without a baseline release commit", async () => {
             expectedCommit: COMMIT,
             log: () => {},
             operations: {
-                status: () => deployment(OLD_VERSION),
-                readReleaseCommit: () => undefined,
-                deploy: () => assert.fail("deploy must not run"),
+                listWorkerScripts: () => new Map(),
+                status: () => assert.fail("status must not run"),
+                readReleaseCommit: () =>
+                    assert.fail("release lookup must not run"),
+                upload: () => assert.fail("upload must not run"),
+                getVersion: () => assert.fail("version lookup must not run"),
+                activate: () => assert.fail("activation must not run"),
                 verify: () => assert.fail("verify must not run"),
-                rollback: () => assert.fail("rollback must not run"),
             },
         }),
-        /requires a full rollback release commit/
+        /require pre-provisioned Workers.*No deployment was attempted/i
     );
 });
 
-test("failed verification restores and verifies the previous version", async () => {
-    const events = [];
-    let current = OLD_VERSION;
-    let firstVerification = true;
+test("one missing Worker blocks a mixed selection before baseline reads", async () => {
     await assert.rejects(
         deployProductionEntries({
             selectedEntries: fixtureEntries(["files", "stream"]),
@@ -334,38 +1544,19 @@ test("failed verification restores and verifies the previous version", async () 
             expectedCommit: COMMIT,
             log: () => {},
             operations: {
-                status: () => deployment(current),
-                readReleaseCommit: () => OLD_COMMIT,
-                deploy: ({ site }) => {
-                    events.push(`deploy:${site.id}`);
-                    current = NEW_VERSION;
-                },
-                verify: ({ site, expectedCommit }) => {
-                    events.push(`verify:${site.id}:${expectedCommit}`);
-                    if (firstVerification) {
-                        firstVerification = false;
-                        throw new Error("runtime smoke failed");
-                    }
-                },
-                rollback: ({ site, versionId }) => {
-                    events.push(`rollback:${site.id}:${versionId}`);
-                    current = versionId;
-                },
+                listWorkerScripts: () => existingWorkerScripts("files"),
+                status: () => assert.fail("status must not run"),
+                readReleaseCommit: () =>
+                    assert.fail("release lookup must not run"),
+                upload: () => assert.fail("upload must not run"),
             },
         }),
-        /automatic rollback to .* succeeded/
+        /missing stream: peerbit-examples-stream/i
     );
-    assert.equal(current, OLD_VERSION);
-    assert.deepEqual(events, [
-        "deploy:files",
-        `verify:files:${COMMIT}`,
-        `rollback:files:${OLD_VERSION}`,
-        `verify:files:${OLD_COMMIT}`,
-    ]);
 });
 
-test("a deploy failure that changed nothing does not create a rollback", async () => {
-    const events = [];
+test("Worker-list API errors never classify a target as missing", async () => {
+    let uploaded = false;
     await assert.rejects(
         deployProductionEntries({
             selectedEntries: fixtureEntries(["files"]),
@@ -373,18 +1564,1632 @@ test("a deploy failure that changed nothing does not create a rollback", async (
             expectedCommit: COMMIT,
             log: () => {},
             operations: {
-                status: () => deployment(OLD_VERSION),
-                readReleaseCommit: () => OLD_COMMIT,
-                deploy: () => {
-                    events.push("deploy");
-                    throw new Error("upload rejected");
+                listWorkerScripts: () => {
+                    throw new Error("Cloudflare authorization failed");
                 },
-                verify: ({ expectedCommit }) =>
-                    events.push(`verify:${expectedCommit}`),
-                rollback: () => events.push("rollback"),
+                upload: () => {
+                    uploaded = true;
+                },
             },
         }),
-        /automatic rollback to .* succeeded/
+        /Cloudflare authorization failed/
     );
-    assert.deepEqual(events, ["deploy", `verify:${OLD_COMMIT}`]);
+    assert.equal(uploaded, false);
+});
+
+test("missing, extra, and wrongly attached custom domains fail before upload", async () => {
+    const cases = [
+        {
+            name: "missing",
+            domains: [],
+        },
+        {
+            name: "extra",
+            domains: [
+                workerDomain("files"),
+                workerDomain("legacy", {
+                    id: "domain-extra",
+                    hostname: "legacy.apps.peerbit.org",
+                    service: "peerbit-examples-files",
+                }),
+            ],
+        },
+        {
+            name: "wrong Worker",
+            domains: [
+                workerDomain("files", {
+                    service: "peerbit-examples-stream",
+                }),
+            ],
+        },
+    ];
+
+    for (const fixture of cases) {
+        const harness = createRolloutHarness(["files"]);
+        harness.operations.listWorkerDomains = () => fixture.domains;
+        await assert.rejects(
+            deployProductionEntries({
+                selectedEntries: fixtureEntries(["files"]),
+                configs: fixtureConfigs(["files"]),
+                expectedCommit: COMMIT,
+                log: () => {},
+                operations: harness.operations,
+            }),
+            /custom domains must exactly equal/,
+            fixture.name
+        );
+        assert.deepEqual(harness.events, [], fixture.name);
+    }
+});
+
+test("mixed-app hostname swaps fail exact attachment validation", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    harness.operations.listWorkerDomains = () => [
+        workerDomain("files"),
+        workerDomain("stream", {
+            service: "peerbit-examples-files",
+        }),
+    ];
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files", "stream"]),
+            configs: fixtureConfigs(["files", "stream"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /files: peerbit-examples-files custom domains must exactly equal/
+    );
+    assert.deepEqual(harness.events, []);
+});
+
+test("noncanonical custom-domain hostnames fail closed before upload", async () => {
+    const harness = createRolloutHarness(["files"]);
+    harness.operations.listWorkerDomains = () => [
+        workerDomain("files", {
+            hostname: "files.apps.peerbit.org.",
+        }),
+    ];
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /invalid or ambiguous inventory/
+    );
+    assert.deepEqual(harness.events, []);
+});
+
+test("traditional Worker routes fail exact attachment validation", async () => {
+    const harness = createRolloutHarness(["files"]);
+    harness.operations.listWorkerScripts = () =>
+        new Map([
+            [
+                "peerbit-examples-files",
+                {
+                    tag: WORKER_TAGS.get("files"),
+                    routes: [
+                        {
+                            id: "route-legacy",
+                            pattern: "peerbit.org/legacy/*",
+                            script: "peerbit-examples-files",
+                        },
+                    ],
+                },
+            ],
+        ]);
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /unreviewed Worker route attachments/
+    );
+    assert.deepEqual(harness.events, []);
+});
+
+test("a targeted deploy rejects retired Workers from the full managed namespace", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    const listWorkerScripts = harness.operations.listWorkerScripts;
+    harness.operations.listWorkerScripts = () =>
+        new Map([
+            ...listWorkerScripts(),
+            [
+                "peerbit-examples-retired",
+                { tag: "retired-worker-tag", routes: [] },
+            ],
+        ]);
+    harness.operations.listWorkerDomains = () => [
+        workerDomain("files"),
+        workerDomain("stream"),
+        workerDomain("retired"),
+    ];
+
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            deploymentEntries: fixtureEntries(["files", "stream"]),
+            configs: fixtureConfigs(["files", "stream"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /unreviewed or retired Worker identity peerbit-examples-retired/
+    );
+    assert.deepEqual(harness.events, []);
+});
+
+test("a targeted deploy rejects unmanaged ownership of retired app hostnames", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    const listWorkerScripts = harness.operations.listWorkerScripts;
+    harness.operations.listWorkerScripts = () =>
+        new Map([
+            ...listWorkerScripts(),
+            [
+                "unrelated-account-worker",
+                { tag: "unrelated-worker-tag", routes: [] },
+            ],
+        ]);
+    harness.operations.listWorkerDomains = () => [
+        workerDomain("files"),
+        workerDomain("stream"),
+        workerDomain("retired", {
+            service: "unrelated-account-worker",
+        }),
+    ];
+
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            deploymentEntries: fixtureEntries(["files", "stream"]),
+            configs: fixtureConfigs(["files", "stream"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /custom domain retired\.apps\.peerbit\.org is not exactly owned/
+    );
+    assert.deepEqual(harness.events, []);
+});
+
+test("a targeted deploy rejects routes on non-selected policy Workers", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    const listWorkerScripts = harness.operations.listWorkerScripts;
+    harness.operations.listWorkerScripts = () => {
+        const scripts = listWorkerScripts();
+        scripts.get("peerbit-examples-stream").routes.push({
+            id: "stream-route",
+            pattern: "unrelated.example.com/*",
+            script: "peerbit-examples-stream",
+        });
+        return scripts;
+    };
+
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            deploymentEntries: fixtureEntries(["files", "stream"]),
+            configs: fixtureConfigs(["files", "stream"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /stream: peerbit-examples-stream has unreviewed Worker route attachments/
+    );
+    assert.deepEqual(harness.events, []);
+});
+
+test("routes targeting the managed app suffix are rejected on unrelated Workers", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    const listWorkerScripts = harness.operations.listWorkerScripts;
+    harness.operations.listWorkerScripts = () =>
+        new Map([
+            ...listWorkerScripts(),
+            [
+                "unrelated-account-worker",
+                {
+                    tag: "unrelated-worker-tag",
+                    routes: [
+                        {
+                            id: "managed-suffix-route",
+                            pattern: "retired.apps.peerbit.org./*",
+                            script: "unrelated-account-worker",
+                        },
+                    ],
+                },
+            ],
+        ]);
+
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            deploymentEntries: fixtureEntries(["files", "stream"]),
+            configs: fixtureConfigs(["files", "stream"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /unrelated-account-worker has unreviewed Worker route attachments/
+    );
+    assert.deepEqual(harness.events, []);
+});
+
+test("unrelated account Workers, routes, and domains remain outside deployment policy", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    const listWorkerScripts = harness.operations.listWorkerScripts;
+    harness.operations.listWorkerScripts = () =>
+        new Map([
+            ...listWorkerScripts(),
+            [
+                "unrelated-account-worker",
+                {
+                    tag: "unrelated-worker-tag",
+                    routes: [
+                        {
+                            id: "unrelated-route",
+                            pattern: "unrelated.example.com/*",
+                            script: "unrelated-account-worker",
+                        },
+                    ],
+                },
+            ],
+        ]);
+    harness.operations.listWorkerDomains = () => [
+        workerDomain("files"),
+        workerDomain("stream"),
+        workerDomain("unrelated", {
+            hostname: "unrelated.example.com",
+            service: "unrelated-account-worker",
+            zoneName: "example.com",
+        }),
+    ];
+
+    await deployProductionEntries({
+        selectedEntries: fixtureEntries(["files"]),
+        deploymentEntries: fixtureEntries(["files", "stream"]),
+        configs: fixtureConfigs(["files", "stream"]),
+        expectedCommit: COMMIT,
+        log: () => {},
+        operations: harness.operations,
+    });
+    assert.equal(harness.current.get("files"), NEW_VERSION);
+    assert.equal(harness.current.get("stream"), OLD_VERSION);
+    assert.equal(harness.events.includes("upload:stream"), false);
+});
+
+test("enabled workers.dev or Worker Preview URLs fail before upload", async (t) => {
+    for (const state of [
+        { name: "workers.dev", enabled: true, previewsEnabled: false },
+        { name: "Preview URLs", enabled: false, previewsEnabled: true },
+    ]) {
+        await t.test(state.name, async () => {
+            const harness = createRolloutHarness(["files"]);
+            harness.subdomains.set("peerbit-examples-files", {
+                enabled: state.enabled,
+                previewsEnabled: state.previewsEnabled,
+            });
+            await assert.rejects(
+                deployProductionEntries({
+                    selectedEntries: fixtureEntries(["files"]),
+                    configs: fixtureConfigs(["files"]),
+                    expectedCommit: COMMIT,
+                    log: () => {},
+                    operations: harness.operations,
+                }),
+                /workers\.dev and Worker Preview URLs must both be disabled/
+            );
+            assert.deepEqual(harness.events, []);
+        });
+    }
+});
+
+test("targeted deploys validate public subdomain state on non-selected policy Workers", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    harness.subdomains.set("peerbit-examples-stream", {
+        enabled: false,
+        previewsEnabled: true,
+    });
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            deploymentEntries: fixtureEntries(["files", "stream"]),
+            configs: fixtureConfigs(["files", "stream"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /peerbit-examples-stream: workers\.dev and Worker Preview URLs must both be disabled/
+    );
+    assert.deepEqual(harness.events, []);
+});
+
+test("existing allowlisted preview Workers receive the same public subdomain fence", async () => {
+    const harness = createRolloutHarness(["files"]);
+    const listWorkerScripts = harness.operations.listWorkerScripts;
+    harness.operations.listWorkerScripts = () =>
+        new Map([
+            ...listWorkerScripts(),
+            [
+                "peerbit-examples-files-preview",
+                { tag: "files-preview-tag", routes: [] },
+            ],
+        ]);
+    harness.subdomains.set("peerbit-examples-files-preview", {
+        enabled: true,
+        previewsEnabled: false,
+    });
+
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /peerbit-examples-files-preview: workers\.dev and Worker Preview URLs must both be disabled/
+    );
+    assert.deepEqual(harness.events, []);
+});
+
+test("a public-subdomain flip is caught immediately before a later upload", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    const getWorkerSubdomain = harness.operations.getWorkerSubdomain;
+    let streamReadsAfterFirstUpload = 0;
+    harness.operations.getWorkerSubdomain = (workerName) => {
+        if (
+            workerName === "peerbit-examples-stream" &&
+            harness.events.includes("upload:files")
+        ) {
+            streamReadsAfterFirstUpload += 1;
+            if (streamReadsAfterFirstUpload >= 2) {
+                return { enabled: false, previewsEnabled: true };
+            }
+        }
+        return getWorkerSubdomain(workerName);
+    };
+
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files", "stream"]),
+            configs: fixtureConfigs(["files", "stream"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /Inactive Worker version upload phase failed.*peerbit-examples-stream: workers\.dev and Worker Preview URLs must both be disabled/is
+    );
+    assert.deepEqual(harness.events, ["upload:files"]);
+});
+
+test("custom-domain inventory API failures stop before upload", async () => {
+    const harness = createRolloutHarness(["files"]);
+    harness.operations.listWorkerDomains = () => {
+        throw new Error("Cloudflare custom-domain authorization failed");
+    };
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /custom-domain authorization failed/
+    );
+    assert.deepEqual(harness.events, []);
+});
+
+test("all rollback baselines are valid before the first inactive upload", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    harness.operations.readReleaseCommit = ({ site }) => {
+        if (site.id === "stream") {
+            throw new Error("release metadata unavailable");
+        }
+        return OLD_COMMIT;
+    };
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files", "stream"]),
+            configs: fixtureConfigs(["files", "stream"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /release metadata unavailable/
+    );
+    assert.deepEqual(harness.events, []);
+});
+
+test("a later inactive upload failure leaves all live traffic untouched", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    const upload = harness.operations.upload;
+    harness.operations.upload = (input) => {
+        if (input.site.id === "stream") {
+            harness.events.push("upload:stream:failed");
+            throw new Error("version upload rejected");
+        }
+        return upload(input);
+    };
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files", "stream"]),
+            configs: fixtureConfigs(["files", "stream"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /Inactive Worker version upload phase failed.*did not change live production traffic/
+    );
+    assert.deepEqual(
+        harness.current,
+        new Map([
+            ["files", OLD_VERSION],
+            ["stream", OLD_VERSION],
+        ])
+    );
+    assert.equal(
+        harness.events.some((event) => event.startsWith("activate:")),
+        false
+    );
+});
+
+test("a Worker deletion and recreation after upload prevents promotion", async () => {
+    const harness = createRolloutHarness(["files"]);
+    const listWorkerScripts = harness.operations.listWorkerScripts;
+    harness.operations.listWorkerScripts = () => {
+        if (harness.events.includes("upload:files")) {
+            return new Map([
+                [
+                    "peerbit-examples-files",
+                    { tag: "replacement-worker-tag", routes: [] },
+                ],
+            ]);
+        }
+        return listWorkerScripts();
+    };
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /baseline changed after inactive uploads.*No uploaded version was promoted/is
+    );
+    assert.deepEqual(harness.events, ["upload:files"]);
+    assert.equal(harness.current.get("files"), OLD_VERSION);
+});
+
+test("a custom-domain change after inactive upload prevents promotion", async () => {
+    const harness = createRolloutHarness(["files"]);
+    harness.operations.listWorkerDomains = () => [
+        workerDomain("files"),
+        ...(harness.events.includes("upload:files")
+            ? [
+                  workerDomain("legacy", {
+                      id: "domain-extra-after-upload",
+                      hostname: "legacy.apps.peerbit.org",
+                      service: "peerbit-examples-files",
+                  }),
+              ]
+            : []),
+    ];
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /Inactive Worker version upload phase failed.*custom domains must exactly equal.*did not change live production traffic/is
+    );
+    assert.deepEqual(harness.events, ["upload:files"]);
+    assert.equal(harness.current.get("files"), OLD_VERSION);
+});
+
+test("an external active version after upload prevents exact-version promotion", async () => {
+    const harness = createRolloutHarness(["files"]);
+    const status = harness.operations.status;
+    let statusCalls = 0;
+    harness.operations.status = (input) => {
+        statusCalls += 1;
+        if (statusCalls >= 3) {
+            harness.current.set("files", EXTERNAL_VERSION);
+        }
+        return status(input);
+    };
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /baseline changed after inactive uploads.*No uploaded version was promoted/is
+    );
+    assert.deepEqual(harness.events, ["upload:files"]);
+    assert.equal(harness.current.get("files"), EXTERNAL_VERSION);
+});
+
+test("invalid version-tag evidence can never authorize promotion", async () => {
+    const harness = createRolloutHarness(["files"]);
+    harness.operations.getVersion = ({ versionId }) => ({
+        id: versionId,
+        annotations: { "workers/tag": "not-this-invocation" },
+    });
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /exact tagged Worker version.*did not change live production traffic/is
+    );
+    assert.deepEqual(harness.events, ["upload:files"]);
+    assert.equal(harness.current.get("files"), OLD_VERSION);
+});
+
+test("every selected version uploads before the first exact promotion", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    await deployProductionEntries({
+        selectedEntries: fixtureEntries(["files", "stream"]),
+        configs: fixtureConfigs(["files", "stream"]),
+        expectedCommit: COMMIT,
+        log: () => {},
+        operations: harness.operations,
+    });
+    assert.deepEqual(harness.events, [
+        "upload:files",
+        "upload:stream",
+        "activate:files:" + NEW_VERSION,
+        "verify:files:" + COMMIT,
+        "activate:stream:" + STREAM_NEW_VERSION,
+        "verify:stream:" + COMMIT,
+    ]);
+    assert.equal(harness.current.get("files"), NEW_VERSION);
+    assert.equal(harness.current.get("stream"), STREAM_NEW_VERSION);
+    assert.match(harness.versionTags.get("files"), /^peerbit_files_/);
+    assert.match(harness.versionTags.get("stream"), /^peerbit_stream_/);
+});
+
+test("final ownership checks catch an earlier app drifting during a later successful verifier", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    const verify = harness.operations.verify;
+    harness.operations.verify = (input) => {
+        verify(input);
+        if (input.site.id === "stream" && input.expectedCommit === COMMIT) {
+            harness.current.set("files", EXTERNAL_VERSION);
+        }
+    };
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files", "stream"]),
+            configs: fixtureConfigs(["files", "stream"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /files: production rollout failed.*active version.*stream: automatic rollback.*files: automatic rollback refused.*another deployment may have won/is
+    );
+    assert.equal(harness.current.get("files"), EXTERNAL_VERSION);
+    assert.equal(harness.current.get("stream"), OLD_VERSION);
+    assert.deepEqual(
+        harness.events.filter((event) => event.startsWith("activate:")),
+        [
+            "activate:files:" + NEW_VERSION,
+            "activate:stream:" + STREAM_NEW_VERSION,
+            "activate:stream:" + OLD_VERSION,
+        ]
+    );
+});
+
+test("final success and rollback fencing include public subdomain state", async () => {
+    const harness = createRolloutHarness(["files"]);
+    const verify = harness.operations.verify;
+    harness.operations.verify = (input) => {
+        verify(input);
+        if (input.expectedCommit === COMMIT) {
+            harness.subdomains.set("peerbit-examples-files", {
+                enabled: true,
+                previewsEnabled: true,
+            });
+        }
+    };
+
+    let failure;
+    try {
+        await deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        });
+    } catch (error) {
+        failure = error;
+    }
+    assert.ok(failure instanceof Error);
+    assert.match(
+        failure.message,
+        /production rollout failed.*workers\.dev and Worker Preview URLs must both be disabled/is
+    );
+    assert.match(failure.message, /automatic rollback refused/);
+    assert.equal(harness.current.get("files"), NEW_VERSION);
+    assert.equal(
+        harness.events.includes("activate:files:" + OLD_VERSION),
+        false
+    );
+});
+
+test("a later verification failure unwinds the whole rollout in reverse", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    const verify = harness.operations.verify;
+    harness.operations.verify = (input) => {
+        verify(input);
+        if (input.site.id === "stream" && input.expectedCommit === COMMIT) {
+            throw new Error("runtime smoke failed");
+        }
+    };
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files", "stream"]),
+            configs: fixtureConfigs(["files", "stream"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /stream: automatic rollback of this invocation.*files: automatic rollback of this invocation/is
+    );
+    assert.deepEqual(
+        harness.events.filter((event) => event.startsWith("activate:")),
+        [
+            "activate:files:" + NEW_VERSION,
+            "activate:stream:" + STREAM_NEW_VERSION,
+            "activate:stream:" + OLD_VERSION,
+            "activate:files:" + OLD_VERSION,
+        ]
+    );
+    assert.equal(harness.current.get("files"), OLD_VERSION);
+    assert.equal(harness.current.get("stream"), OLD_VERSION);
+});
+
+test("a later promotion failure unwinds earlier apps but does not touch its baseline", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    const activate = harness.operations.activate;
+    harness.operations.activate = (input) => {
+        if (
+            input.site.id === "stream" &&
+            input.versionId === STREAM_NEW_VERSION
+        ) {
+            harness.events.push("activate:stream:failed");
+            throw new Error("promotion API failed before mutation");
+        }
+        return activate(input);
+    };
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files", "stream"]),
+            configs: fixtureConfigs(["files", "stream"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /stream: previous baseline .* remains active.*files: automatic rollback/is
+    );
+    assert.equal(harness.current.get("files"), OLD_VERSION);
+    assert.equal(harness.current.get("stream"), OLD_VERSION);
+    assert.equal(
+        harness.events.includes("activate:stream:" + OLD_VERSION),
+        false
+    );
+});
+
+test("baseline-remained-active recovery rechecks the active version after its verifier", async () => {
+    const harness = createRolloutHarness(["files"]);
+    harness.operations.activate = (input) => {
+        if (input.versionId === NEW_VERSION) {
+            harness.events.push("activate:files:failed-before-dispatch");
+            throw new Error("local activation validation failed");
+        }
+        assert.fail("a rollback POST must not be dispatched");
+    };
+    const verify = harness.operations.verify;
+    harness.operations.verify = (input) => {
+        verify(input);
+        if (input.expectedCommit === OLD_COMMIT) {
+            harness.current.set("files", EXTERNAL_VERSION);
+        }
+    };
+
+    let failure;
+    try {
+        await deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        });
+    } catch (error) {
+        failure = error;
+    }
+    assert.ok(failure instanceof Error);
+    assert.match(
+        failure.message,
+        /automatic rollback refused.*active version changed .* during baseline verification/is
+    );
+    assert.doesNotMatch(failure.message, /no rollback was necessary/i);
+    assert.equal(harness.current.get("files"), EXTERNAL_VERSION);
+});
+
+test("an indeterminate promotion waits for a delayed mutation and unwinds it", async () => {
+    const harness = createRolloutHarness(["files"]);
+    const activate = harness.operations.activate;
+    const secret = "transport-secret-token";
+    let waits = 0;
+    harness.operations.activate = (input) => {
+        if (input.versionId === NEW_VERSION) {
+            harness.events.push("activate:files:indeterminate");
+            throw new CloudflareWorkersApiError({
+                operation: "activate exact Worker version",
+                cause: new Error(`connection lost after POST ${secret}`),
+                secrets: [secret],
+                indeterminateMutation: true,
+            });
+        }
+        return activate(input);
+    };
+    harness.operations.waitForActivationSettlement = async () => {
+        waits += 1;
+        if (waits === 2) {
+            harness.current.set("files", NEW_VERSION);
+        }
+    };
+
+    let failure;
+    try {
+        await deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        });
+    } catch (error) {
+        failure = error;
+    }
+    assert.ok(failure instanceof Error);
+    assert.match(failure.message, /indeterminateMutation":true/);
+    assert.match(failure.message, /\[REDACTED\]/);
+    assert.doesNotMatch(failure.message, new RegExp(secret));
+    assert.match(failure.message, /automatic rollback of this invocation/);
+    assert.equal(waits, 2);
+    assert.equal(harness.current.get("files"), OLD_VERSION);
+    assert.deepEqual(
+        harness.events.filter((event) => event.startsWith("activate:")),
+        ["activate:files:indeterminate", "activate:files:" + OLD_VERSION]
+    );
+});
+
+test("a valid 2xx activation that appears during settlement is unwound end to end", async () => {
+    const harness = createRolloutHarness(["files"]);
+    const activate = harness.operations.activate;
+    let waits = 0;
+    harness.operations.activate = (input) => {
+        if (input.versionId === NEW_VERSION) {
+            harness.events.push("activate:files:acknowledged-pending");
+            return deployment(NEW_VERSION);
+        }
+        return activate(input);
+    };
+    harness.operations.waitForActivationSettlement = async () => {
+        waits += 1;
+        if (waits === 2) {
+            harness.current.set("files", NEW_VERSION);
+        }
+    };
+
+    let failure;
+    try {
+        await deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        });
+    } catch (error) {
+        failure = error;
+    }
+    assert.ok(failure instanceof Error);
+    assert.match(failure.message, /active version .* does not match/);
+    assert.match(failure.message, /automatic rollback of this invocation/);
+    assert.equal(waits, 2);
+    assert.equal(harness.current.get("files"), OLD_VERSION);
+    assert.deepEqual(
+        harness.events.filter((event) => event.startsWith("activate:")),
+        ["activate:files:acknowledged-pending", "activate:files:" + OLD_VERSION]
+    );
+});
+
+test("baseline-only settlement remains manual when the lost POST lands later", async () => {
+    const harness = createRolloutHarness(["files"]);
+    const activate = harness.operations.activate;
+    let waits = 0;
+    harness.operations.activate = (input) => {
+        if (input.versionId === NEW_VERSION) {
+            harness.events.push("activate:files:indeterminate");
+            throw new CloudflareWorkersApiError({
+                operation: "activate exact Worker version",
+                cause: new Error("connection lost after deployment POST"),
+                secrets: [],
+                indeterminateMutation: true,
+            });
+        }
+        return activate(input);
+    };
+    harness.operations.waitForActivationSettlement = async () => {
+        waits += 1;
+        if (waits === 11) {
+            setTimeout(() => {
+                harness.current.set("files", NEW_VERSION);
+            }, 0);
+        }
+    };
+
+    let failure;
+    try {
+        await deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        });
+    } catch (error) {
+        failure = error;
+    }
+    assert.ok(failure instanceof Error);
+    assert.match(
+        failure.message,
+        /automatic rollback refused.*activation remains indeterminate after the bounded settlement window/is
+    );
+    assert.doesNotMatch(failure.message, /no rollback was necessary/i);
+    assert.equal(waits, 11);
+    assert.equal(harness.current.get("files"), OLD_VERSION);
+    assert.equal(
+        harness.events.includes("activate:files:" + OLD_VERSION),
+        false
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(harness.current.get("files"), NEW_VERSION);
+});
+
+test("a valid deployment response remains pending until GET observes it active", async () => {
+    const harness = createRolloutHarness(["files"]);
+    const activate = harness.operations.activate;
+    let waits = 0;
+    harness.operations.activate = (input) => {
+        if (input.versionId === NEW_VERSION) {
+            harness.events.push("activate:files:acknowledged");
+            return deployment(NEW_VERSION);
+        }
+        return activate(input);
+    };
+    harness.operations.waitForActivationSettlement = async () => {
+        waits += 1;
+        if (waits === 11) {
+            setTimeout(() => {
+                harness.current.set("files", NEW_VERSION);
+            }, 0);
+        }
+    };
+
+    let failure;
+    try {
+        await deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        });
+    } catch (error) {
+        failure = error;
+    }
+    assert.ok(failure instanceof Error);
+    assert.match(
+        failure.message,
+        /active version .* does not match this invocation.*automatic rollback refused.*activation remains indeterminate after the bounded settlement window/is
+    );
+    assert.doesNotMatch(failure.message, /no rollback was necessary/i);
+    assert.equal(waits, 11);
+    assert.equal(harness.current.get("files"), OLD_VERSION);
+    assert.equal(
+        harness.events.includes("activate:files:" + OLD_VERSION),
+        false
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(harness.current.get("files"), NEW_VERSION);
+});
+
+test("ambiguous Deployment responses stay manual when the POST lands after settlement", async (t) => {
+    for (const fixture of ambiguousDeploymentResponseCases) {
+        await t.test(fixture.name, async () => {
+            const { failure: responseFailure } =
+                await captureAmbiguousDeploymentResponse(fixture.response);
+            assert.ok(responseFailure instanceof CloudflareWorkersApiError);
+
+            const harness = createRolloutHarness(["files"]);
+            const activate = harness.operations.activate;
+            let waits = 0;
+            harness.operations.activate = (input) => {
+                if (input.versionId === NEW_VERSION) {
+                    harness.events.push("activate:files:indeterminate");
+                    throw responseFailure;
+                }
+                return activate(input);
+            };
+            harness.operations.waitForActivationSettlement = async () => {
+                waits += 1;
+                if (waits === 11) {
+                    setTimeout(() => {
+                        harness.current.set("files", NEW_VERSION);
+                    }, 0);
+                }
+            };
+
+            let rolloutFailure;
+            try {
+                await deployProductionEntries({
+                    selectedEntries: fixtureEntries(["files"]),
+                    configs: fixtureConfigs(["files"]),
+                    expectedCommit: COMMIT,
+                    log: () => {},
+                    operations: harness.operations,
+                });
+            } catch (error) {
+                rolloutFailure = error;
+            }
+            assert.ok(rolloutFailure instanceof Error);
+            assert.match(
+                rolloutFailure.message,
+                /automatic rollback refused.*activation remains indeterminate after the bounded settlement window/is
+            );
+            assert.doesNotMatch(
+                rolloutFailure.message,
+                /no rollback was necessary/i
+            );
+            assert.equal(waits, 11);
+            assert.equal(harness.current.get("files"), OLD_VERSION);
+            assert.equal(
+                harness.events.includes("activate:files:" + OLD_VERSION),
+                false
+            );
+
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            assert.equal(harness.current.get("files"), NEW_VERSION);
+        });
+    }
+});
+
+test("an external version is never clobbered and earlier owned apps still unwind", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    const verify = harness.operations.verify;
+    harness.operations.verify = (input) => {
+        verify(input);
+        if (input.site.id === "stream" && input.expectedCommit === COMMIT) {
+            harness.current.set("stream", EXTERNAL_VERSION);
+            throw new Error("runtime smoke failed after external deployment");
+        }
+    };
+    let failure;
+    try {
+        await deployProductionEntries({
+            selectedEntries: fixtureEntries(["files", "stream"]),
+            configs: fixtureConfigs(["files", "stream"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        });
+    } catch (error) {
+        failure = error;
+    }
+    assert.ok(failure instanceof Error);
+    assert.match(failure.message, /another deployment may have won/);
+    assert.match(failure.message, /files: automatic rollback/);
+    assert.equal(harness.current.get("stream"), EXTERNAL_VERSION);
+    assert.equal(harness.current.get("files"), OLD_VERSION);
+    assert.equal(
+        harness.events.includes("activate:stream:" + OLD_VERSION),
+        false
+    );
+});
+
+test("reverse unwind skips an earlier app changed by an external actor", async () => {
+    const harness = createRolloutHarness(["files", "stream"]);
+    const verify = harness.operations.verify;
+    harness.operations.verify = (input) => {
+        verify(input);
+        if (input.site.id === "stream" && input.expectedCommit === COMMIT) {
+            harness.current.set("files", EXTERNAL_VERSION);
+            throw new Error("runtime smoke failed");
+        }
+    };
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files", "stream"]),
+            configs: fixtureConfigs(["files", "stream"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /stream: automatic rollback.*files: automatic rollback refused.*another deployment may have won/is
+    );
+    assert.equal(harness.current.get("stream"), OLD_VERSION);
+    assert.equal(harness.current.get("files"), EXTERNAL_VERSION);
+    assert.equal(
+        harness.events.includes("activate:files:" + OLD_VERSION),
+        false
+    );
+});
+
+test("rollback success requires full policy and active-version confirmation after the verifier", async (t) => {
+    const cases = [
+        {
+            name: "active version drift",
+            pattern:
+                /post-verifier rollback confirmation observed active version/,
+            configure: (harness) => () => {
+                harness.current.set("files", EXTERNAL_VERSION);
+            },
+        },
+        {
+            name: "custom-domain drift",
+            pattern: /custom domains must exactly equal/,
+            configure: (harness) => {
+                let drifted = false;
+                harness.operations.listWorkerDomains = () => [
+                    workerDomain("files"),
+                    ...(drifted
+                        ? [
+                              workerDomain("retired", {
+                                  id: "rollback-domain-drift",
+                                  service: "peerbit-examples-files",
+                              }),
+                          ]
+                        : []),
+                ];
+                return () => {
+                    drifted = true;
+                };
+            },
+        },
+        {
+            name: "traditional-route drift",
+            pattern: /unreviewed Worker route attachments/,
+            configure: (harness) => {
+                let drifted = false;
+                const listWorkerScripts = harness.operations.listWorkerScripts;
+                harness.operations.listWorkerScripts = () => {
+                    const scripts = listWorkerScripts();
+                    if (drifted) {
+                        scripts.get("peerbit-examples-files").routes.push({
+                            id: "rollback-route-drift",
+                            pattern: "files.apps.peerbit.org/*",
+                            script: "peerbit-examples-files",
+                        });
+                    }
+                    return scripts;
+                };
+                return () => {
+                    drifted = true;
+                };
+            },
+        },
+        {
+            name: "public-subdomain drift",
+            pattern:
+                /workers\.dev and Worker Preview URLs must both be disabled/,
+            configure: (harness) => () => {
+                harness.subdomains.set("peerbit-examples-files", {
+                    enabled: false,
+                    previewsEnabled: true,
+                });
+            },
+        },
+    ];
+
+    for (const fixture of cases) {
+        await t.test(fixture.name, async () => {
+            const harness = createRolloutHarness(["files"]);
+            const introduceDrift = fixture.configure(harness);
+            const verify = harness.operations.verify;
+            harness.operations.verify = (input) => {
+                verify(input);
+                if (input.expectedCommit === COMMIT) {
+                    throw new Error("runtime verification failed");
+                }
+                if (input.expectedCommit === OLD_COMMIT) {
+                    introduceDrift();
+                }
+            };
+
+            let failure;
+            try {
+                await deployProductionEntries({
+                    selectedEntries: fixtureEntries(["files"]),
+                    configs: fixtureConfigs(["files"]),
+                    expectedCommit: COMMIT,
+                    log: () => {},
+                    operations: harness.operations,
+                });
+            } catch (error) {
+                failure = error;
+            }
+            assert.ok(failure instanceof Error);
+            assert.match(
+                failure.message,
+                /automatic rollback was applied and observed, but final confirmation failed/i
+            );
+            assert.match(failure.message, fixture.pattern);
+            assert.doesNotMatch(failure.message, /automatic rollback refused/i);
+        });
+    }
+});
+
+test("rollback dispatch ambiguity and delayed visibility use confirmation-failure diagnostics", async (t) => {
+    for (const fixture of [
+        { name: "ambiguous response", throws: true },
+        { name: "valid response with delayed visibility", throws: false },
+    ]) {
+        await t.test(fixture.name, async () => {
+            const harness = createRolloutHarness(["files"]);
+            const activate = harness.operations.activate;
+            harness.operations.activate = (input) => {
+                if (input.versionId !== OLD_VERSION) return activate(input);
+                harness.events.push("activate:files:rollback-dispatched");
+                setTimeout(() => {
+                    harness.current.set("files", OLD_VERSION);
+                }, 0);
+                if (fixture.throws) {
+                    throw new CloudflareWorkersApiError({
+                        operation: "rollback exact Worker version",
+                        status: 500,
+                        payload: {
+                            success: false,
+                            errors: [{ code: 1001, message: "response lost" }],
+                        },
+                        secrets: [],
+                        indeterminateMutation: true,
+                    });
+                }
+                return deployment(OLD_VERSION);
+            };
+            const verify = harness.operations.verify;
+            harness.operations.verify = (input) => {
+                verify(input);
+                if (input.expectedCommit === COMMIT) {
+                    throw new Error("runtime verification failed");
+                }
+            };
+
+            let failure;
+            try {
+                await deployProductionEntries({
+                    selectedEntries: fixtureEntries(["files"]),
+                    configs: fixtureConfigs(["files"]),
+                    expectedCommit: COMMIT,
+                    log: () => {},
+                    operations: harness.operations,
+                });
+            } catch (error) {
+                failure = error;
+            }
+            assert.ok(failure instanceof Error);
+            assert.match(
+                failure.message,
+                /automatic rollback was dispatched and may have been applied, but confirmation failed/i
+            );
+            assert.doesNotMatch(failure.message, /automatic rollback refused/i);
+            assert.equal(harness.current.get("files"), NEW_VERSION);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            assert.equal(harness.current.get("files"), OLD_VERSION);
+        });
+    }
+});
+
+test("rollback requires the exact invocation version tag at authorization time", async () => {
+    const harness = createRolloutHarness(["files"]);
+    const getVersion = harness.operations.getVersion;
+    let reads = 0;
+    harness.operations.getVersion = (input) => {
+        reads += 1;
+        const version = getVersion(input);
+        if (reads >= 4) {
+            version.annotations["workers/tag"] = "external-version-tag";
+        }
+        return version;
+    };
+    const verify = harness.operations.verify;
+    harness.operations.verify = (input) => {
+        verify(input);
+        if (input.expectedCommit === COMMIT) {
+            throw new Error("verification failed");
+        }
+    };
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /exact version and tag could not be safely unwound.*exact tagged Worker version/is
+    );
+    assert.equal(harness.current.get("files"), NEW_VERSION);
+    assert.equal(
+        harness.events.includes("activate:files:" + OLD_VERSION),
+        false
+    );
+});
+
+test("ambiguous rollback status cannot authorize a traffic mutation", async () => {
+    const harness = createRolloutHarness(["files"]);
+    let verificationFailed = false;
+    const status = harness.operations.status;
+    harness.operations.status = (input) => {
+        if (verificationFailed) {
+            return {
+                versions: [
+                    { version_id: NEW_VERSION, percentage: 50 },
+                    { version_id: EXTERNAL_VERSION, percentage: 50 },
+                ],
+            };
+        }
+        return status(input);
+    };
+    const verify = harness.operations.verify;
+    harness.operations.verify = (input) => {
+        verify(input);
+        if (input.expectedCommit === COMMIT) {
+            verificationFailed = true;
+            throw new Error("verification failed");
+        }
+    };
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /exact version and tag could not be safely unwound.*exactly one valid version/is
+    );
+    assert.equal(
+        harness.events.includes("activate:files:" + OLD_VERSION),
+        false
+    );
+});
+
+test("a replacement Worker identity blocks automatic rollback", async () => {
+    const harness = createRolloutHarness(["files"]);
+    const verify = harness.operations.verify;
+    harness.operations.verify = (input) => {
+        verify(input);
+        if (input.expectedCommit === COMMIT) {
+            harness.workerTags.set("files", "replacement-worker-tag");
+            throw new Error("verification failed after Worker recreation");
+        }
+    };
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /exact version and tag could not be safely unwound.*immutable Worker tag/is
+    );
+    assert.equal(
+        harness.events.includes("activate:files:" + OLD_VERSION),
+        false
+    );
+});
+
+test("malformed captured JSON never exposes credentialed stdout", () => {
+    const secretOutput =
+        '{"token":"' +
+        CLOUDFLARE_CREDENTIALS.CLOUDFLARE_API_TOKEN +
+        '","account":"' +
+        CLOUDFLARE_CREDENTIALS.CLOUDFLARE_ACCOUNT_ID;
+    let failure;
+    try {
+        runCloudflareCapturedJson(
+            "/tools/wrangler",
+            ["deployments", "status", "--json"],
+            CLOUDFLARE_CREDENTIALS,
+            {
+                run: () => ({
+                    status: 0,
+                    stdout: secretOutput,
+                    stderr: "",
+                }),
+            }
+        );
+    } catch (error) {
+        failure = error;
+    }
+    assert.ok(failure instanceof Error);
+    assert.match(failure.message, /returned malformed JSON output/);
+    assert.doesNotMatch(
+        failure.message,
+        new RegExp(CLOUDFLARE_CREDENTIALS.CLOUDFLARE_API_TOKEN)
+    );
+    assert.doesNotMatch(
+        failure.message,
+        new RegExp(CLOUDFLARE_CREDENTIALS.CLOUDFLARE_ACCOUNT_ID)
+    );
+    assert.doesNotMatch(failure.message, /\"token\"/);
+});
+
+const canonicalRouteConfig = (id) => ({
+    $schema: "../tools/wrangler/node_modules/wrangler/config-schema.json",
+    name: "peerbit-examples-" + id,
+    compatibility_date: "2026-07-13",
+    workers_dev: false,
+    preview_urls: false,
+    routes: [
+        {
+            pattern: id + ".apps.peerbit.org",
+            custom_domain: true,
+        },
+    ],
+    ...(id === "stream"
+        ? {
+              main: "../cloudflare/cached-static-assets.mjs",
+              cache: { enabled: true, cross_version_cache: false },
+          }
+        : {}),
+    assets: {
+        directory:
+            id === "stream"
+                ? "../packages/media-streaming/video-streaming/frontend/dist"
+                : "../packages/file-share/frontend/dist",
+        html_handling: "auto-trailing-slash",
+        not_found_handling: "none",
+    },
+});
+
+test("private deployment configs omit routes and retain absolute asset inputs", () => {
+    const canonical = canonicalRouteConfig("stream");
+    const configFile = path.join(repoRoot, ".wrangler-config", "stream.jsonc");
+    const privateConfig = createRouteFreeWranglerConfig({
+        configFile,
+        renderedConfig: canonical,
+        workerName: "peerbit-examples-stream",
+    });
+
+    assert.equal("routes" in privateConfig, false);
+    assert.equal("route" in privateConfig, false);
+    assert.equal("domains" in privateConfig, false);
+    assert.equal("$schema" in privateConfig, false);
+    assert.equal(
+        privateConfig.main,
+        path.join(repoRoot, "cloudflare/cached-static-assets.mjs")
+    );
+    assert.equal(
+        privateConfig.assets.directory,
+        path.join(
+            repoRoot,
+            "packages/media-streaming/video-streaming/frontend/dist"
+        )
+    );
+    assert.equal(canonical.routes.length, 1);
+    assert.equal(canonical.assets.directory.startsWith("../"), true);
+    assert.throws(
+        () =>
+            createRouteFreeWranglerConfig({
+                configFile,
+                renderedConfig: {
+                    ...canonical,
+                    route: "stream.apps.peerbit.org",
+                },
+                workerName: "peerbit-examples-stream",
+            }),
+        /must not contain alternate route fields/
+    );
+    assert.throws(
+        () =>
+            createRouteFreeWranglerConfig({
+                configFile,
+                renderedConfig: {
+                    ...canonical,
+                    domains: ["stream.apps.peerbit.org"],
+                },
+                workerName: "peerbit-examples-stream",
+            }),
+        /must not contain alternate route fields/
+    );
+});
+
+test("Wrangler versions upload receives only a private route-free config", () => {
+    const canonical = canonicalRouteConfig("files");
+    const canonicalFile = path.join(
+        repoRoot,
+        ".wrangler-config",
+        "files.jsonc"
+    );
+    let invokedConfigFile;
+    const versionTag = "peerbit_files_aaaaaaaaaaaa_test";
+    const evidence = runWranglerVersionUpload({
+        wrangler: "/tools/wrangler",
+        configFile: canonicalFile,
+        renderedConfig: canonical,
+        site: { id: "files" },
+        expectedCommit: COMMIT,
+        workerName: "peerbit-examples-files",
+        versionTag,
+        environment: CLOUDFLARE_CREDENTIALS,
+        runtime: {
+            runLogged: (command, args, environment) => {
+                assert.equal(command, "/tools/wrangler");
+                assert.deepEqual(args.slice(0, 2), ["versions", "upload"]);
+                assert.equal(args[args.indexOf("--tag") + 1], versionTag);
+                assert.equal(
+                    args.some((argument) =>
+                        [
+                            "--route",
+                            "--routes",
+                            "--domain",
+                            "--domains",
+                        ].includes(argument)
+                    ),
+                    false
+                );
+                invokedConfigFile = args[args.indexOf("--config") + 1];
+                assert.notEqual(invokedConfigFile, canonicalFile);
+                const invokedConfig = JSON.parse(
+                    readFileSync(invokedConfigFile, "utf8")
+                );
+                assert.equal("routes" in invokedConfig, false);
+                assert.equal("route" in invokedConfig, false);
+                assert.equal("domains" in invokedConfig, false);
+                assert.equal(
+                    invokedConfig.assets.directory,
+                    path.join(repoRoot, "packages/file-share/frontend/dist")
+                );
+                assert.equal(statSync(invokedConfigFile).mode & 0o777, 0o600);
+                assert.equal(
+                    statSync(path.dirname(invokedConfigFile)).mode & 0o077,
+                    0
+                );
+                writeFileSync(
+                    environment.WRANGLER_OUTPUT_FILE_PATH,
+                    wranglerVersionUploadRecord() + "\n",
+                    "utf8"
+                );
+            },
+        },
+    });
+
+    assert.deepEqual(evidence, deploymentEvidence("files"));
+    assert.ok(invokedConfigFile);
+    assert.equal(existsSync(path.dirname(invokedConfigFile)), false);
+});
+
+test("unexpected Wrangler Preview URL output fails closed without exposing the account slug", () => {
+    const accountSlug = "private-account-slug";
+    const previewUrl = `https://version-files.${accountSlug}.workers.dev`;
+    let failure;
+    try {
+        runWranglerVersionUpload({
+            wrangler: "/tools/wrangler",
+            configFile: path.join(repoRoot, ".wrangler-config", "files.jsonc"),
+            renderedConfig: canonicalRouteConfig("files"),
+            site: { id: "files" },
+            expectedCommit: COMMIT,
+            workerName: "peerbit-examples-files",
+            versionTag: "peerbit_files_aaaaaaaaaaaa_preview_guard",
+            environment: CLOUDFLARE_CREDENTIALS,
+            runtime: {
+                runLogged: (_command, _args, environment, output) => {
+                    assert.equal(typeof output.writeStdout, "function");
+                    assert.equal(typeof output.writeStderr, "function");
+                    output.writeStdout(previewUrl);
+                    output.writeStderr(previewUrl);
+                    writeFileSync(
+                        environment.WRANGLER_OUTPUT_FILE_PATH,
+                        wranglerVersionUploadRecord() + "\n",
+                        "utf8"
+                    );
+                    return { stdout: previewUrl, stderr: "" };
+                },
+            },
+        });
+    } catch (error) {
+        failure = error;
+    }
+    assert.ok(failure instanceof Error);
+    assert.match(failure.message, /unexpected workers\.dev/);
+    assert.doesNotMatch(failure.message, new RegExp(accountSlug));
+    assert.doesNotMatch(failure.message, /version-files/);
+});
+
+test("pinned Wrangler version upload cannot invoke route or domain publishers", () => {
+    const wranglerPackage = JSON.parse(
+        readFileSync(path.join(repoRoot, "tools/wrangler/package.json"), "utf8")
+    );
+    const wranglerLock = JSON.parse(
+        readFileSync(
+            path.join(repoRoot, "tools/wrangler/package-lock.json"),
+            "utf8"
+        )
+    );
+    assert.equal(wranglerPackage.devDependencies.wrangler, "4.110.0");
+    assert.equal(
+        wranglerLock.packages["node_modules/wrangler"].version,
+        "4.110.0"
+    );
+    assert.match(
+        wranglerLock.packages["node_modules/wrangler"].integrity,
+        /^sha512-/
+    );
+
+    const bundleFile = path.join(
+        repoRoot,
+        "tools/wrangler/node_modules/wrangler/wrangler-dist/cli.js"
+    );
+    assert.equal(
+        existsSync(bundleFile),
+        true,
+        "install the exact locked Wrangler before running safety tests"
+    );
+    const bundle = readFileSync(bundleFile, "utf8");
+
+    const mergeStart = bundle.indexOf(
+        "async function mergeVersionsUploadConfigArgs(args, config2)"
+    );
+    const mergeEnd = bundle.indexOf(
+        "\nfunction cleanupDestination",
+        mergeStart
+    );
+    assert.ok(mergeStart >= 0 && mergeEnd > mergeStart);
+    const mergeUpload = bundle.slice(mergeStart, mergeEnd);
+    assert.doesNotMatch(mergeUpload, /routes|domains|triggers/);
+
+    const uploadStart = bundle.indexOf(
+        "async function versionsUpload(props, config2, buildResult, callbacks)"
+    );
+    const uploadEnd = bundle.indexOf(
+        "\nfunction sanitizeBranchName",
+        uploadStart
+    );
+    assert.ok(uploadStart >= 0 && uploadEnd > uploadStart);
+    const upload = bundle.slice(uploadStart, uploadEnd);
+    assert.match(upload, /`\$\{workerUrl\}\/versions`[\s\S]*method: "POST"/);
+    assert.match(
+        upload,
+        /Changes to triggers \(routes, custom domains, cron schedules, etc\) must be applied with the command/
+    );
+    assert.doesNotMatch(upload, /\btriggersDeploy\(/);
+    assert.doesNotMatch(upload, /\bpublishRoutes\(|\bpublishCustomDomains\(/);
+    assert.doesNotMatch(upload, /\/domains\/records|\/routes/);
 });

--- a/cloudflare/deployment-safety.test.mjs
+++ b/cloudflare/deployment-safety.test.mjs
@@ -695,6 +695,83 @@ test("Worker subdomain API ambiguity and authorization failures fail closed", as
     }
 });
 
+test("Worker subdomain API failures redact complete workers.dev references", async (t) => {
+    const accountId = "d".repeat(32);
+    const apiToken = "redact-this-token";
+    const longTail = "x".repeat(600);
+    const fixtures = [
+        {
+            name: "HTTP error payload",
+            reference:
+                "https://v-worker.private-account-slug.workers.dev/path?x=1",
+            request: (reference) =>
+                new Response(
+                    JSON.stringify({
+                        success: false,
+                        errors: [
+                            {
+                                code: 10000,
+                                message: `${reference} token ${apiToken} account ${accountId} ${longTail}`,
+                            },
+                        ],
+                    }),
+                    { status: 403 }
+                ),
+        },
+        {
+            name: "mixed-case transport error",
+            reference:
+                "HTTPS://V-WorKer.Private-Account-Slug.WoRkErS.DeV:8787/Private-Path?Secret-Query=1#Private-Fragment",
+            request: (reference) => {
+                throw new Error(
+                    `${reference} token ${apiToken} account ${accountId} ${longTail}`
+                );
+            },
+        },
+    ];
+
+    for (const fixture of fixtures) {
+        await t.test(fixture.name, async () => {
+            const api = createCloudflareWorkersApi({
+                accountId,
+                apiToken,
+                request: async () => fixture.request(fixture.reference),
+            });
+            let failure;
+            try {
+                await api.getWorkerSubdomain("peerbit-examples-files");
+            } catch (error) {
+                failure = error;
+            }
+
+            assert.ok(failure instanceof CloudflareWorkersApiError);
+            const normalizedMessage = failure.details.errors[0].message;
+            assert.match(failure.message, /\[REDACTED_WORKERS_DEV_REFERENCE\]/);
+            assert.match(failure.message, /\[REDACTED\]/);
+            assert.doesNotMatch(normalizedMessage, /workers\.dev/i);
+            for (const privateValue of [
+                fixture.reference,
+                "v-worker",
+                "private-account-slug",
+                "8787",
+                "private-path",
+                "secret-query",
+                "private-fragment",
+                apiToken,
+                accountId,
+            ]) {
+                assert.equal(
+                    failure.message
+                        .toLowerCase()
+                        .includes(privateValue.toLowerCase()),
+                    false
+                );
+            }
+            assert.equal(failure.details.indeterminateMutation, false);
+        });
+    }
+});
+
 test("Cloudflare Workers API exhausts read-only custom-domain pagination", async () => {
     const accountId = "c".repeat(32);
     const apiToken = "test-token_123";
@@ -1963,7 +2040,7 @@ test("a public-subdomain flip is caught immediately before a later upload", asyn
             log: () => {},
             operations: harness.operations,
         }),
-        /Inactive Worker version upload phase failed.*peerbit-examples-stream: workers\.dev and Worker Preview URLs must both be disabled/is
+        /Inactive Worker version upload phase failed.*peerbit-examples-stream: \[REDACTED_WORKERS_DEV_REFERENCE\] and Worker Preview URLs must both be disabled/is
     );
     assert.deepEqual(harness.events, ["upload:files"]);
 });
@@ -2223,7 +2300,7 @@ test("final success and rollback fencing include public subdomain state", async 
     assert.ok(failure instanceof Error);
     assert.match(
         failure.message,
-        /production rollout failed.*workers\.dev and Worker Preview URLs must both be disabled/is
+        /production rollout failed.*\[REDACTED_WORKERS_DEV_REFERENCE\] and Worker Preview URLs must both be disabled/is
     );
     assert.match(failure.message, /automatic rollback refused/);
     assert.equal(harness.current.get("files"), NEW_VERSION);
@@ -2704,7 +2781,7 @@ test("rollback success requires full policy and active-version confirmation afte
         {
             name: "public-subdomain drift",
             pattern:
-                /workers\.dev and Worker Preview URLs must both be disabled/,
+                /\[REDACTED_WORKERS_DEV_REFERENCE\] and Worker Preview URLs must both be disabled/,
             configure: (harness) => () => {
                 harness.subdomains.set("peerbit-examples-files", {
                     enabled: false,

--- a/cloudflare/workflow-safety.test.mjs
+++ b/cloudflare/workflow-safety.test.mjs
@@ -26,6 +26,10 @@ test("credentialed production shell receives target and commit through env", () 
         productionWorkflow,
         /--commit[^\n]*\$\{\{[^\n]*github\.sha/
     );
+    assert.doesNotMatch(
+        productionWorkflow,
+        /initialize_missing_workers|INITIALIZE_MISSING_WORKERS|initialize-missing-workers/
+    );
 });
 
 test("Cloudflare workflows carry no Supabase build configuration", () => {
@@ -44,6 +48,14 @@ test("preview hosting is validation-only and has no Cloudflare credentials", () 
         /environment:\s*cloudflare-production/
     );
     assert.match(previewWorkflow, /--dry-run/);
+    assert.match(previewWorkflow, /wrangler versions upload/);
+});
+
+test("every CI bundle check exercises the inactive versions-upload path", () => {
+    for (const workflow of [previewWorkflow, productionWorkflow]) {
+        assert.match(workflow, /wrangler versions upload/);
+        assert.doesNotMatch(workflow, /wrangler deploy\s*\\\s*\n\s*--config/);
+    }
 });
 
 test("production deployment remains manually gated", () => {
@@ -54,4 +66,18 @@ test("production deployment remains manually gated", () => {
         /inputs\.confirm == 'deploy-peerbit-production'/
     );
     assert.match(productionWorkflow, /environment: cloudflare-production/);
+    assert.doesNotMatch(productionWorkflow, /initialize_missing_workers/);
+});
+
+test("locked Wrangler is installed before its source contract tests", () => {
+    for (const workflow of [previewWorkflow, productionWorkflow]) {
+        const install = workflow.indexOf(
+            "npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler"
+        );
+        const safetyTests = workflow.indexOf(
+            "node --test cloudflare/*.test.mjs"
+        );
+        assert.ok(install >= 0);
+        assert.ok(safetyTests > install);
+    }
 });

--- a/scripts/cloudflare-deployment-policy.mjs
+++ b/scripts/cloudflare-deployment-policy.mjs
@@ -12,6 +12,7 @@ const readJson = (file) => JSON.parse(readFileSync(file, "utf8"));
 export const APP_PRODUCTION_SUFFIX = ".apps.peerbit.org";
 export const APP_PRODUCTION_HOSTNAME_PATTERN =
     /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.apps\.peerbit\.org$/;
+export const CLOUDFLARE_WORKER_NAMESPACE_PREFIX = "peerbit-examples-";
 
 export const resolveCloudflareConfigOutputDirectory = ({
     output,
@@ -107,6 +108,16 @@ export const validateCloudflareDeploymentPolicy = (manifest, policy) => {
         }
         if (!/^[a-z0-9-]{1,63}$/.test(entry.previewWorker || "")) {
             throw new Error(`${entry.id}: invalid preview Worker`);
+        }
+        if (
+            !entry.productionWorker.startsWith(
+                CLOUDFLARE_WORKER_NAMESPACE_PREFIX
+            ) ||
+            !entry.previewWorker.startsWith(CLOUDFLARE_WORKER_NAMESPACE_PREFIX)
+        ) {
+            throw new Error(
+                `${entry.id}: Worker identities must stay inside the reviewed ${CLOUDFLARE_WORKER_NAMESPACE_PREFIX} namespace`
+            );
         }
         if (entry.productionWorker === entry.previewWorker) {
             throw new Error(

--- a/scripts/cloudflare-workers-api.mjs
+++ b/scripts/cloudflare-workers-api.mjs
@@ -1,0 +1,543 @@
+const CLOUDFLARE_ACCOUNT_ID = /^[0-9a-f]{32}$/i;
+const WORKER_NAME = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+const DNS_HOSTNAME =
+    /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const VERSION_ID =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const CLOUDFLARE_API_BASE_URL = "https://api.cloudflare.com/client/v4";
+const CUSTOM_DOMAIN_PAGE_SIZE = 100;
+const MAX_CUSTOM_DOMAIN_PAGES = 1_000;
+const MAX_CUSTOM_DOMAIN_SNAPSHOT_ATTEMPTS = 3;
+
+const redactText = (value, secrets, { maxLength } = {}) => {
+    let text = value instanceof Error ? value.message : String(value);
+    const orderedSecrets = [
+        ...new Set(
+            secrets.filter(
+                (secret) => typeof secret === "string" && secret.length > 0
+            )
+        ),
+    ].sort((left, right) => right.length - left.length);
+    for (const secret of orderedSecrets) {
+        text = text.replaceAll(secret, "[REDACTED]");
+    }
+    return Number.isSafeInteger(maxLength) ? text.slice(0, maxLength) : text;
+};
+
+const normalizedErrors = ({ payload, cause, secrets }) => {
+    const errors = Array.isArray(payload?.errors) ? payload.errors : [];
+    const normalized = errors.slice(0, 5).map((error) => ({
+        ...(Number.isSafeInteger(error?.code) ? { code: error.code } : {}),
+        message: redactText(
+            error?.message ?? "Unspecified API error",
+            secrets,
+            {
+                maxLength: 500,
+            }
+        ),
+    }));
+    if (normalized.length === 0 && cause) {
+        normalized.push({
+            message: redactText(cause, secrets, { maxLength: 500 }),
+        });
+    }
+    if (normalized.length === 0) {
+        normalized.push({ message: "Unspecified API error" });
+    }
+    return normalized;
+};
+
+export class CloudflareWorkersApiError extends Error {
+    constructor({
+        operation,
+        status,
+        payload,
+        cause,
+        secrets,
+        indeterminateMutation = false,
+    }) {
+        const details = {
+            operation,
+            status: Number.isInteger(status) ? status : null,
+            indeterminateMutation: indeterminateMutation === true,
+            errors: normalizedErrors({ payload, cause, secrets }),
+        };
+        super(`Cloudflare Workers API error: ${JSON.stringify(details)}`);
+        this.name = "CloudflareWorkersApiError";
+        this.details = details;
+        this.indeterminateMutation = details.indeterminateMutation;
+    }
+}
+
+export const isIndeterminateCloudflareMutationError = (error) =>
+    error instanceof CloudflareWorkersApiError &&
+    error.indeterminateMutation === true;
+
+const parseResponse = async ({
+    response,
+    operation,
+    secrets,
+    mutationDispatched = false,
+}) => {
+    let payload;
+    try {
+        const raw = await response.text();
+        payload = raw.trim() === "" ? undefined : JSON.parse(raw);
+    } catch {
+        throw new CloudflareWorkersApiError({
+            operation,
+            status: response.status,
+            cause: new Error("Cloudflare returned malformed JSON"),
+            secrets,
+            // A response-body failure after dispatch cannot prove whether the
+            // mutation was accepted before the response became unreadable.
+            indeterminateMutation: mutationDispatched,
+        });
+    }
+
+    if (!response.ok || (payload && payload.success !== true)) {
+        throw new CloudflareWorkersApiError({
+            operation,
+            status: response.status,
+            payload,
+            secrets,
+            // Cloudflare does not expose at-most-once or non-application
+            // evidence for this mutation. Once the POST has been dispatched,
+            // no response failure is safe evidence that it was not applied.
+            indeterminateMutation: mutationDispatched,
+        });
+    }
+    if (!payload) {
+        throw new CloudflareWorkersApiError({
+            operation,
+            status: response.status,
+            cause: new Error("Cloudflare returned an empty response"),
+            secrets,
+            indeterminateMutation: mutationDispatched,
+        });
+    }
+    return payload;
+};
+
+export const createCloudflareWorkersApi = ({
+    accountId,
+    apiToken,
+    request = fetch,
+}) => {
+    if (!CLOUDFLARE_ACCOUNT_ID.test(accountId || "")) {
+        throw new Error(
+            "CLOUDFLARE_ACCOUNT_ID must be exactly 32 hexadecimal characters"
+        );
+    }
+    if (
+        typeof apiToken !== "string" ||
+        apiToken.length === 0 ||
+        /\s/.test(apiToken)
+    ) {
+        throw new Error("CLOUDFLARE_API_TOKEN is missing or malformed");
+    }
+    const scriptsUrl = `${CLOUDFLARE_API_BASE_URL}/accounts/${accountId}/workers/scripts`;
+    const domainsUrl = `${CLOUDFLARE_API_BASE_URL}/accounts/${accountId}/workers/domains`;
+    const secrets = [apiToken, accountId];
+    const call = async ({ operation, url, method = "GET", body }) => {
+        let response;
+        try {
+            response = await request(url, {
+                method,
+                headers: {
+                    Authorization: `Bearer ${apiToken}`,
+                    ...(body === undefined
+                        ? {}
+                        : { "Content-Type": "application/json" }),
+                },
+                ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+                signal: AbortSignal.timeout(15_000),
+            });
+        } catch (cause) {
+            throw new CloudflareWorkersApiError({
+                operation,
+                cause,
+                secrets,
+                // Once a mutation request has left the client, a transport
+                // failure cannot prove whether Cloudflare accepted it. GET
+                // failures are observational and therefore never carry this
+                // marker.
+                indeterminateMutation: method !== "GET",
+            });
+        }
+        return parseResponse({
+            response,
+            operation,
+            secrets,
+            mutationDispatched: method !== "GET",
+        });
+    };
+
+    const invalidResult = ({
+        operation,
+        message,
+        indeterminateMutation = false,
+    }) => {
+        throw new CloudflareWorkersApiError({
+            operation,
+            status: 200,
+            cause: new Error(message),
+            secrets,
+            indeterminateMutation,
+        });
+    };
+    const workerResourceUrl = (workerName) => {
+        if (!WORKER_NAME.test(workerName || "")) {
+            throw new Error("Cloudflare Worker name is missing or malformed");
+        }
+        return `${scriptsUrl}/${workerName}`;
+    };
+    const requireVersionId = (versionId) => {
+        if (!VERSION_ID.test(versionId || "")) {
+            throw new Error(
+                "Cloudflare Worker version ID is missing or malformed"
+            );
+        }
+        return versionId;
+    };
+
+    return {
+        listWorkerScripts: async () => {
+            const payload = await call({
+                operation: "list account Worker scripts",
+                url: scriptsUrl,
+            });
+            if (!Array.isArray(payload.result)) {
+                throw new CloudflareWorkersApiError({
+                    operation: "list account Worker scripts",
+                    status: 200,
+                    cause: new Error(
+                        "Cloudflare returned no Worker script list"
+                    ),
+                    secrets,
+                });
+            }
+            const scripts = new Map();
+            for (const script of payload.result) {
+                if (
+                    typeof script?.id !== "string" ||
+                    script.id.length === 0 ||
+                    scripts.has(script.id) ||
+                    (script.tag != null &&
+                        (typeof script.tag !== "string" ||
+                            script.tag.length === 0)) ||
+                    !Array.isArray(script.routes)
+                ) {
+                    throw new CloudflareWorkersApiError({
+                        operation: "list account Worker scripts",
+                        status: 200,
+                        cause: new Error(
+                            "Cloudflare returned an invalid Worker script identity"
+                        ),
+                        secrets,
+                    });
+                }
+                const routeIds = new Set();
+                const routePatterns = new Set();
+                const routes = [];
+                for (const route of script.routes) {
+                    if (
+                        typeof route?.id !== "string" ||
+                        route.id.length === 0 ||
+                        routeIds.has(route.id) ||
+                        typeof route.pattern !== "string" ||
+                        route.pattern.length === 0 ||
+                        routePatterns.has(route.pattern) ||
+                        route.script !== script.id
+                    ) {
+                        throw new CloudflareWorkersApiError({
+                            operation: "list account Worker scripts",
+                            status: 200,
+                            cause: new Error(
+                                "Cloudflare returned an invalid or ambiguous Worker route attachment"
+                            ),
+                            secrets,
+                        });
+                    }
+                    routeIds.add(route.id);
+                    routePatterns.add(route.pattern);
+                    routes.push({
+                        id: route.id,
+                        pattern: route.pattern,
+                        script: route.script,
+                    });
+                }
+                scripts.set(script.id, { tag: script.tag, routes });
+            }
+            return scripts;
+        },
+        listWorkerDomains: async () => {
+            const operation = "list account Worker custom domains";
+            const readSnapshot = async () => {
+                const domains = [];
+                const domainIds = new Set();
+                const hostnames = new Set();
+                let expectedTotalCount;
+                let expectedTotalPages;
+                let expectedPerPage;
+
+                for (let page = 1; page <= MAX_CUSTOM_DOMAIN_PAGES; page += 1) {
+                    const payload = await call({
+                        operation,
+                        url: `${domainsUrl}?page=${page}&per_page=${CUSTOM_DOMAIN_PAGE_SIZE}`,
+                    });
+                    const result = payload.result;
+                    const info = payload.result_info;
+                    const validInfo =
+                        Array.isArray(result) &&
+                        info &&
+                        typeof info === "object" &&
+                        Number.isSafeInteger(info.count) &&
+                        info.count >= 0 &&
+                        info.count === result.length &&
+                        Number.isSafeInteger(info.page) &&
+                        info.page === page &&
+                        Number.isSafeInteger(info.per_page) &&
+                        info.per_page > 0 &&
+                        info.count <= info.per_page &&
+                        Number.isSafeInteger(info.total_count) &&
+                        info.total_count >= 0 &&
+                        Number.isSafeInteger(info.total_pages) &&
+                        info.total_pages >= 0 &&
+                        info.total_pages <= MAX_CUSTOM_DOMAIN_PAGES &&
+                        (info.total_count === 0
+                            ? info.total_pages === 0 || info.total_pages === 1
+                            : info.total_pages ===
+                              Math.ceil(info.total_count / info.per_page)) &&
+                        page <= Math.max(info.total_pages, 1);
+                    if (!validInfo) {
+                        invalidResult({
+                            operation,
+                            message:
+                                "Cloudflare returned invalid or ambiguous custom-domain pagination",
+                        });
+                    }
+
+                    expectedTotalCount ??= info.total_count;
+                    expectedTotalPages ??= info.total_pages;
+                    expectedPerPage ??= info.per_page;
+                    if (
+                        info.total_count !== expectedTotalCount ||
+                        info.total_pages !== expectedTotalPages ||
+                        info.per_page !== expectedPerPage
+                    ) {
+                        invalidResult({
+                            operation,
+                            message:
+                                "Cloudflare custom-domain pagination changed while it was being read",
+                        });
+                    }
+
+                    for (const domain of result) {
+                        const hostname =
+                            typeof domain?.hostname === "string"
+                                ? domain.hostname.toLowerCase()
+                                : undefined;
+                        if (
+                            typeof domain?.id !== "string" ||
+                            domain.id.length === 0 ||
+                            domainIds.has(domain.id) ||
+                            !hostname ||
+                            !DNS_HOSTNAME.test(hostname) ||
+                            domain.hostname.trim() !== domain.hostname ||
+                            hostnames.has(hostname) ||
+                            !WORKER_NAME.test(domain.service || "") ||
+                            typeof domain.environment !== "string" ||
+                            domain.environment.length === 0 ||
+                            !CLOUDFLARE_ACCOUNT_ID.test(domain.zone_id || "") ||
+                            typeof domain.zone_name !== "string" ||
+                            domain.zone_name.length === 0
+                        ) {
+                            invalidResult({
+                                operation,
+                                message:
+                                    "Cloudflare returned an invalid or ambiguous custom-domain attachment",
+                            });
+                        }
+                        domainIds.add(domain.id);
+                        hostnames.add(hostname);
+                        domains.push({
+                            id: domain.id,
+                            hostname,
+                            service: domain.service,
+                            environment: domain.environment,
+                            zoneId: domain.zone_id,
+                            zoneName: domain.zone_name.toLowerCase(),
+                        });
+                    }
+
+                    if (page >= info.total_pages) break;
+                }
+
+                if (
+                    expectedTotalCount == null ||
+                    expectedTotalPages == null ||
+                    domains.length !== expectedTotalCount
+                ) {
+                    invalidResult({
+                        operation,
+                        message:
+                            "Cloudflare returned an incomplete custom-domain inventory",
+                    });
+                }
+                return domains.sort((left, right) =>
+                    left.id.localeCompare(right.id)
+                );
+            };
+
+            let previousCanonicalSnapshot;
+            for (
+                let attempt = 1;
+                attempt <= MAX_CUSTOM_DOMAIN_SNAPSHOT_ATTEMPTS;
+                attempt += 1
+            ) {
+                const snapshot = await readSnapshot();
+                const canonicalSnapshot = JSON.stringify(snapshot);
+                if (canonicalSnapshot === previousCanonicalSnapshot) {
+                    return snapshot;
+                }
+                previousCanonicalSnapshot = canonicalSnapshot;
+            }
+            invalidResult({
+                operation,
+                message:
+                    "Cloudflare custom-domain inventory did not remain stable across complete snapshots",
+            });
+        },
+        getWorkerSubdomain: async (workerName) => {
+            const operation = `read workers.dev and Preview URL state for ${workerName}`;
+            const payload = await call({
+                operation,
+                url: `${workerResourceUrl(workerName)}/subdomain`,
+            });
+            const result = payload.result;
+            const keys =
+                result && typeof result === "object" && !Array.isArray(result)
+                    ? Object.keys(result).sort()
+                    : [];
+            if (
+                keys.length !== 2 ||
+                keys[0] !== "enabled" ||
+                keys[1] !== "previews_enabled" ||
+                typeof result.enabled !== "boolean" ||
+                typeof result.previews_enabled !== "boolean"
+            ) {
+                invalidResult({
+                    operation,
+                    message:
+                        "Cloudflare returned invalid or ambiguous Worker subdomain state",
+                });
+            }
+            return {
+                enabled: result.enabled,
+                previewsEnabled: result.previews_enabled,
+            };
+        },
+        getCurrentDeployment: async (workerName) => {
+            const operation = `read active deployment for ${workerName}`;
+            const payload = await call({
+                operation,
+                url: `${workerResourceUrl(workerName)}/deployments`,
+            });
+            if (
+                !Array.isArray(payload.result?.deployments) ||
+                !payload.result.deployments[0] ||
+                typeof payload.result.deployments[0] !== "object"
+            ) {
+                invalidResult({
+                    operation,
+                    message: "Cloudflare returned no active Worker deployment",
+                });
+            }
+            // Cloudflare documents the first item as the deployment actively
+            // serving traffic. Returning only it prevents callers from
+            // accidentally treating an older history item as current.
+            return payload.result.deployments[0];
+        },
+        getWorkerVersion: async (workerName, versionId) => {
+            const validVersionId = requireVersionId(versionId);
+            const operation = `read Worker version ${validVersionId} for ${workerName}`;
+            const payload = await call({
+                operation,
+                url: `${workerResourceUrl(workerName)}/versions/${validVersionId}`,
+            });
+            if (
+                !payload.result ||
+                typeof payload.result !== "object" ||
+                payload.result.id !== validVersionId
+            ) {
+                invalidResult({
+                    operation,
+                    message: "Cloudflare returned the wrong Worker version",
+                });
+            }
+            return payload.result;
+        },
+        createDeployment: async ({ workerName, versionId, message }) => {
+            const validVersionId = requireVersionId(versionId);
+            if (
+                typeof message !== "string" ||
+                message.length === 0 ||
+                new TextEncoder().encode(message).byteLength > 1_000
+            ) {
+                throw new Error(
+                    "Cloudflare deployment message is missing or too long"
+                );
+            }
+            const operation = `activate Worker version ${validVersionId} for ${workerName}`;
+            const payload = await call({
+                operation,
+                url: `${workerResourceUrl(workerName)}/deployments`,
+                method: "POST",
+                body: {
+                    strategy: "percentage",
+                    versions: [{ version_id: validVersionId, percentage: 100 }],
+                    annotations: {
+                        "workers/message": message,
+                        "workers/triggered_by": "peerbit-production-workflow",
+                    },
+                },
+            });
+            const result = payload.result;
+            if (
+                !result ||
+                typeof result !== "object" ||
+                !VERSION_ID.test(result.id || "") ||
+                result.strategy !== "percentage" ||
+                !Array.isArray(result.versions) ||
+                result.versions.length !== 1 ||
+                result.versions[0]?.version_id !== validVersionId ||
+                result.versions[0]?.percentage !== 100
+            ) {
+                invalidResult({
+                    operation,
+                    message:
+                        "Cloudflare returned invalid exact-version deployment evidence",
+                    indeterminateMutation: true,
+                });
+            }
+            return result;
+        },
+    };
+};
+
+export const isCloudflareAuthenticationEnvironmentVariable = (name) =>
+    name.startsWith("CLOUDFLARE_") ||
+    name.startsWith("CF_") ||
+    name === "WRANGLER_CF_AUTHORIZATION_TOKEN" ||
+    name === "WRANGLER_R2_SQL_AUTH_TOKEN";
+
+export const redactCloudflareCredentials = (value, environment) =>
+    redactText(
+        value,
+        Object.entries(environment)
+            .filter(([name]) =>
+                isCloudflareAuthenticationEnvironmentVariable(name)
+            )
+            .map(([, secret]) => secret)
+    );

--- a/scripts/cloudflare-workers-api.mjs
+++ b/scripts/cloudflare-workers-api.mjs
@@ -8,9 +8,12 @@ const CLOUDFLARE_API_BASE_URL = "https://api.cloudflare.com/client/v4";
 const CUSTOM_DOMAIN_PAGE_SIZE = 100;
 const MAX_CUSTOM_DOMAIN_PAGES = 1_000;
 const MAX_CUSTOM_DOMAIN_SNAPSHOT_ATTEMPTS = 3;
+const WORKERS_DEV_REFERENCE =
+    /(?<![a-z0-9-])(?:(?:[a-z][a-z0-9+.-]*:)?\/\/)?(?:[a-z0-9-]+\.)*workers\.dev(?![a-z0-9.-])(?::[0-9]+)?(?:[/?#][^\s<>"']*)?/gi;
+const WORKERS_DEV_REDACTION = "[REDACTED_WORKERS_DEV_REFERENCE]";
 
 const redactText = (value, secrets, { maxLength } = {}) => {
-    let text = value instanceof Error ? value.message : String(value);
+    const text = value instanceof Error ? value.message : String(value);
     const orderedSecrets = [
         ...new Set(
             secrets.filter(
@@ -18,10 +21,25 @@ const redactText = (value, secrets, { maxLength } = {}) => {
             )
         ),
     ].sort((left, right) => right.length - left.length);
-    for (const secret of orderedSecrets) {
-        text = text.replaceAll(secret, "[REDACTED]");
+    const redactSecrets = (segment) => {
+        let result = segment;
+        for (const secret of orderedSecrets) {
+            result = result.replaceAll(secret, "[REDACTED]");
+        }
+        return result;
+    };
+    const redacted = [];
+    let cursor = 0;
+    for (const match of text.matchAll(WORKERS_DEV_REFERENCE)) {
+        redacted.push(redactSecrets(text.slice(cursor, match.index)));
+        redacted.push(WORKERS_DEV_REDACTION);
+        cursor = match.index + match[0].length;
     }
-    return Number.isSafeInteger(maxLength) ? text.slice(0, maxLength) : text;
+    redacted.push(redactSecrets(text.slice(cursor)));
+    const result = redacted.join("");
+    return Number.isSafeInteger(maxLength)
+        ? result.slice(0, maxLength)
+        : result;
 };
 
 const normalizedErrors = ({ payload, cause, secrets }) => {

--- a/scripts/cloudflare-workers-api.mjs
+++ b/scripts/cloudflare-workers-api.mjs
@@ -9,7 +9,7 @@ const CUSTOM_DOMAIN_PAGE_SIZE = 100;
 const MAX_CUSTOM_DOMAIN_PAGES = 1_000;
 const MAX_CUSTOM_DOMAIN_SNAPSHOT_ATTEMPTS = 3;
 const WORKERS_DEV_REFERENCE =
-    /(?<![a-z0-9-])(?:(?:[a-z][a-z0-9+.-]*:)?\/\/)?(?:[a-z0-9-]+\.)*workers\.dev(?![a-z0-9.-])(?::[0-9]+)?(?:[/?#][^\s<>"']*)?/gi;
+    /(?<![a-z0-9-])(?:(?:[a-z][a-z0-9+.-]*:)?\/\/)?(?:[a-z0-9-]+\.)*workers\.dev(?:\.(?![a-z0-9-])|(?![a-z0-9.-]))(?::[0-9]+)?(?:[/?#][^\s<>"']*)?/gi;
 const WORKERS_DEV_REDACTION = "[REDACTED_WORKERS_DEV_REFERENCE]";
 
 const redactText = (value, secrets, { maxLength } = {}) => {

--- a/scripts/deploy-cloudflare-production.mjs
+++ b/scripts/deploy-cloudflare-production.mjs
@@ -1,16 +1,42 @@
 import { spawnSync } from "node:child_process";
+import {
+    existsSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import {
+    APP_PRODUCTION_SUFFIX,
+    CLOUDFLARE_WORKER_NAMESPACE_PREFIX,
     loadCloudflareDeploymentData,
     repoRoot,
     selectCloudflareDeploymentEntries,
     validateRenderedCloudflareConfigSet,
 } from "./cloudflare-deployment-policy.mjs";
+import {
+    createCloudflareWorkersApi,
+    isCloudflareAuthenticationEnvironmentVariable,
+    isIndeterminateCloudflareMutationError,
+    redactCloudflareCredentials,
+} from "./cloudflare-workers-api.mjs";
 
 const VERSION_ID =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const FULL_GIT_COMMIT = /^[0-9a-f]{40}$/i;
+const PRODUCTION_DEPLOYMENT_ARGUMENTS = new Set(["target", "commit"]);
+const PRODUCTION_DEPLOYMENT_USAGE =
+    "Usage: deploy-cloudflare-production.mjs --target ID|apps|all --commit SHA";
+const MAX_DIAGNOSTIC_LENGTH = 2_000;
+const VERSION_TAG = /^[A-Za-z0-9_-]{1,100}$/;
+const DNS_HOSTNAME =
+    /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const INDETERMINATE_ACTIVATION_OBSERVATIONS = 12;
+const INDETERMINATE_ACTIVATION_DELAY_MS = 2_500;
 
 const productionOrigin = ({ site, policy }) => {
     if (
@@ -99,8 +125,756 @@ export const readSingleVersionDeployment = (deployment, siteId) => {
     return deployment.versions[0].version_id;
 };
 
+const validateDeploymentEvidence = (evidence, expectedWorkerName) => {
+    if (
+        evidence?.workerName !== expectedWorkerName ||
+        typeof evidence.workerTag !== "string" ||
+        !/^[A-Za-z0-9_-]{1,128}$/.test(evidence.workerTag) ||
+        !VERSION_ID.test(evidence.versionId || "")
+    ) {
+        throw new Error(
+            `${expectedWorkerName}: Wrangler returned invalid deployment ownership evidence`
+        );
+    }
+    return {
+        workerName: evidence.workerName,
+        workerTag: evidence.workerTag,
+        versionId: evidence.versionId,
+    };
+};
+
+const assertNoWorkersDevOutput = (...values) => {
+    if (values.some((value) => /workers\.dev/i.test(String(value || "")))) {
+        // Never include the matching output. It contains the Cloudflare
+        // account subdomain and may expose a public version Preview URL.
+        throw new Error(
+            "Wrangler emitted unexpected workers.dev or Worker Preview URL output"
+        );
+    }
+};
+
+export const parseWranglerVersionUploadOutput = (
+    output,
+    expectedWorkerName
+) => {
+    assertNoWorkersDevOutput(output);
+    const entries = [];
+    for (const line of output.split(/\r?\n/)) {
+        if (line.trim() === "") continue;
+        try {
+            const entry = JSON.parse(line);
+            if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+                throw new Error("invalid record");
+            }
+            entries.push(entry);
+        } catch {
+            throw new Error("Wrangler deployment output is not valid NDJSON");
+        }
+    }
+    const uploads = entries.filter(({ type }) => type === "version-upload");
+    if (uploads.length !== 1) {
+        throw new Error(
+            `${expectedWorkerName}: Wrangler output requires exactly one version-upload record`
+        );
+    }
+    const upload = uploads[0];
+    if (upload.version !== 1 || upload.worker_name_overridden !== false) {
+        throw new Error(
+            `${expectedWorkerName}: Wrangler version-upload record has unsupported identity metadata`
+        );
+    }
+    return validateDeploymentEvidence(
+        {
+            workerName: upload.worker_name,
+            workerTag: upload.worker_tag,
+            versionId: upload.version_id,
+        },
+        expectedWorkerName
+    );
+};
+
+export const createInvocationVersionTag = ({
+    siteId,
+    expectedCommit,
+    nonce = randomUUID(),
+}) => {
+    const tag = `peerbit_${siteId}_${expectedCommit.slice(0, 12)}_${nonce}`;
+    if (!VERSION_TAG.test(tag)) {
+        throw new Error(
+            `${siteId}: could not create a safe Worker version tag`
+        );
+    }
+    return tag;
+};
+
+const readWorkerScriptMap = async (operations) => {
+    const scripts = await operations.listWorkerScripts();
+    if (
+        !(scripts instanceof Map) ||
+        [...scripts].some(
+            ([scriptName, metadata]) =>
+                typeof scriptName !== "string" ||
+                scriptName.length === 0 ||
+                !metadata ||
+                typeof metadata !== "object" ||
+                (metadata.tag != null &&
+                    (typeof metadata.tag !== "string" ||
+                        metadata.tag.length === 0)) ||
+                !Array.isArray(metadata.routes) ||
+                metadata.routes.some(
+                    (route) =>
+                        !route ||
+                        typeof route !== "object" ||
+                        typeof route.id !== "string" ||
+                        route.id.length === 0 ||
+                        typeof route.pattern !== "string" ||
+                        route.pattern.length === 0 ||
+                        route.script !== scriptName
+                )
+        )
+    ) {
+        throw new Error(
+            "Cloudflare Worker list operation returned an invalid script map"
+        );
+    }
+    return scripts;
+};
+
+const readWorkerDomainInventory = async (operations) => {
+    const domains = await operations.listWorkerDomains();
+    const ids = new Set();
+    const hostnames = new Set();
+    if (
+        !Array.isArray(domains) ||
+        domains.some((domain) => {
+            const invalid =
+                !domain ||
+                typeof domain !== "object" ||
+                typeof domain.id !== "string" ||
+                domain.id.length === 0 ||
+                ids.has(domain.id) ||
+                typeof domain.hostname !== "string" ||
+                domain.hostname.length === 0 ||
+                domain.hostname !== domain.hostname.toLowerCase() ||
+                !DNS_HOSTNAME.test(domain.hostname) ||
+                hostnames.has(domain.hostname) ||
+                typeof domain.service !== "string" ||
+                domain.service.length === 0 ||
+                typeof domain.environment !== "string" ||
+                domain.environment.length === 0 ||
+                typeof domain.zoneId !== "string" ||
+                domain.zoneId.length === 0 ||
+                typeof domain.zoneName !== "string" ||
+                domain.zoneName.length === 0;
+            if (!invalid) {
+                ids.add(domain.id);
+                hostnames.add(domain.hostname);
+            }
+            return invalid;
+        })
+    ) {
+        throw new Error(
+            "Cloudflare custom-domain list operation returned an invalid or ambiguous inventory"
+        );
+    }
+    return domains;
+};
+
+const managedAppHostname = (hostname) =>
+    hostname === APP_PRODUCTION_SUFFIX.slice(1) ||
+    hostname.endsWith(APP_PRODUCTION_SUFFIX);
+
+const routeTargetsManagedAppHostname = (pattern) => {
+    const authority = pattern
+        .trim()
+        .toLowerCase()
+        .replace(/^[a-z]+:\/\//, "")
+        .split("/", 1)[0]
+        .replace(/:\d+$/, "")
+        .replace(/\.$/, "")
+        .replace(/^\*+/, "");
+    return managedAppHostname(authority);
+};
+
+const validateProductionAttachmentInventory = ({ plans, scripts, domains }) => {
+    const expectedByHostname = new Map();
+    const policyWorkerNames = new Set();
+    for (const plan of plans) {
+        policyWorkerNames.add(plan.workerName);
+        policyWorkerNames.add(plan.policy.previewWorker);
+        for (const hostname of plan.policy.productionHostnames) {
+            expectedByHostname.set(hostname, plan.workerName);
+        }
+    }
+
+    for (const plan of plans) {
+        const metadata = scripts.get(plan.workerName);
+        if (!metadata) {
+            throw new Error(
+                `${plan.site.id}: production Worker ${plan.workerName} disappeared during attachment validation`
+            );
+        }
+        if (metadata.routes.length !== 0) {
+            throw new Error(
+                `${plan.site.id}: ${plan.workerName} has unreviewed Worker route attachments (${metadata.routes
+                    .map(({ pattern }) => pattern)
+                    .join(", ")})`
+            );
+        }
+
+        const expectedHostnames = plan.policy.productionHostnames;
+        if (
+            !Array.isArray(expectedHostnames) ||
+            expectedHostnames.length === 0 ||
+            expectedHostnames.some(
+                (hostname) =>
+                    typeof hostname !== "string" ||
+                    hostname.length === 0 ||
+                    hostname !== hostname.toLowerCase()
+            ) ||
+            new Set(expectedHostnames).size !== expectedHostnames.length
+        ) {
+            throw new Error(
+                `${plan.site.id}: production custom-domain policy is invalid`
+            );
+        }
+
+        const attachedToWorker = domains.filter(
+            ({ service }) => service === plan.workerName
+        );
+        const actualHostnames = attachedToWorker
+            .map(({ hostname }) => hostname)
+            .sort();
+        const expectedSorted = [...expectedHostnames].sort();
+        if (
+            attachedToWorker.some(
+                ({ environment }) => environment !== "production"
+            ) ||
+            actualHostnames.length !== expectedSorted.length ||
+            actualHostnames.some(
+                (hostname, index) => hostname !== expectedSorted[index]
+            )
+        ) {
+            throw new Error(
+                `${plan.site.id}: ${plan.workerName} custom domains must exactly equal ${JSON.stringify(
+                    expectedSorted
+                )}; found ${JSON.stringify(actualHostnames)}`
+            );
+        }
+
+        for (const hostname of expectedHostnames) {
+            const attachment = domains.find(
+                (domain) => domain.hostname === hostname
+            );
+            if (
+                !attachment ||
+                attachment.service !== plan.workerName ||
+                attachment.environment !== "production"
+            ) {
+                throw new Error(
+                    `${plan.site.id}: reviewed hostname ${hostname} is not attached to ${plan.workerName}'s production environment`
+                );
+            }
+        }
+    }
+
+    for (const [workerName, metadata] of scripts) {
+        const policyOwned = policyWorkerNames.has(workerName);
+        const inManagedNamespace = workerName.startsWith(
+            CLOUDFLARE_WORKER_NAMESPACE_PREFIX
+        );
+        if (inManagedNamespace && !policyOwned) {
+            throw new Error(
+                `Cloudflare has an unreviewed or retired Worker identity ${workerName} inside the ${CLOUDFLARE_WORKER_NAMESPACE_PREFIX} namespace`
+            );
+        }
+        const managedRoutes = metadata.routes.filter(({ pattern }) =>
+            routeTargetsManagedAppHostname(pattern)
+        );
+        if (
+            metadata.routes.length > 0 &&
+            (policyOwned || inManagedNamespace || managedRoutes.length > 0)
+        ) {
+            throw new Error(
+                `${workerName} has unreviewed Worker route attachments (${metadata.routes
+                    .map(({ pattern }) => pattern)
+                    .join(", ")})`
+            );
+        }
+    }
+
+    for (const domain of domains) {
+        const expectedWorker = expectedByHostname.get(domain.hostname);
+        const managedHostname = managedAppHostname(domain.hostname);
+        const policyOwnedWorker = policyWorkerNames.has(domain.service);
+        const managedWorker = domain.service.startsWith(
+            CLOUDFLARE_WORKER_NAMESPACE_PREFIX
+        );
+        if (
+            (managedHostname || policyOwnedWorker || managedWorker) &&
+            (expectedWorker == null ||
+                domain.service !== expectedWorker ||
+                domain.environment !== "production")
+        ) {
+            throw new Error(
+                `Cloudflare custom domain ${domain.hostname} is not exactly owned by the reviewed production Worker policy`
+            );
+        }
+    }
+};
+
+const readAndValidateWorkerSubdomains = async ({
+    plans,
+    scripts,
+    operations,
+}) => {
+    const workerNames = new Set(plans.map(({ workerName }) => workerName));
+    for (const { policy } of plans) {
+        if (scripts.has(policy.previewWorker)) {
+            workerNames.add(policy.previewWorker);
+        }
+    }
+    for (const workerName of workerNames) {
+        const state = await operations.getWorkerSubdomain(workerName);
+        const keys =
+            state && typeof state === "object" && !Array.isArray(state)
+                ? Object.keys(state).sort()
+                : [];
+        if (
+            keys.length !== 2 ||
+            keys[0] !== "enabled" ||
+            keys[1] !== "previewsEnabled" ||
+            typeof state.enabled !== "boolean" ||
+            typeof state.previewsEnabled !== "boolean"
+        ) {
+            throw new Error(
+                `${workerName}: Worker subdomain operation returned invalid or ambiguous state`
+            );
+        }
+        if (state.enabled || state.previewsEnabled) {
+            throw new Error(
+                `${workerName}: workers.dev and Worker Preview URLs must both be disabled`
+            );
+        }
+    }
+};
+
+const readAndValidateProductionAttachments = async ({
+    plans,
+    operations,
+    scripts: providedScripts,
+}) => {
+    const scripts = providedScripts ?? (await readWorkerScriptMap(operations));
+    const domains = await readWorkerDomainInventory(operations);
+    validateProductionAttachmentInventory({ plans, scripts, domains });
+    await readAndValidateWorkerSubdomains({ plans, scripts, operations });
+    return scripts;
+};
+
+const productionWorkerConfig = ({ site, policy, configs }) => {
+    if (policy.id !== site.id) {
+        throw new Error(
+            `${site.id}: Cloudflare policy identity does not match site`
+        );
+    }
+    if (
+        typeof policy.productionWorker !== "string" ||
+        policy.productionWorker.length === 0
+    ) {
+        throw new Error(`${site.id}: production Worker identity is missing`);
+    }
+    const rendered = configs.get(site.id);
+    if (!rendered || rendered.config?.name !== policy.productionWorker) {
+        throw new Error(
+            `${site.id}: rendered production Worker must exactly equal ${policy.productionWorker}`
+        );
+    }
+    return {
+        file: rendered.file,
+        renderedConfig: rendered.config,
+        workerName: policy.productionWorker,
+    };
+};
+
+const requireWorkerTag = ({ site, workerName, metadata }) => {
+    if (typeof metadata?.tag !== "string" || metadata.tag.length === 0) {
+        throw new Error(
+            `${site.id}: Cloudflare did not provide immutable tag for ${workerName}`
+        );
+    }
+    return metadata.tag;
+};
+
+const readRollbackBaseline = async ({
+    site,
+    policy,
+    file,
+    workerName,
+    workerMetadata,
+    operations,
+}) => {
+    const previousDeployment = await operations.status({
+        configFile: file,
+        site,
+        policy,
+        workerName,
+    });
+    const previousVersion = readSingleVersionDeployment(
+        previousDeployment,
+        site.id
+    );
+    const previousCommit = await operations.readReleaseCommit({
+        site,
+        policy,
+    });
+    if (policy.kind === "app" && !FULL_GIT_COMMIT.test(previousCommit || "")) {
+        throw new Error(
+            `${site.id}: production app requires a full rollback release commit`
+        );
+    }
+    return {
+        previousVersion,
+        previousCommit,
+        workerTag: requireWorkerTag({
+            site,
+            workerName,
+            metadata: workerMetadata,
+        }),
+    };
+};
+
+const revalidateRollbackBaseline = async ({
+    site,
+    policy,
+    file,
+    workerName,
+    baseline,
+    operations,
+}) => {
+    const currentCommit = await operations.readReleaseCommit({ site, policy });
+    if (policy.kind === "app" && !FULL_GIT_COMMIT.test(currentCommit || "")) {
+        throw new Error(
+            `${site.id}: production app requires a full rollback release commit`
+        );
+    }
+    const scripts = await readWorkerScriptMap(operations);
+    const currentTag = requireWorkerTag({
+        site,
+        workerName,
+        metadata: scripts.get(workerName),
+    });
+    const currentDeployment = await operations.status({
+        configFile: file,
+        site,
+        policy,
+        workerName,
+    });
+    const currentVersion = readSingleVersionDeployment(
+        currentDeployment,
+        site.id
+    );
+    if (
+        currentVersion !== baseline.previousVersion ||
+        currentCommit !== baseline.previousCommit ||
+        currentTag !== baseline.workerTag
+    ) {
+        throw new Error(
+            `${site.id}: rollback baseline changed after production preflight`
+        );
+    }
+};
+
+const deploymentDiagnostic = (error) =>
+    redactCloudflareCredentials(error, deploymentEnvironment).slice(
+        0,
+        MAX_DIAGNOSTIC_LENGTH
+    );
+
+const manualRecoveryDiagnostic = ({ site, workerName, reason }) =>
+    `${site.id}: automatic rollback refused: ${reason}; inspect ${workerName}'s active version, routes, custom domains, and public subdomain state in Cloudflare before retrying`;
+
+const dispatchedRollbackDiagnostic = ({
+    site,
+    workerName,
+    reason,
+    appliedObserved,
+}) =>
+    `${site.id}: automatic rollback ${
+        appliedObserved
+            ? "was applied and observed, but final confirmation failed"
+            : "was dispatched and may have been applied, but confirmation failed"
+    }: ${reason}; inspect ${workerName}'s active version, routes, custom domains, and public subdomain state in Cloudflare before retrying`;
+
+const validateUploadedVersionOwnership = ({ plan, version }) => {
+    if (
+        !version ||
+        typeof version !== "object" ||
+        version.id !== plan.invocation.versionId ||
+        version.annotations?.["workers/tag"] !== plan.versionTag
+    ) {
+        throw new Error(
+            `${plan.site.id}: Cloudflare did not return this invocation's exact tagged Worker version`
+        );
+    }
+};
+
+const readActiveVersion = async ({ plan, operations }) =>
+    readSingleVersionDeployment(
+        await operations.status({
+            configFile: plan.file,
+            site: plan.site,
+            policy: plan.policy,
+            workerName: plan.workerName,
+        }),
+        plan.site.id
+    );
+
+const readCurrentWorkerTag = async ({ plan, operations }) => {
+    const scripts = await readWorkerScriptMap(operations);
+    return requireWorkerTag({
+        site: plan.site,
+        workerName: plan.workerName,
+        metadata: scripts.get(plan.workerName),
+    });
+};
+
+const readFencedActiveVersionLast = async ({
+    plan,
+    inventoryPlans,
+    operations,
+    expectedWorkerTag,
+    phase,
+}) => {
+    await readAndValidateProductionAttachments({
+        plans: inventoryPlans,
+        operations,
+    });
+    const currentTag = await readCurrentWorkerTag({ plan, operations });
+    if (currentTag !== expectedWorkerTag) {
+        throw new Error(`${phase}: immutable Worker tag changed`);
+    }
+    // Keep the active deployment read last. Runtime verification can take
+    // minutes, and an earlier observation cannot prove the final state.
+    return readActiveVersion({ plan, operations });
+};
+
+const confirmInvocationActive = async ({ plan, operations }) => {
+    const currentTag = await readCurrentWorkerTag({ plan, operations });
+    if (
+        currentTag !== plan.baseline.workerTag ||
+        currentTag !== plan.invocation.workerTag
+    ) {
+        throw new Error(
+            `${plan.site.id}: active Worker identity no longer matches this invocation`
+        );
+    }
+    validateUploadedVersionOwnership({
+        plan,
+        version: await operations.getVersion({
+            workerName: plan.workerName,
+            versionId: plan.invocation.versionId,
+            site: plan.site,
+            policy: plan.policy,
+        }),
+    });
+    const activeVersion = await readActiveVersion({ plan, operations });
+    if (activeVersion !== plan.invocation.versionId) {
+        throw new Error(
+            `${plan.site.id}: active version ${activeVersion} does not match this invocation's version ${plan.invocation.versionId}`
+        );
+    }
+};
+
+const observeIndeterminateActivationSettlement = async ({
+    plan,
+    operations,
+}) => {
+    const wait =
+        operations.waitForActivationSettlement ??
+        ((delayMs) =>
+            new Promise((resolve) => {
+                setTimeout(resolve, delayMs);
+            }));
+    for (
+        let observation = 1;
+        observation <= INDETERMINATE_ACTIVATION_OBSERVATIONS;
+        observation += 1
+    ) {
+        const currentTag = await readCurrentWorkerTag({ plan, operations });
+        if (
+            currentTag !== plan.baseline.workerTag ||
+            currentTag !== plan.invocation.workerTag
+        ) {
+            throw new Error(
+                "the immutable Worker tag changed during indeterminate activation settlement"
+            );
+        }
+        const currentVersion = await readActiveVersion({ plan, operations });
+        if (currentVersion !== plan.baseline.previousVersion) {
+            return currentVersion;
+        }
+        if (observation < INDETERMINATE_ACTIVATION_OBSERVATIONS) {
+            await wait(INDETERMINATE_ACTIVATION_DELAY_MS);
+        }
+    }
+    return plan.baseline.previousVersion;
+};
+
+const rollbackExactInvocation = async ({
+    plan,
+    inventoryPlans,
+    operations,
+    log,
+}) => {
+    const { previousVersion, previousCommit, workerTag } = plan.baseline;
+    plan.rollbackMutationState = "not-dispatched";
+    if (workerTag !== plan.invocation.workerTag) {
+        throw new Error(
+            "the immutable Worker tag no longer matches the preflight and invocation identity"
+        );
+    }
+
+    let currentVersion = await readFencedActiveVersionLast({
+        plan,
+        inventoryPlans,
+        operations,
+        expectedWorkerTag: workerTag,
+        phase: "rollback authorization",
+    });
+    if (
+        currentVersion === previousVersion &&
+        plan.indeterminateActivation === true
+    ) {
+        currentVersion = await observeIndeterminateActivationSettlement({
+            plan,
+            operations,
+        });
+    }
+    if (currentVersion === previousVersion) {
+        await operations.verify({
+            site: plan.site,
+            policy: plan.policy,
+            expectedCommit: previousCommit,
+        });
+        currentVersion = await readFencedActiveVersionLast({
+            plan,
+            inventoryPlans,
+            operations,
+            expectedWorkerTag: workerTag,
+            phase: "post-verifier baseline confirmation",
+        });
+        if (currentVersion === previousVersion) {
+            if (plan.indeterminateActivation === true) {
+                throw new Error(
+                    `activation remains indeterminate after the bounded settlement window; baseline ${previousVersion} was observed and verified, but the original deployment POST may still be applied later`
+                );
+            }
+            return `${plan.site.id}: previous baseline ${previousVersion} remains active and verified; no rollback was necessary`;
+        }
+        if (plan.indeterminateActivation !== true) {
+            throw new Error(
+                `active version changed to ${currentVersion} during baseline verification`
+            );
+        }
+    }
+    if (currentVersion !== plan.invocation.versionId) {
+        throw new Error(
+            `active version ${currentVersion} differs from this invocation's version ${plan.invocation.versionId}; another deployment may have won`
+        );
+    }
+
+    validateUploadedVersionOwnership({
+        plan,
+        version: await operations.getVersion({
+            workerName: plan.workerName,
+            versionId: plan.invocation.versionId,
+            site: plan.site,
+            policy: plan.policy,
+        }),
+    });
+
+    // Repeat the entire public-attachment and Worker-identity fence before the
+    // active-version read immediately preceding mutation. Cloudflare's
+    // deployment endpoint has no compare-and-swap precondition.
+    const confirmedVersion = await readFencedActiveVersionLast({
+        plan,
+        inventoryPlans,
+        operations,
+        expectedWorkerTag: workerTag,
+        phase: "final rollback authorization",
+    });
+    if (confirmedVersion !== plan.invocation.versionId) {
+        throw new Error(
+            `active version changed to ${confirmedVersion} before rollback authorization`
+        );
+    }
+
+    log(
+        `${plan.site.id}: rolling back invocation ${plan.invocation.versionId} to ${previousVersion}`
+    );
+    plan.rollbackMutationState = "dispatched";
+    let rollbackDeployment;
+    try {
+        rollbackDeployment = await operations.activate({
+            workerName: plan.workerName,
+            versionId: previousVersion,
+            message: `peerbit-examples ${plan.site.id} automatic rollback to ${previousVersion}`,
+            site: plan.site,
+            policy: plan.policy,
+        });
+    } catch (rollbackError) {
+        if (!isIndeterminateCloudflareMutationError(rollbackError)) {
+            // Ordinary adapter errors are local validation failures that occur
+            // before the deployment POST is dispatched.
+            plan.rollbackMutationState = "not-dispatched";
+        }
+        throw rollbackError;
+    }
+    const rollbackVersion = readSingleVersionDeployment(
+        rollbackDeployment,
+        plan.site.id
+    );
+    if (rollbackVersion !== previousVersion) {
+        throw new Error(
+            `rollback API selected ${rollbackVersion}, expected ${previousVersion}`
+        );
+    }
+    const restoredVersion = await readActiveVersion({ plan, operations });
+    if (restoredVersion !== previousVersion) {
+        throw new Error(
+            `rollback dispatch was acknowledged but active-version confirmation observed ${restoredVersion}, expected ${previousVersion}`
+        );
+    }
+    plan.rollbackMutationState = "applied-observed";
+    const restoredTag = await readCurrentWorkerTag({ plan, operations });
+    if (restoredTag !== workerTag) {
+        throw new Error("Worker identity changed while rollback was running");
+    }
+    await operations.verify({
+        site: plan.site,
+        policy: plan.policy,
+        expectedCommit: previousCommit,
+    });
+    const finalVersion = await readFencedActiveVersionLast({
+        plan,
+        inventoryPlans,
+        operations,
+        expectedWorkerTag: workerTag,
+        phase: "post-verifier rollback confirmation",
+    });
+    if (finalVersion !== previousVersion) {
+        throw new Error(
+            `post-verifier rollback confirmation observed active version ${finalVersion}, expected exact baseline ${previousVersion}`
+        );
+    }
+    plan.rollbackMutationState = "confirmed";
+    log(`${plan.site.id}: previous version restored and verified`);
+    return `${plan.site.id}: automatic rollback of this invocation to ${previousVersion} succeeded`;
+};
+
 export const deployProductionEntries = async ({
     selectedEntries,
+    deploymentEntries,
     configs,
     expectedCommit,
     operations,
@@ -111,132 +885,333 @@ export const deployProductionEntries = async ({
             "Production deployment requires a full Git commit hash"
         );
     }
-
-    for (const { site, policy } of selectedEntries) {
-        const { file } = configs.get(site.id);
-        const previousDeployment = await operations.status({
-            configFile: file,
-            site,
-            policy,
-        });
-        const previousVersion = readSingleVersionDeployment(
-            previousDeployment,
-            site.id
+    if (!Array.isArray(selectedEntries) || selectedEntries.length === 0) {
+        throw new Error(
+            "Production deployment requires a non-empty selected entry set"
         );
-        const previousCommit = await operations.readReleaseCommit({
-            site,
-            policy,
-        });
+    }
+    if (!Array.isArray(deploymentEntries) || deploymentEntries.length === 0) {
+        throw new Error(
+            "Production deployment requires explicit non-empty full-policy entries for account-wide attachment validation"
+        );
+    }
+    if (
+        deploymentEntries.some(
+            (entry) =>
+                !entry ||
+                typeof entry !== "object" ||
+                !entry.site ||
+                typeof entry.site !== "object" ||
+                typeof entry.site.id !== "string" ||
+                entry.site.id.length === 0 ||
+                !entry.policy ||
+                typeof entry.policy !== "object"
+        )
+    ) {
+        throw new Error(
+            "Production deployment full-policy entries are malformed"
+        );
+    }
+    const attachmentPlans = deploymentEntries.map(({ site, policy }) => ({
+        site,
+        policy,
+        ...productionWorkerConfig({ site, policy, configs }),
+    }));
+    const attachmentPlansById = new Map(
+        attachmentPlans.map((plan) => [plan.site.id, plan])
+    );
+    if (attachmentPlansById.size !== attachmentPlans.length) {
+        throw new Error(
+            "Production deployment full-policy entries contain duplicate site identities"
+        );
+    }
+    const plans = selectedEntries.map(({ site, policy }) => {
+        const plan = attachmentPlansById.get(site.id);
         if (
-            policy.kind === "app" &&
-            !FULL_GIT_COMMIT.test(previousCommit || "")
+            !plan ||
+            plan.policy.id !== policy.id ||
+            plan.workerName !== policy.productionWorker
         ) {
             throw new Error(
-                `${site.id}: production app requires a full rollback release commit`
+                `${site.id}: selected deployment target is outside the full deployment policy`
             );
         }
-        let deployedVersion;
+        return plan;
+    });
+    const scripts = await readWorkerScriptMap(operations);
+    const missingPlans = attachmentPlans.filter(
+        ({ workerName }) => !scripts.has(workerName)
+    );
+    if (missingPlans.length > 0) {
+        const missing = missingPlans
+            .map(({ site, workerName }) => `${site.id}: ${workerName}`)
+            .join(", ");
+        throw new Error(
+            `Production deploys require pre-provisioned Workers; missing ${missing}. Provision these exact Worker names and their reviewed custom domains from cloudflare/deployment-policy.json in Cloudflare once, then rerun. No deployment was attempted`
+        );
+    }
+    await readAndValidateProductionAttachments({
+        plans: attachmentPlans,
+        operations,
+        scripts,
+    });
 
+    const baselines = new Map();
+    for (const plan of plans) {
+        if (!scripts.has(plan.workerName)) continue;
+        baselines.set(
+            plan.site.id,
+            await readRollbackBaseline({
+                ...plan,
+                workerMetadata: scripts.get(plan.workerName),
+                operations,
+            })
+        );
+    }
+
+    for (const plan of plans) {
+        plan.baseline = baselines.get(plan.site.id);
+        plan.versionTag = createInvocationVersionTag({
+            siteId: plan.site.id,
+            expectedCommit,
+        });
+        const { previousVersion, previousCommit } = plan.baseline;
         log(
-            `${site.id}: rollback baseline ${previousVersion}${
+            `${plan.site.id}: rollback baseline ${previousVersion}${
                 previousCommit ? ` at ${previousCommit}` : ""
             }`
         );
-        try {
-            await operations.deploy({
-                configFile: file,
-                site,
-                policy,
-                expectedCommit,
-            });
-            const deployed = await operations.status({
-                configFile: file,
-                site,
-                policy,
-            });
-            deployedVersion = readSingleVersionDeployment(deployed, site.id);
-            await operations.verify({
-                site,
-                policy,
-                expectedCommit,
-            });
-            log(`${site.id}: deployed and verified ${deployedVersion}`);
-        } catch (deploymentError) {
-            let rollbackError;
-            try {
-                let currentVersion;
-                try {
-                    const current = await operations.status({
-                        configFile: file,
-                        site,
-                        policy,
-                    });
-                    currentVersion = readSingleVersionDeployment(
-                        current,
-                        site.id
-                    );
-                } catch {
-                    // If status is inconclusive, attempting the known-good
-                    // rollback is safer than assuming the failed deploy was
-                    // atomic.
-                }
+    }
 
-                if (currentVersion !== previousVersion) {
-                    log(
-                        `${site.id}: deployment failed; rolling back to ${previousVersion}`
-                    );
-                    await operations.rollback({
-                        configFile: file,
-                        site,
-                        policy,
-                        versionId: previousVersion,
-                    });
-                }
-                const restored = await operations.status({
-                    configFile: file,
-                    site,
-                    policy,
-                });
-                const restoredVersion = readSingleVersionDeployment(
-                    restored,
-                    site.id
-                );
-                if (restoredVersion !== previousVersion) {
-                    throw new Error(
-                        `${site.id}: rollback restored ${restoredVersion}, expected ${previousVersion}`
-                    );
-                }
-                await operations.verify({
-                    site,
-                    policy,
-                    expectedCommit: previousCommit,
-                });
-                log(`${site.id}: previous version restored and verified`);
-            } catch (error) {
-                rollbackError = error;
-            }
+    // Validate every baseline before creating even inactive versions. This
+    // keeps multi-app planning fail-closed and avoids uploading to a Worker
+    // that was replaced during the initial baseline reads.
+    await readAndValidateProductionAttachments({
+        plans: attachmentPlans,
+        operations,
+    });
+    for (const plan of plans) {
+        await revalidateRollbackBaseline({
+            ...plan,
+            operations,
+        });
+    }
 
-            const messages = [
-                `${site.id}: production deployment failed: ${deploymentError}`,
-            ];
-            if (rollbackError) {
-                messages.push(
-                    `${site.id}: automatic rollback also failed: ${rollbackError}`
-                );
-            } else {
-                messages.push(
-                    `${site.id}: automatic rollback to ${previousVersion} succeeded`
+    // Upload every selected version before changing any live deployment. If a
+    // later upload or its ownership evidence fails, all production traffic is
+    // still on the captured baselines.
+    try {
+        for (const plan of plans) {
+            // Wrangler can alter workers.dev and Preview URL state as part of
+            // an upload. Fence the full account policy immediately before
+            // each individual version mutation, not only once per batch.
+            await readAndValidateProductionAttachments({
+                plans: attachmentPlans,
+                operations,
+            });
+            plan.invocation = validateDeploymentEvidence(
+                await operations.upload({
+                    configFile: plan.file,
+                    renderedConfig: plan.renderedConfig,
+                    site: plan.site,
+                    policy: plan.policy,
+                    expectedCommit,
+                    versionTag: plan.versionTag,
+                }),
+                plan.workerName
+            );
+            await readAndValidateProductionAttachments({
+                plans: attachmentPlans,
+                operations,
+            });
+            if (plan.invocation.workerTag !== plan.baseline.workerTag) {
+                throw new Error(
+                    `${plan.site.id}: uploaded version belongs to a replacement Worker identity`
                 );
             }
-            throw new Error(messages.join("\n"));
+            validateUploadedVersionOwnership({
+                plan,
+                version: await operations.getVersion({
+                    workerName: plan.workerName,
+                    versionId: plan.invocation.versionId,
+                    site: plan.site,
+                    policy: plan.policy,
+                }),
+            });
+            log(
+                `${plan.site.id}: uploaded inactive version ${plan.invocation.versionId} with tag ${plan.versionTag}`
+            );
         }
+    } catch (uploadError) {
+        throw new Error(
+            `Inactive Worker version upload phase failed: ${deploymentDiagnostic(
+                uploadError
+            )}. This workflow did not change live production traffic`
+        );
+    }
+
+    // A deletion/recreation or external deployment during the upload phase
+    // invalidates the transaction. Revalidate all apps before the first exact
+    // version is promoted.
+    try {
+        await readAndValidateProductionAttachments({
+            plans: attachmentPlans,
+            operations,
+        });
+        for (const plan of plans) {
+            await revalidateRollbackBaseline({ ...plan, operations });
+        }
+    } catch (baselineError) {
+        throw new Error(
+            `Production baseline changed after inactive uploads: ${deploymentDiagnostic(
+                baselineError
+            )}. No uploaded version was promoted`
+        );
+    }
+
+    const activatedPlans = [];
+    let currentPlan;
+    let failurePlan;
+    try {
+        for (const plan of plans) {
+            currentPlan = plan;
+            failurePlan = plan;
+            await readAndValidateProductionAttachments({
+                plans: attachmentPlans,
+                operations,
+            });
+            validateUploadedVersionOwnership({
+                plan,
+                version: await operations.getVersion({
+                    workerName: plan.workerName,
+                    versionId: plan.invocation.versionId,
+                    site: plan.site,
+                    policy: plan.policy,
+                }),
+            });
+            await revalidateRollbackBaseline({ ...plan, operations });
+
+            // The deployment remains potentially pending from dispatch until
+            // an independent GET positively observes this invocation active.
+            // A valid POST response alone is not sufficient because the
+            // deployment read can temporarily remain on the baseline.
+            plan.indeterminateActivation = true;
+            let activated;
+            try {
+                activated = await operations.activate({
+                    workerName: plan.workerName,
+                    versionId: plan.invocation.versionId,
+                    message: `peerbit-examples ${plan.site.id} ${expectedCommit}`,
+                    site: plan.site,
+                    policy: plan.policy,
+                });
+            } catch (activationError) {
+                if (!isIndeterminateCloudflareMutationError(activationError)) {
+                    // The API adapter reserves ordinary errors for local
+                    // validation that failed before it dispatched the POST.
+                    plan.indeterminateActivation = false;
+                }
+                throw activationError;
+            }
+            const activatedVersion = readSingleVersionDeployment(
+                activated,
+                plan.site.id
+            );
+            if (activatedVersion !== plan.invocation.versionId) {
+                throw new Error(
+                    `${plan.site.id}: activation API selected ${activatedVersion}, expected ${plan.invocation.versionId}`
+                );
+            }
+            await confirmInvocationActive({ plan, operations });
+            plan.indeterminateActivation = false;
+            activatedPlans.push(plan);
+            await operations.verify({
+                site: plan.site,
+                policy: plan.policy,
+                expectedCommit,
+            });
+            log(
+                `${plan.site.id}: promoted and verified ${plan.invocation.versionId}`
+            );
+        }
+
+        // Runtime verification can take several minutes. Re-read every app's
+        // immutable Worker identity, exact tagged version, active deployment,
+        // and read-only attachment inventory before reporting transaction
+        // success. A drifted app fails into the same reverse, ownership-scoped
+        // unwind path as an ordinary verifier failure.
+        for (const plan of activatedPlans) {
+            failurePlan = plan;
+            await readAndValidateProductionAttachments({
+                plans: attachmentPlans,
+                operations,
+            });
+            await confirmInvocationActive({ plan, operations });
+        }
+        return;
+    } catch (deploymentError) {
+        const messages = [
+            `${failurePlan?.site.id ?? "production"}: production rollout failed: ${deploymentDiagnostic(
+                deploymentError
+            )}`,
+        ];
+        const rollbackCandidates = [
+            ...(currentPlan ? [currentPlan] : []),
+            ...activatedPlans.slice().reverse(),
+        ];
+        const seen = new Set();
+        for (const plan of rollbackCandidates) {
+            if (seen.has(plan.site.id)) continue;
+            seen.add(plan.site.id);
+            try {
+                messages.push(
+                    await rollbackExactInvocation({
+                        plan,
+                        inventoryPlans: attachmentPlans,
+                        operations,
+                        log,
+                    })
+                );
+            } catch (rollbackError) {
+                const reason = `this transaction's exact version and tag could not be safely unwound (${deploymentDiagnostic(
+                    rollbackError
+                )})`;
+                if (
+                    plan.rollbackMutationState === "dispatched" ||
+                    plan.rollbackMutationState === "applied-observed"
+                ) {
+                    messages.push(
+                        dispatchedRollbackDiagnostic({
+                            site: plan.site,
+                            workerName: plan.workerName,
+                            reason,
+                            appliedObserved:
+                                plan.rollbackMutationState ===
+                                "applied-observed",
+                        })
+                    );
+                } else {
+                    messages.push(
+                        manualRecoveryDiagnostic({
+                            site: plan.site,
+                            workerName: plan.workerName,
+                            reason,
+                        })
+                    );
+                }
+            }
+        }
+        throw new Error(messages.join("\n"));
     }
 };
 
 export const withoutCloudflareDeploymentCredentials = (environment) => {
     const sanitized = { ...environment };
-    delete sanitized.CLOUDFLARE_API_TOKEN;
-    delete sanitized.CLOUDFLARE_ACCOUNT_ID;
+    for (const name of Object.keys(sanitized)) {
+        if (isCloudflareAuthenticationEnvironmentVariable(name)) {
+            delete sanitized[name];
+        }
+    }
     return sanitized;
 };
 
@@ -245,20 +1220,106 @@ const verificationEnvironment = withoutCloudflareDeploymentCredentials(
     process.env
 );
 
-const runCaptured = (command, args) => {
-    const result = spawnSync(command, args, {
+export const removeTemporaryWranglerOutput = (
+    outputDirectory,
+    environment = deploymentEnvironment,
+    {
+        remove = (directory) =>
+            rmSync(directory, { recursive: true, force: true }),
+        writeWarning = (value) => process.stderr.write(value),
+    } = {}
+) => {
+    try {
+        remove(outputDirectory);
+    } catch (error) {
+        try {
+            writeWarning(
+                `Warning: could not remove temporary Wrangler deployment output: ${redactCloudflareCredentials(
+                    error,
+                    environment
+                )}\n`
+            );
+        } catch {
+            // Temporary-file cleanup must never replace the deployment result,
+            // even when the process output stream is unavailable.
+        }
+    }
+};
+
+export const runCloudflareCapturedJson = (
+    command,
+    args,
+    environment = deploymentEnvironment,
+    { run = spawnSync } = {}
+) => {
+    const result = run(command, args, {
         cwd: repoRoot,
-        env: deploymentEnvironment,
+        env: environment,
         encoding: "utf8",
         maxBuffer: 10 * 1024 * 1024,
     });
-    if (result.error) throw result.error;
+    if (result.error) {
+        throw new Error(redactCloudflareCredentials(result.error, environment));
+    }
     if (result.status !== 0) {
         throw new Error(
-            `${path.basename(command)} ${args.join(" ")} exited ${result.status}: ${result.stderr.trim()}`
+            `${path.basename(command)} ${args.join(" ")} exited ${result.status}: ${redactCloudflareCredentials(
+                String(result.stderr || "").trim(),
+                environment
+            )}`
         );
     }
-    return result.stdout;
+    try {
+        return JSON.parse(String(result.stdout || ""));
+    } catch {
+        // Never include stdout here. Wrangler may echo a credential in a
+        // malformed response, and JSON parser errors otherwise tempt callers
+        // to append the original payload to diagnostics.
+        throw new Error(
+            `${path.basename(command)} ${args.join(" ")} returned malformed JSON output`
+        );
+    }
+};
+
+export const runCloudflareLogged = (
+    command,
+    args,
+    environment = deploymentEnvironment,
+    {
+        run = spawnSync,
+        writeStdout = (value) => process.stdout.write(value),
+        writeStderr = (value) => process.stderr.write(value),
+    } = {}
+) => {
+    const result = run(command, args, {
+        cwd: repoRoot,
+        env: environment,
+        encoding: "utf8",
+        stdio: ["inherit", "pipe", "pipe"],
+        maxBuffer: 10 * 1024 * 1024,
+    });
+    const hasWorkersDevOutput = /workers\.dev/i.test(
+        `${String(result.stdout || "")}\n${String(result.stderr || "")}`
+    );
+    const stdout = redactCloudflareCredentials(
+        result.stdout || "",
+        environment
+    );
+    const stderr = redactCloudflareCredentials(
+        result.stderr || "",
+        environment
+    );
+    if (stdout) writeStdout(stdout);
+    if (stderr) writeStderr(stderr);
+    if (result.error) {
+        throw new Error(redactCloudflareCredentials(result.error, environment));
+    }
+    if (result.status !== 0) {
+        throw new Error(
+            `${path.basename(command)} ${args.join(" ")} exited ${result.status}`
+        );
+    }
+    return { stdout, stderr, hasWorkersDevOutput };
 };
 
 const runInherited = (command, args, env = deploymentEnvironment) => {
@@ -275,25 +1336,237 @@ const runInherited = (command, args, env = deploymentEnvironment) => {
     }
 };
 
-const parseArgs = (argv) => {
+const resolveTemporaryConfigPath = ({ configFile, value, label, root }) => {
+    if (typeof value !== "string" || value.length === 0) {
+        throw new Error(`${label} must be a non-empty path`);
+    }
+    const resolved = path.resolve(path.dirname(configFile), value);
+    const relative = path.relative(root, resolved);
+    if (
+        relative.length === 0 ||
+        relative.startsWith("..") ||
+        path.isAbsolute(relative)
+    ) {
+        throw new Error(`${label} must resolve inside the repository`);
+    }
+    return resolved;
+};
+
+export const createRouteFreeWranglerConfig = ({
+    configFile,
+    renderedConfig,
+    workerName,
+    root = repoRoot,
+}) => {
+    if (
+        !renderedConfig ||
+        typeof renderedConfig !== "object" ||
+        Array.isArray(renderedConfig) ||
+        renderedConfig.name !== workerName ||
+        renderedConfig.workers_dev !== false ||
+        renderedConfig.preview_urls !== false ||
+        !Array.isArray(renderedConfig.routes) ||
+        renderedConfig.routes.length === 0
+    ) {
+        throw new Error(
+            `${workerName}: canonical production config is not valid for a route-free deployment`
+        );
+    }
+    if ("route" in renderedConfig || "domains" in renderedConfig) {
+        throw new Error(
+            `${workerName}: canonical production config must not contain alternate route fields`
+        );
+    }
+    if (
+        renderedConfig.routes.some(
+            (route) =>
+                !route ||
+                typeof route !== "object" ||
+                typeof route.pattern !== "string" ||
+                route.custom_domain !== true
+        )
+    ) {
+        throw new Error(
+            `${workerName}: canonical production routes must be reviewed custom domains`
+        );
+    }
+
+    const privateConfig = structuredClone(renderedConfig);
+    delete privateConfig.$schema;
+    delete privateConfig.routes;
+    if ("main" in privateConfig) {
+        privateConfig.main = resolveTemporaryConfigPath({
+            configFile,
+            value: privateConfig.main,
+            label: `${workerName}: main`,
+            root,
+        });
+    }
+    if (privateConfig.assets) {
+        privateConfig.assets.directory = resolveTemporaryConfigPath({
+            configFile,
+            value: privateConfig.assets.directory,
+            label: `${workerName}: assets.directory`,
+            root,
+        });
+    }
+    if (
+        "routes" in privateConfig ||
+        "route" in privateConfig ||
+        "domains" in privateConfig
+    ) {
+        throw new Error(
+            `${workerName}: private deployment config must omit all routes`
+        );
+    }
+    return privateConfig;
+};
+
+export const runWranglerVersionUpload = ({
+    wrangler,
+    configFile,
+    renderedConfig,
+    site,
+    expectedCommit,
+    workerName,
+    versionTag,
+    environment = deploymentEnvironment,
+    runtime = {},
+}) => {
+    if (!VERSION_TAG.test(versionTag || "")) {
+        throw new Error(
+            `${site.id}: Worker version tag is missing or malformed`
+        );
+    }
+    const {
+        makeTemporaryDirectory = mkdtempSync,
+        writeTemporaryConfig = writeFileSync,
+        runLogged = runCloudflareLogged,
+        outputExists = existsSync,
+        readOutput = readFileSync,
+        removeTemporaryDirectory = (directory) =>
+            rmSync(directory, { recursive: true, force: true }),
+    } = runtime;
+    const outputDirectory = makeTemporaryDirectory(
+        path.join(tmpdir(), "peerbit-wrangler-version-upload-")
+    );
+    const privateConfigFile = path.join(outputDirectory, "deploy.json");
+    const outputFile = path.join(outputDirectory, "deploy.ndjson");
+    try {
+        const privateConfig = createRouteFreeWranglerConfig({
+            configFile,
+            renderedConfig,
+            workerName,
+        });
+        writeTemporaryConfig(
+            privateConfigFile,
+            `${JSON.stringify(privateConfig, null, 2)}\n`,
+            {
+                encoding: "utf8",
+                mode: 0o600,
+                flag: "wx",
+            }
+        );
+        let commandError;
+        try {
+            const commandOutput = runLogged(
+                wrangler,
+                [
+                    "versions",
+                    "upload",
+                    "--config",
+                    privateConfigFile,
+                    "--strict",
+                    "--tag",
+                    versionTag,
+                    "--message",
+                    `peerbit-examples ${site.id} ${expectedCommit}`,
+                ],
+                {
+                    ...environment,
+                    WRANGLER_OUTPUT_FILE_PATH: outputFile,
+                },
+                {
+                    // Capture rather than echo Wrangler's normal version URL.
+                    // If public previews are unexpectedly enabled, the URL
+                    // contains the account's workers.dev subdomain.
+                    writeStdout: () => {},
+                    writeStderr: () => {},
+                }
+            );
+            assertNoWorkersDevOutput(
+                commandOutput?.hasWorkersDevOutput ? "workers.dev" : "",
+                commandOutput?.stdout,
+                commandOutput?.stderr
+            );
+        } catch (error) {
+            commandError = error;
+        }
+
+        let deploymentEvidence;
+        try {
+            deploymentEvidence = parseWranglerVersionUploadOutput(
+                outputExists(outputFile) ? readOutput(outputFile, "utf8") : "",
+                workerName
+            );
+        } catch (error) {
+            if (!commandError) throw error;
+        }
+        if (commandError) {
+            if (deploymentEvidence) {
+                commandError.deploymentEvidence = deploymentEvidence;
+            }
+            throw commandError;
+        }
+        return deploymentEvidence;
+    } finally {
+        removeTemporaryWranglerOutput(outputDirectory, environment, {
+            remove: removeTemporaryDirectory,
+        });
+    }
+};
+
+export const parseProductionDeploymentArgs = (argv) => {
     const args = new Map();
+    if (argv.length % 2 !== 0) {
+        throw new Error(PRODUCTION_DEPLOYMENT_USAGE);
+    }
     for (let index = 0; index < argv.length; index += 2) {
         const key = argv[index];
         const value = argv[index + 1];
         if (!key?.startsWith("--") || value == null) {
+            throw new Error(PRODUCTION_DEPLOYMENT_USAGE);
+        }
+        const name = key.slice(2);
+        if (!PRODUCTION_DEPLOYMENT_ARGUMENTS.has(name)) {
             throw new Error(
-                "Usage: deploy-cloudflare-production.mjs --target ID|apps|all --commit SHA"
+                `Unsupported production deployment argument: ${key}`
             );
         }
-        args.set(key.slice(2), value);
+        if (args.has(name)) {
+            throw new Error(`Duplicate production deployment argument: ${key}`);
+        }
+        args.set(name, value);
     }
-    return args;
+
+    const target = args.get("target");
+    const expectedCommit = args.get("commit");
+    if (!target || !/^[a-z][a-z0-9-]*$/.test(target)) {
+        throw new Error("Production deployment target is missing or malformed");
+    }
+    if (!FULL_GIT_COMMIT.test(expectedCommit || "")) {
+        throw new Error(
+            "Production deployment requires a full Git commit hash"
+        );
+    }
+    return {
+        target,
+        expectedCommit,
+    };
 };
 
 export const main = async (argv = process.argv.slice(2)) => {
-    const args = parseArgs(argv);
-    const target = args.get("target");
-    const expectedCommit = args.get("commit");
+    const { target, expectedCommit } = parseProductionDeploymentArgs(argv);
     const { entries } = loadCloudflareDeploymentData();
     const selectedEntries = selectCloudflareDeploymentEntries(entries, target);
     const configDirectory = path.join(repoRoot, ".wrangler-config");
@@ -312,36 +1585,40 @@ export const main = async (argv = process.argv.slice(2)) => {
         ["stream", "streaming preview serves exact MP4 byte ranges"],
     ]);
     const runtimeSmokeEnv = productionSmokeEnvironment(entries);
+    const workersApi = createCloudflareWorkersApi({
+        accountId: deploymentEnvironment.CLOUDFLARE_ACCOUNT_ID,
+        apiToken: deploymentEnvironment.CLOUDFLARE_API_TOKEN,
+    });
     const operations = {
-        status: ({ configFile }) =>
-            JSON.parse(
-                runCaptured(wrangler, [
-                    "deployments",
-                    "status",
-                    "--config",
-                    configFile,
-                    "--json",
-                ])
-            ),
-        deploy: ({ configFile, site, expectedCommit: commit }) =>
-            runInherited(wrangler, [
-                "deploy",
-                "--config",
+        listWorkerScripts: workersApi.listWorkerScripts,
+        listWorkerDomains: workersApi.listWorkerDomains,
+        getWorkerSubdomain: workersApi.getWorkerSubdomain,
+        status: ({ workerName }) => workersApi.getCurrentDeployment(workerName),
+        getVersion: ({ workerName, versionId }) =>
+            workersApi.getWorkerVersion(workerName, versionId),
+        upload: ({
+            configFile,
+            renderedConfig,
+            site,
+            policy,
+            expectedCommit: commit,
+            versionTag,
+        }) =>
+            runWranglerVersionUpload({
+                wrangler,
                 configFile,
-                "--strict",
-                "--message",
-                `peerbit-examples ${site.id} ${commit}`,
-            ]),
-        rollback: ({ configFile, site, versionId }) =>
-            runInherited(wrangler, [
-                "rollback",
+                renderedConfig,
+                site,
+                expectedCommit: commit,
+                workerName: policy.productionWorker,
+                versionTag,
+            }),
+        activate: ({ workerName, versionId, message }) =>
+            workersApi.createDeployment({
+                workerName,
                 versionId,
-                "--config",
-                configFile,
-                "--yes",
-                "--message",
-                `automatic rollback after failed ${site.id} verification`,
-            ]),
+                message,
+            }),
         readReleaseCommit: readBaselineReleaseCommit,
         verify: ({ site, expectedCommit: commit }) => {
             runInherited(
@@ -387,6 +1664,7 @@ export const main = async (argv = process.argv.slice(2)) => {
 
     await deployProductionEntries({
         selectedEntries,
+        deploymentEntries: entries,
         configs,
         expectedCommit,
         operations,


### PR DESCRIPTION
## Summary

- make production Worker rollouts fail closed around preflight, inactive version upload, exact activation, verification, and ownership-scoped rollback
- enforce the full account-wide Worker, route, custom-domain, workers.dev, and Preview URL policy before and after every upload and at final/rollback fences
- suppress and reject unexpected workers.dev output so an unverified version or account slug is not exposed
- handle ambiguous or eventually consistent deployment responses conservatively, including delayed activation and rollback confirmation
- require stable complete custom-domain snapshots and canonical managed hostnames
- document one-time Worker/domain provisioning plus the remaining Cloudflare no-CAS race windows

## Safety

The workflow does not mutate route, custom-domain, or subdomain attachments. Production deployment remains manual and requires pre-provisioned Workers whose live settings exactly match the reviewed policy. Any missing, malformed, unexpected, or drifting state aborts the rollout.

## Validation

- Cloudflare safety suites: 113/113
- focused deployment tests: 104/104
- full workspace build
- production bootstrap, deterministic assets, owned-domain, and source-diff integrity checks
- seven rendered production Wrangler dry-runs
- targeted ESLint, Prettier, and diff checks
- independent adversarial rereview: no remaining P0/P1/P2 findings

The broader examples test command rebuilt successfully and reported 110 passing, 3 skipped, and one unrelated existing media-streaming timing failure at packages/media-streaming/streaming-utils/src/__tests__/index.test.ts:495. That test reproduces alone and this PR does not change the package; it is being triaged separately.