### PR TITLE
chore: remove retired domain metadata

### DIFF
--- a/.changeset/retired-author-metadata.md
+++ b/.changeset/retired-author-metadata.md
@@ -1,0 +1,6 @@
+---
+---
+
+Replace retired package author metadata without releasing any packages. This
+changeset is intentionally empty because the update has no runtime or API
+effect; each public package will carry the metadata on its next planned release.

--- a/cloudflare/owned-domain-policy.test.mjs
+++ b/cloudflare/owned-domain-policy.test.mjs
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+    findUnsafeOwnedDomainReferences,
+    findUnsafeOwnedDomainTreeReferences,
+    isAllowedHistoricalReference,
+} from "../scripts/validate-owned-domains.mjs";
+
+const find = (file, contents) =>
+    findUnsafeOwnedDomainReferences(file, contents);
+
+test("allows owned app origins and dao-xyz package and repository namespaces", () => {
+    assert.deepEqual(
+        find(
+            "package.json",
+            JSON.stringify({
+                author: "Peerbit contributors",
+                repository: "https://github.com/dao-xyz/peerbit-examples",
+                dependencies: { "@dao-xyz/borsh": "^6.0.0" },
+                homepage: "https://files.apps.peerbit.org",
+            })
+        ),
+        []
+    );
+});
+
+test("rejects unowned author metadata and live retired URLs", () => {
+    const metadata = find(
+        "packages/example/package.json",
+        '{"author":"dao.xyz"}'
+    );
+    assert.equal(metadata.length, 1);
+    assert.match(metadata[0], /metadata identity dao\.xyz/);
+
+    const urls = find(
+        "packages/example/config.ts",
+        [
+            'export const api = "https://files.dao.xyz";',
+            'export const fallback = "https://giga.place";',
+        ].join("\n")
+    );
+    assert.equal(urls.length, 2);
+    assert.match(urls[0], /dao\.xyz/);
+    assert.match(urls[1], /giga\.place/);
+});
+
+test("rejects active Giga imports, source paths, Workers, and origins", () => {
+    assert.match(
+        find(
+            "packages/example/src/index.ts",
+            'import { AppProvider } from "@giga-app/sdk";'
+        )[0],
+        /retired Giga package namespace/
+    );
+    assert.match(
+        find("packages/social-media-app/frontend/src/App.tsx", "export {};")[0],
+        /retired Giga source tree/
+    );
+    assert.match(
+        find(
+            "cloudflare/sites.json",
+            '{"worker":"peerbit-examples-giga","domains":["giga.apps.peerbit.org"]}'
+        ).join("\n"),
+        /retired Giga Worker/
+    );
+    assert.match(
+        find(
+            "cloudflare/sites.json",
+            '{"worker":"peerbit-examples-giga","domains":["giga.apps.peerbit.org"]}'
+        ).join("\n"),
+        /retired Giga production origin/
+    );
+});
+
+test("rejects retired source paths even when their files are binary", (t) => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "peerbit-domain-policy-"));
+    t.after(() => rmSync(root, { recursive: true, force: true }));
+
+    const retiredAsset = path.join(
+        root,
+        "packages/social-media-app/assets/logo.png"
+    );
+    mkdirSync(path.dirname(retiredAsset), { recursive: true });
+    writeFileSync(retiredAsset, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+    assert.deepEqual(findUnsafeOwnedDomainTreeReferences(root), [
+        "packages/social-media-app/assets/logo.png: path contains retired Giga source tree packages/social-media-app",
+    ]);
+});
+
+test("scans active Go, PowerShell, patch, module, and shader formats", (t) => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "peerbit-domain-policy-"));
+    t.after(() => rmSync(root, { recursive: true, force: true }));
+
+    const forbiddenFiles = [
+        ["native/main.go", 'const endpoint = "https://files.dao.xyz"'],
+        ["native/go.mod", "module dao.xyz/native"],
+        ["native/go.sum", "dao.xyz/native v1.0.0 h1:checksum"],
+        ["patches/legacy.patch", "+endpoint=https://files.dao.xyz"],
+        ["scripts/deploy.ps1", '$endpoint = "https://files.dao.xyz"'],
+        ["shaders/player.wgsl", "// https://files.dao.xyz"],
+    ];
+    for (const [relativeFile, contents] of forbiddenFiles) {
+        const absoluteFile = path.join(root, relativeFile);
+        mkdirSync(path.dirname(absoluteFile), { recursive: true });
+        writeFileSync(absoluteFile, contents);
+    }
+
+    const findings = findUnsafeOwnedDomainTreeReferences(root);
+    assert.equal(findings.length, forbiddenFiles.length);
+    for (const [relativeFile] of forbiddenFiles) {
+        assert.ok(
+            findings.some((finding) =>
+                finding.startsWith(`${relativeFile}:1: contains`)
+            ),
+            `expected a forbidden reference in ${relativeFile}`
+        );
+    }
+});
+
+test("allows only exact historical copyright lines", () => {
+    const copyrightReference = {
+        allowance: "historical-copyright",
+    };
+    assert.equal(
+        isAllowedHistoricalReference(
+            "LICENSE",
+            "Copyright (c) 2022 dao.xyz",
+            copyrightReference
+        ),
+        true
+    );
+    assert.deepEqual(
+        find(
+            "LICENSE",
+            [
+                "Copyright (c) 2022 dao.xyz",
+                "Copyright (c) 2022 dao.xyz; endpoint=https://files.dao.xyz",
+            ].join("\n")
+        ),
+        ["LICENSE:2: contains unowned host or metadata identity dao.xyz"]
+    );
+    assert.equal(
+        find("packages/example/package.json", '{"author":"dao.xyz"}').length,
+        1
+    );
+});
+
+test("allows exact Giga dependency history only in changelogs", () => {
+    const historical = "    - @giga-app/sdk@2.0.1";
+    assert.deepEqual(find("packages/example/CHANGELOG.md", historical), []);
+    assert.equal(find("packages/example/README.md", historical).length, 1);
+    assert.equal(
+        find(
+            "packages/example/CHANGELOG.md",
+            'import sdk from "@giga-app/sdk";'
+        ).length,
+        1
+    );
+    assert.equal(
+        find(
+            "packages/example/package.json",
+            '{"dependencies":{"@giga-app/sdk":"2.0.1"}}'
+        ).length,
+        1
+    );
+});
+
+test("allows retired-reference literals only in the exact policy fixtures", () => {
+    const fixture = [
+        "https://files.dao.xyz",
+        "https://giga.place",
+        'import "@giga-app/sdk";',
+    ].join("\n");
+    assert.deepEqual(find("scripts/validate-owned-domains.mjs", fixture), []);
+    assert.deepEqual(
+        find("cloudflare/owned-domain-policy.test.mjs", fixture),
+        []
+    );
+    assert.equal(find("scripts/other-validator.mjs", fixture).length, 3);
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@dao-xyz/peerbit-examples",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/@dao-xyz/peerbit-node",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/blog-platform/cli/package.json
+++ b/packages/blog-platform/cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/blog",
     "version": "2.0.1",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/blog-platform/library/package.json
+++ b/packages/blog-platform/library/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/blog-sdk",
     "version": "2.0.1",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/blog-platform/server/package.json
+++ b/packages/blog-platform/server/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/blog-server",
     "version": "2.0.1",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/file-share/cli/package.json
+++ b/packages/file-share/cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/please",
     "version": "2.0.5",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/file-share/library/package.json
+++ b/packages/file-share/library/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/please-lib",
     "version": "2.0.5",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/identity/supabase-react/package.json
+++ b/packages/identity/supabase-react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/identity-supabase-react",
     "version": "0.1.1",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/identity/supabase/package.json
+++ b/packages/identity/supabase/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/identity-supabase",
     "version": "0.1.1",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/many-chat-rooms/library/package.json
+++ b/packages/many-chat-rooms/library/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/example-many-chat-rooms",
     "version": "2.0.1",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/media-streaming/music-library/music-library-utils/package.json
+++ b/packages/media-streaming/music-library/music-library-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/music-library-utils",
     "version": "2.0.1",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/media-streaming/playback-utils/package.json
+++ b/packages/media-streaming/playback-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/media-streaming-web",
     "version": "2.0.1",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/media-streaming/streaming-utils/package.json
+++ b/packages/media-streaming/streaming-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/media-streaming",
     "version": "2.0.1",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/media-streaming/video-streaming/cli/package.json
+++ b/packages/media-streaming/video-streaming/cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/video-replicator-cli",
     "version": "2.0.1",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/name-service/library/package.json
+++ b/packages/name-service/library/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/peer-names",
     "version": "2.0.1",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/shared-fs/cli/package.json
+++ b/packages/shared-fs/cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/shared-fs-cli",
     "version": "0.0.4",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/packages/shared-fs/library/package.json
+++ b/packages/shared-fs/library/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@peerbit/shared-fs",
     "version": "0.0.4",
-    "author": "dao.xyz",
+    "author": "Peerbit contributors",
     "repository": "https://github.com/dao-xyz/peerbit-examples",
     "license": "Apache-2.0",
     "type": "module",

--- a/scripts/validate-owned-domains.mjs
+++ b/scripts/validate-owned-domains.mjs
@@ -6,6 +6,10 @@ const repoRoot = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     ".."
 );
+const policyFixtureFiles = new Set([
+    "scripts/validate-owned-domains.mjs",
+    "cloudflare/owned-domain-policy.test.mjs",
+]);
 const retiredDirectAppHosts = [
     "stream",
     "music",
@@ -22,7 +26,8 @@ const retiredDirectAppHosts = [
 const forbiddenReferences = [
     {
         needle: "dao" + ".xyz",
-        description: "unowned host",
+        description: "unowned host or metadata identity",
+        allowance: "historical-copyright",
     },
     {
         needle: "giga" + ".place",
@@ -36,13 +41,29 @@ const forbiddenReferences = [
         needle: "dao-xyz.github" + ".io/peerbit-examples",
         description: "retired GitHub Pages URL",
     },
+    {
+        needle: "@giga" + "-app/",
+        description: "retired Giga package namespace",
+        allowance: "historical-giga-changelog",
+    },
+    {
+        needle: "packages/social-media-" + "app",
+        description: "retired Giga source tree",
+    },
+    {
+        needle: "peerbit-examples-" + "giga",
+        description: "retired Giga Worker",
+    },
+    {
+        needle: "giga.apps." + "peerbit.org",
+        description: "retired Giga production origin",
+    },
     ...retiredDirectAppHosts,
 ];
-const legalAttributionFiles = new Set([
-    "LICENSE",
-    "LICENSE-MIT",
-    "packages/text-document/LICENSE",
-]);
+const historicalCopyrightPattern =
+    /^\s*Copyright(?: \(c\))? \d{4} dao\.xyz\s*$/i;
+const historicalGigaChangelogPattern =
+    /^\s*-\s+@giga-app\/[a-z0-9._-]+@\d+\.\d+\.\d+(?:-[0-9a-z.-]+)?(?:\+[0-9a-z.-]+)?\s*$/i;
 const ignoredDirectories = new Set([
     ".git",
     "node_modules",
@@ -55,6 +76,7 @@ const textExtensions = new Set([
     ".css",
     ".cjs",
     ".env",
+    ".go",
     ".html",
     ".js",
     ".json",
@@ -63,9 +85,13 @@ const textExtensions = new Set([
     ".md",
     ".mjs",
     ".map",
+    ".mod",
+    ".patch",
+    ".ps1",
     ".sass",
     ".scss",
     ".sh",
+    ".sum",
     ".svelte",
     ".svg",
     ".ts",
@@ -76,58 +102,117 @@ const textExtensions = new Set([
     ".xml",
     ".yaml",
     ".yml",
+    ".wgsl",
 ]);
 
-const violations = [];
-const visit = (absolutePath) => {
-    const relativePath = path
-        .relative(repoRoot, absolutePath)
-        .split(path.sep)
-        .join("/");
-    const stat = statSync(absolutePath, { throwIfNoEntry: false });
-    if (!stat) return;
-    if (stat.isDirectory()) {
-        if (ignoredDirectories.has(path.basename(absolutePath))) return;
-        for (const name of readdirSync(absolutePath)) {
-            visit(path.join(absolutePath, name));
-        }
-        return;
-    }
-    if (
-        !stat.isFile() ||
-        legalAttributionFiles.has(relativePath) ||
-        (!textExtensions.has(path.extname(absolutePath)) &&
-            !path.basename(absolutePath).includes(".env."))
-    ) {
-        return;
-    }
+const normalizeFile = (file) => file.split(path.sep).join("/");
 
-    let contents = readFileSync(absolutePath, "utf8");
-    if (path.basename(absolutePath) === "package.json") {
-        const manifest = JSON.parse(contents);
-        // Package authorship is historical provenance, not a network target.
-        // It follows a separate legal/release process from host ownership.
-        delete manifest.author;
-        contents = JSON.stringify(manifest);
+export const isAllowedHistoricalReference = (file, line, reference) => {
+    if (reference.allowance === "historical-copyright") {
+        return historicalCopyrightPattern.test(line);
     }
-    contents = contents.toLowerCase();
+    if (reference.allowance === "historical-giga-changelog") {
+        return (
+            /(?:^|\/)CHANGELOG\.md$/.test(normalizeFile(file)) &&
+            historicalGigaChangelogPattern.test(line)
+        );
+    }
+    return false;
+};
+
+const findUnsafeOwnedPathReferences = (normalizedFile) => {
+    if (policyFixtureFiles.has(normalizedFile)) return [];
+
+    const findings = new Set();
+    const lowerFile = normalizedFile.toLowerCase();
     for (const reference of forbiddenReferences) {
-        if (contents.includes(reference.needle)) {
-            violations.push(
-                `${relativePath}: contains ${reference.description} ${reference.needle}`
+        if (lowerFile.includes(reference.needle)) {
+            findings.add(
+                `${normalizedFile}: path contains ${reference.description} ${reference.needle}`
             );
         }
     }
+    return [...findings];
 };
 
-visit(repoRoot);
+const findUnsafeOwnedContentReferences = (normalizedFile, contents) => {
+    if (policyFixtureFiles.has(normalizedFile)) return [];
 
-if (violations.length > 0) {
-    throw new Error(
-        `Unsafe or retired domain references found:\n${violations.join("\n")}`
+    const findings = new Set();
+    for (const [index, line] of contents.split(/\r?\n/).entries()) {
+        const lowerLine = line.toLowerCase();
+        for (const reference of forbiddenReferences) {
+            if (!lowerLine.includes(reference.needle)) continue;
+            if (isAllowedHistoricalReference(normalizedFile, line, reference)) {
+                continue;
+            }
+            findings.add(
+                `${normalizedFile}:${index + 1}: contains ${reference.description} ${reference.needle}`
+            );
+        }
+    }
+    return [...findings];
+};
+
+export const findUnsafeOwnedDomainReferences = (file, contents) => {
+    const normalizedFile = normalizeFile(file);
+    return [
+        ...findUnsafeOwnedPathReferences(normalizedFile),
+        ...findUnsafeOwnedContentReferences(normalizedFile, contents),
+    ];
+};
+
+export const findUnsafeOwnedDomainTreeReferences = (root = repoRoot) => {
+    const violations = [];
+    const visit = (absolutePath) => {
+        const relativePath = normalizeFile(path.relative(root, absolutePath));
+        const stat = statSync(absolutePath, { throwIfNoEntry: false });
+        if (!stat) return;
+        if (stat.isDirectory()) {
+            if (ignoredDirectories.has(path.basename(absolutePath))) return;
+            for (const name of readdirSync(absolutePath).sort()) {
+                visit(path.join(absolutePath, name));
+            }
+            return;
+        }
+        if (!stat.isFile()) return;
+
+        violations.push(...findUnsafeOwnedPathReferences(relativePath));
+
+        const extension = path.extname(absolutePath).toLowerCase();
+        const basename = path.basename(absolutePath).toLowerCase();
+        if (!textExtensions.has(extension) && !basename.includes(".env.")) {
+            return;
+        }
+
+        violations.push(
+            ...findUnsafeOwnedContentReferences(
+                relativePath,
+                readFileSync(absolutePath, "utf8")
+            )
+        );
+    };
+
+    visit(root);
+    return [...new Set(violations)];
+};
+
+const main = () => {
+    const violations = findUnsafeOwnedDomainTreeReferences();
+    if (violations.length > 0) {
+        throw new Error(
+            `Unsafe or retired project references found:\n${violations.join("\n")}`
+        );
+    }
+
+    console.log(
+        "Validated that source, metadata, and generated text assets avoid unsafe or retired project references"
     );
-}
+};
 
-console.log(
-    "Validated that source and generated text assets avoid unsafe and retired project domains"
-);
+if (
+    process.argv[1] &&
+    path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+    main();
+}


### PR DESCRIPTION
## Summary

- replace dao.xyz package-author metadata with Peerbit contributors
- reject retired dao.xyz, giga.place, Giga app/Worker, and social-media source references from active files
- preserve exact historical legal and changelog records plus dao-xyz GitHub/npm namespaces
- scan retired paths before content filtering, including binary files, and cover all active source formats used by the repository

## Validation

- focused owned-domain policy tests: 8/8
- full Cloudflare policy suite: 121/121
- repository owned-domain validation
- Changesets release plan: zero package releases
- Prettier and git diff check

This does not modify the dao-xyz GitHub organization or its metadata.