### PR TITLE
feat(cloudflare): add fail-closed production provisioner

### DIFF
--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -37,7 +37,9 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Install locked Wrangler toolchain
-              run: npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler
+              run: |
+                  npm ci --no-audit --no-fund --prefix tools/wrangler
+                  node scripts/validate-wrangler-toolchain.mjs
 
             - name: Validate production bootstrap sources
               run: |

--- a/.github/workflows/cloudflare-production-provision.yml
+++ b/.github/workflows/cloudflare-production-provision.yml
@@ -1,0 +1,269 @@
+name: Provision Cloudflare production once
+
+on:
+    workflow_dispatch:
+        inputs:
+            mode:
+                description: Read-only plan or confirmed one-time provisioning
+                required: true
+                type: choice
+                default: plan
+                options:
+                    - plan
+                    - apply
+            planned_commit:
+                description: Exact 40-character commit reviewed by plan and apply
+                required: true
+                type: string
+            planned_state_digest:
+                description: Use 64 zeroes for plan; use the exact PLAN_STATE_SHA256 emitted by the reviewed plan for apply
+                required: true
+                type: string
+            confirm:
+                description: Plan phrase binds the commit; apply phrase binds both commit and planned state digest
+                required: true
+                type: string
+
+permissions:
+    contents: read
+
+concurrency:
+    group: cloudflare-examples-production
+    cancel-in-progress: false
+
+jobs:
+    validate:
+        runs-on: ubuntu-24.04
+        timeout-minutes: 30
+        steps:
+            - name: Validate SHA-bound dispatch receipt
+              env:
+                  PROVISION_MODE: ${{ inputs.mode }}
+                  PROVISION_CONFIRM: ${{ inputs.confirm }}
+                  PROVISION_PLANNED_COMMIT: ${{ inputs.planned_commit }}
+                  PROVISION_PLANNED_STATE_DIGEST: ${{ inputs.planned_state_digest }}
+                  PROVISION_COMMIT: ${{ github.sha }}
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  if [[ "$GITHUB_REF" != "refs/heads/master" ]]; then
+                      echo "Provisioning is permitted only from master" >&2
+                      exit 1
+                  fi
+                  if [[ ! "$PROVISION_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]] ||
+                     [[ ! "$PROVISION_PLANNED_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]]; then
+                      echo "Both checked-out and planned commits must be full SHA-1 values" >&2
+                      exit 1
+                  fi
+                  planned_commit="$(printf '%s' "$PROVISION_PLANNED_COMMIT" | tr '[:upper:]' '[:lower:]')"
+                  checked_out_commit="$(printf '%s' "$PROVISION_COMMIT" | tr '[:upper:]' '[:lower:]')"
+                  if [[ "$planned_commit" != "$checked_out_commit" ]]; then
+                      echo "Planned commit receipt does not match the checked-out commit" >&2
+                      exit 1
+                  fi
+                  if [[ ! "$PROVISION_PLANNED_STATE_DIGEST" =~ ^[0-9a-f]{64}$ ]]; then
+                      echo "Planned state digest must be a lowercase SHA-256 value" >&2
+                      exit 1
+                  fi
+                  state_sentinel="$(printf '0%.0s' {1..64})"
+                  case "$PROVISION_MODE" in
+                      plan)
+                          [[ "$PROVISION_PLANNED_STATE_DIGEST" == "$state_sentinel" ]] || {
+                              echo "Plan requires the 64-zero state sentinel" >&2; exit 1;
+                          }
+                          confirmation="plan-peerbit-production-${planned_commit}"
+                          ;;
+                      apply)
+                          [[ "$PROVISION_PLANNED_STATE_DIGEST" != "$state_sentinel" ]] || {
+                              echo "Apply requires the reviewed nonzero state digest" >&2; exit 1;
+                          }
+                          confirmation="provision-peerbit-production-${planned_commit}-${PROVISION_PLANNED_STATE_DIGEST}"
+                          ;;
+                      *) echo "Provisioning mode must be plan or apply" >&2; exit 1 ;;
+                  esac
+                  if [[ "$PROVISION_CONFIRM" != "$confirmation" ]]; then
+                      echo "Confirmation is not bound to the exact planned commit and state" >&2
+                      exit 1
+                  fi
+
+            - name: Checkout
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  ref: ${{ github.sha }}
+                  persist-credentials: false
+
+            - name: Setup Node
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+              with:
+                  node-version: 22.x
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+              with:
+                  run_install: false
+
+            - name: Build and test every production source
+              env:
+                  COMMIT_HASH: ${{ github.sha }}
+              run: |
+                  pnpm install --frozen-lockfile
+                  npm ci --no-audit --no-fund --prefix tools/wrangler
+                  node scripts/validate-wrangler-toolchain.mjs
+                  node scripts/validate-production-bootstrap.mjs
+                  node --test cloudflare/*.test.mjs
+                  export SHORT_SHA="${GITHUB_SHA::7}"
+                  pnpm run build
+
+            - name: Install locked Chromium for hosted-app validation
+              run: pnpm exec playwright install --with-deps chromium
+
+            - name: Smoke-test every hosted app
+              run: pnpm run test:hosted-apps
+
+            - name: Validate exact route-free production bundles
+              env:
+                  COMMIT_HASH: ${{ github.sha }}
+              run: |
+                  node scripts/prepare-cloudflare-assets.mjs
+                  node scripts/validate-owned-domains.mjs
+                  git diff --exit-code
+                  node scripts/render-cloudflare-configs.mjs --mode production
+                  rm -rf .wrangler-dry-run
+                  for config in .wrangler-config/*.jsonc; do
+                      output="$PWD/.wrangler-dry-run/$(basename "$config" .jsonc)"
+                      tools/wrangler/node_modules/.bin/wrangler versions upload \
+                          --config "$config" \
+                          --dry-run \
+                          --outdir "$output"
+                  done
+                  node scripts/create-cloudflare-artifact-manifests.mjs
+
+    provision:
+        needs: validate
+        if: always()
+        runs-on: ubuntu-24.04
+        timeout-minutes: 90
+        environment: cloudflare-production
+        steps:
+            - name: Validate SHA-bound dispatch receipt
+              env:
+                  PROVISION_MODE: ${{ inputs.mode }}
+                  PROVISION_CONFIRM: ${{ inputs.confirm }}
+                  PROVISION_PLANNED_COMMIT: ${{ inputs.planned_commit }}
+                  PROVISION_PLANNED_STATE_DIGEST: ${{ inputs.planned_state_digest }}
+                  PROVISION_COMMIT: ${{ github.sha }}
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  if [[ "$GITHUB_REF" != "refs/heads/master" ]]; then
+                      echo "Provisioning is permitted only from master" >&2
+                      exit 1
+                  fi
+                  if [[ ! "$PROVISION_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]] ||
+                     [[ ! "$PROVISION_PLANNED_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]]; then
+                      echo "Both checked-out and planned commits must be full SHA-1 values" >&2
+                      exit 1
+                  fi
+                  planned_commit="$(printf '%s' "$PROVISION_PLANNED_COMMIT" | tr '[:upper:]' '[:lower:]')"
+                  checked_out_commit="$(printf '%s' "$PROVISION_COMMIT" | tr '[:upper:]' '[:lower:]')"
+                  if [[ "$planned_commit" != "$checked_out_commit" ]]; then
+                      echo "Planned commit receipt does not match the checked-out commit" >&2
+                      exit 1
+                  fi
+                  if [[ ! "$PROVISION_PLANNED_STATE_DIGEST" =~ ^[0-9a-f]{64}$ ]]; then
+                      echo "Planned state digest must be a lowercase SHA-256 value" >&2
+                      exit 1
+                  fi
+                  state_sentinel="$(printf '0%.0s' {1..64})"
+                  case "$PROVISION_MODE" in
+                      plan)
+                          [[ "$PROVISION_PLANNED_STATE_DIGEST" == "$state_sentinel" ]] || {
+                              echo "Plan requires the 64-zero state sentinel" >&2; exit 1;
+                          }
+                          confirmation="plan-peerbit-production-${planned_commit}"
+                          ;;
+                      apply)
+                          [[ "$PROVISION_PLANNED_STATE_DIGEST" != "$state_sentinel" ]] || {
+                              echo "Apply requires the reviewed nonzero state digest" >&2; exit 1;
+                          }
+                          confirmation="provision-peerbit-production-${planned_commit}-${PROVISION_PLANNED_STATE_DIGEST}"
+                          ;;
+                      *) echo "Provisioning mode must be plan or apply" >&2; exit 1 ;;
+                  esac
+                  if [[ "$PROVISION_CONFIRM" != "$confirmation" ]]; then
+                      echo "Confirmation is not bound to the exact planned commit and state" >&2
+                      exit 1
+                  fi
+
+            - name: Require successful source validation
+              env:
+                  VALIDATE_RESULT: ${{ needs.validate.result }}
+              run: |
+                  if [[ "$VALIDATE_RESULT" != "success" ]]; then
+                      echo "Source validation did not succeed" >&2
+                      exit 1
+                  fi
+
+            - name: Checkout
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  ref: ${{ github.sha }}
+                  persist-credentials: false
+
+            - name: Setup Node
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+              with:
+                  node-version: 22.x
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+              with:
+                  run_install: false
+
+            - name: Rebuild reviewed inputs without deployment credentials
+              env:
+                  COMMIT_HASH: ${{ github.sha }}
+              run: |
+                  pnpm install --frozen-lockfile
+                  npm ci --no-audit --no-fund --prefix tools/wrangler
+                  node scripts/validate-wrangler-toolchain.mjs
+                  node scripts/validate-production-bootstrap.mjs
+                  node --test cloudflare/*.test.mjs
+                  export SHORT_SHA="${GITHUB_SHA::7}"
+                  pnpm run build
+                  node scripts/prepare-cloudflare-assets.mjs
+                  node scripts/validate-owned-domains.mjs
+                  git diff --exit-code
+                  node scripts/render-cloudflare-configs.mjs --mode production
+                  rm -rf .wrangler-dry-run
+                  for config in .wrangler-config/*.jsonc; do
+                      output="$PWD/.wrangler-dry-run/$(basename "$config" .jsonc)"
+                      tools/wrangler/node_modules/.bin/wrangler versions upload \
+                          --config "$config" \
+                          --dry-run \
+                          --outdir "$output"
+                  done
+                  node scripts/create-cloudflare-artifact-manifests.mjs
+
+            - name: Install Chromium for live baseline checks
+              if: inputs.mode == 'apply'
+              run: >-
+                  pnpm --dir packages/file-share/frontend exec playwright
+                  install --with-deps chromium
+
+            - name: Plan or provision exact production baseline
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PRODUCTION_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+                  PROVISION_MODE: ${{ inputs.mode }}
+                  PROVISION_CONFIRM: ${{ inputs.confirm }}
+                  PROVISION_PLANNED_COMMIT: ${{ inputs.planned_commit }}
+                  PROVISION_PLANNED_STATE_DIGEST: ${{ inputs.planned_state_digest }}
+                  PROVISION_COMMIT: ${{ github.sha }}
+              run: >-
+                  node scripts/provision-cloudflare-production.mjs
+                  --mode "$PROVISION_MODE"
+                  --commit "$PROVISION_COMMIT"
+                  --planned-commit "$PROVISION_PLANNED_COMMIT"
+                  --planned-state-digest "$PROVISION_PLANNED_STATE_DIGEST"
+                  --confirm "$PROVISION_CONFIRM"

--- a/.github/workflows/cloudflare-production.yml
+++ b/.github/workflows/cloudflare-production.yml
@@ -55,7 +55,8 @@ jobs:
                   COMMIT_HASH: ${{ github.sha }}
               run: |
                   pnpm install --frozen-lockfile
-                  npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler
+                  npm ci --no-audit --no-fund --prefix tools/wrangler
+                  node scripts/validate-wrangler-toolchain.mjs
                   node scripts/validate-production-bootstrap.mjs
                   node --test cloudflare/*.test.mjs
                   export SHORT_SHA="${GITHUB_SHA::7}"
@@ -110,7 +111,8 @@ jobs:
                   COMMIT_HASH: ${{ github.sha }}
               run: |
                   pnpm install --frozen-lockfile
-                  npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler
+                  npm ci --no-audit --no-fund --prefix tools/wrangler
+                  node scripts/validate-wrangler-toolchain.mjs
                   node scripts/validate-production-bootstrap.mjs
                   node --test cloudflare/*.test.mjs
                   export SHORT_SHA="${GITHUB_SHA::7}"

--- a/README.md
+++ b/README.md
@@ -196,3 +196,12 @@ no existing deployment, because there would be no version to restore. Seed a
 new production Worker once under direct operator supervision, verify it, then
 use the workflow for all later releases. Use the separately reviewed production
 environment and retain a known-good Worker version.
+
+The auditable, idempotent first-deploy procedure is documented in
+[`cloudflare/production-provisioning.md`](./cloudflare/production-provisioning.md).
+Its manual workflow has a read-only plan and a separately confirmed apply; it
+independently pins all seven production and preview identities, maintains one
+invocation-wide production ledger, proves every existing managed public URL is
+disabled before and throughout deployment mutations, attaches custom domains
+last, and leaves retired Worker cleanup as an independent explicitly approved
+operation.

--- a/cloudflare/artifact-manifest.test.mjs
+++ b/cloudflare/artifact-manifest.test.mjs
@@ -1,0 +1,443 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+    chmodSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import {
+    CLOUDFLARE_ARTIFACT_DIGEST_BINDING,
+    CLOUDFLARE_ARTIFACT_PUBLIC_PATH,
+    artifactBoundVersionMessage,
+    createCloudflareArtifactManifest,
+    revalidateCloudflareArtifactManifest,
+    validateActiveWorkerModule,
+    verifyLiveCloudflareArtifact,
+} from "../scripts/cloudflare-artifact-manifest.mjs";
+import { repoRoot } from "../scripts/cloudflare-deployment-policy.mjs";
+import {
+    createRouteFreeWranglerConfig,
+    runWranglerVersionUpload,
+} from "../scripts/deploy-cloudflare-production.mjs";
+
+const COMMIT = "a".repeat(40);
+const MODULE_BYTES = Buffer.from(
+    "export default { fetch() { return new Response('reviewed') } };\n"
+);
+
+const createFixture = () => {
+    const root = mkdtempSync(
+        path.join(repoRoot, ".cloudflare-artifact-manifest-test-")
+    );
+    const assetsDirectory = path.join(root, "assets");
+    const artifactRoot = path.join(root, "artifacts");
+    const artifactDirectory = path.join(artifactRoot, "test-site");
+    mkdirSync(path.join(assetsDirectory, "assets"), { recursive: true });
+    mkdirSync(artifactDirectory, { recursive: true });
+    writeFileSync(path.join(artifactDirectory, "worker.mjs"), MODULE_BYTES);
+    writeFileSync(
+        path.join(assetsDirectory, "index.html"),
+        "<h1>reviewed</h1>\n"
+    );
+    writeFileSync(
+        path.join(assetsDirectory, "release.json"),
+        `${JSON.stringify({ site: "test-site", commit: COMMIT })}\n`
+    );
+    writeFileSync(path.join(assetsDirectory, "assets/app.js"), "app();\n");
+    writeFileSync(
+        path.join(assetsDirectory, "_headers"),
+        "/*\n  X-Test: yes\n"
+    );
+    const configFile = path.join(root, "production.jsonc");
+    const renderedConfig = {
+        name: "peerbit-examples-test-site",
+        main: "../source-worker.mjs",
+        compatibility_date: "2026-07-14",
+        compatibility_flags: ["nodejs_compat"],
+        workers_dev: false,
+        preview_urls: false,
+        upload_source_maps: false,
+        routes: [
+            {
+                pattern: "test.apps.peerbit.org",
+                custom_domain: true,
+            },
+        ],
+        assets: {
+            directory: "./assets",
+            binding: "ASSETS",
+            run_worker_first: ["/media/*"],
+        },
+        vars: { RELEASE_CHANNEL: "production" },
+    };
+    writeFileSync(configFile, `${JSON.stringify(renderedConfig)}\n`);
+    const site = { id: "test-site" };
+    const policy = {
+        id: site.id,
+        productionWorker: renderedConfig.name,
+    };
+    const artifact = createCloudflareArtifactManifest({
+        site,
+        policy,
+        configFile,
+        renderedConfig,
+        expectedCommit: COMMIT,
+        artifactRoot,
+    });
+    return {
+        root,
+        assetsDirectory,
+        artifactRoot,
+        configFile,
+        renderedConfig,
+        site,
+        policy,
+        artifact,
+        cleanup: () => rmSync(root, { recursive: true, force: true }),
+    };
+};
+
+test("pre-credential artifact receipt binds exact module, route-free config, and every asset", () => {
+    const fixture = createFixture();
+    try {
+        const { artifact, renderedConfig, configFile, policy } = fixture;
+        assert.match(artifact.digest, /^[0-9a-f]{64}$/);
+        assert.ok(Object.isFrozen(artifact.manifest));
+        assert.ok(Object.isFrozen(artifact.manifest.module));
+        assert.ok(Object.isFrozen(artifact.manifest.assets));
+        assert.deepEqual(artifact.manifest.module, {
+            path: "worker.mjs",
+            size: MODULE_BYTES.length,
+            sha256: createHash("sha256").update(MODULE_BYTES).digest("hex"),
+            contentType: "application/javascript+module",
+        });
+        assert.deepEqual(
+            artifact.manifest.assets.map(
+                ({ path: assetPath, public: isPublic }) => [assetPath, isPublic]
+            ),
+            [
+                ["_headers", false],
+                ["assets/app.js", true],
+                ["index.html", true],
+                ["release.json", true],
+            ]
+        );
+        assert.equal(artifact.manifest.deploymentConfig.routes, undefined);
+        assert.equal(artifact.manifest.deploymentConfig.no_bundle, true);
+        assert.equal(
+            artifact.manifest.deploymentConfig.find_additional_modules,
+            false
+        );
+        assert.equal(
+            artifact.manifest.deploymentConfig.upload_source_maps,
+            false
+        );
+        assert.equal(artifact.manifest.deploymentConfig.main, "worker.mjs");
+        assert.equal(
+            artifact.manifest.deploymentConfig.assets.directory,
+            "<reviewed-static-assets>"
+        );
+
+        const privateConfig = createRouteFreeWranglerConfig({
+            configFile,
+            renderedConfig,
+            workerName: policy.productionWorker,
+            artifact,
+        });
+        assert.equal(privateConfig.main, artifact.moduleFile);
+        assert.equal(privateConfig.no_bundle, true);
+        assert.equal(privateConfig.find_additional_modules, false);
+        assert.equal(privateConfig.upload_source_maps, false);
+        assert.equal(privateConfig.routes, undefined);
+        assert.equal(
+            privateConfig.vars[CLOUDFLARE_ARTIFACT_DIGEST_BINDING],
+            artifact.digest
+        );
+        assert.match(
+            artifactBoundVersionMessage({
+                siteId: fixture.site.id,
+                expectedCommit: COMMIT,
+                artifactManifestDigest: artifact.digest,
+            }),
+            new RegExp(`artifact-sha256:${artifact.digest}$`)
+        );
+        assert.equal(revalidateCloudflareArtifactManifest(artifact), artifact);
+    } finally {
+        fixture.cleanup();
+    }
+});
+
+test("a compromised credentialed upload cannot silently substitute reviewed config or module inputs", () => {
+    const fixture = createFixture();
+    try {
+        assert.throws(
+            () =>
+                createRouteFreeWranglerConfig({
+                    configFile: fixture.configFile,
+                    renderedConfig: {
+                        ...fixture.renderedConfig,
+                        compatibility_date: "2026-07-15",
+                    },
+                    workerName: fixture.policy.productionWorker,
+                    artifact: fixture.artifact,
+                }),
+            /reviewed route-free runtime\/config changed/
+        );
+        assert.throws(
+            () =>
+                createRouteFreeWranglerConfig({
+                    configFile: fixture.configFile,
+                    renderedConfig: {
+                        ...fixture.renderedConfig,
+                        assets: {
+                            ...fixture.renderedConfig.assets,
+                            run_worker_first: ["/unreviewed/*"],
+                        },
+                    },
+                    workerName: fixture.policy.productionWorker,
+                    artifact: fixture.artifact,
+                }),
+            /reviewed route-free runtime\/config changed/
+        );
+        assert.throws(
+            () =>
+                createRouteFreeWranglerConfig({
+                    configFile: fixture.configFile,
+                    renderedConfig: {
+                        ...fixture.renderedConfig,
+                        find_additional_modules: true,
+                    },
+                    workerName: fixture.policy.productionWorker,
+                    artifact: fixture.artifact,
+                }),
+            /forbids Wrangler auxiliary-module discovery/
+        );
+        assert.throws(
+            () =>
+                createRouteFreeWranglerConfig({
+                    configFile: fixture.configFile,
+                    renderedConfig: {
+                        ...fixture.renderedConfig,
+                        upload_source_maps: true,
+                    },
+                    workerName: fixture.policy.productionWorker,
+                    artifact: fixture.artifact,
+                }),
+            /requires Wrangler source-map upload to be explicitly disabled/
+        );
+        assert.throws(
+            () =>
+                createRouteFreeWranglerConfig({
+                    configFile: fixture.configFile,
+                    renderedConfig: {
+                        ...fixture.renderedConfig,
+                        wasm_modules: { ROGUE: "./rogue.wasm" },
+                    },
+                    workerName: fixture.policy.productionWorker,
+                    artifact: fixture.artifact,
+                }),
+            /forbids auxiliary-module setting wasm_modules/
+        );
+        chmodSync(fixture.artifact.moduleFile, 0o644);
+        writeFileSync(
+            fixture.artifact.moduleFile,
+            "export default { fetch() { return new Response('substituted') } };\n"
+        );
+        assert.throws(
+            () => revalidateCloudflareArtifactManifest(fixture.artifact),
+            /reviewed main-module bytes changed/
+        );
+    } finally {
+        fixture.cleanup();
+    }
+});
+
+test("the reviewed dry-run receipt fails closed on every auxiliary runtime module", () => {
+    const fixture = createFixture();
+    try {
+        writeFileSync(
+            path.join(path.dirname(fixture.artifact.moduleFile), "rogue.wasm"),
+            Buffer.from([0, 97, 115, 109])
+        );
+        assert.throws(
+            () => revalidateCloudflareArtifactManifest(fixture.artifact),
+            /exactly one Wrangler runtime-module output/
+        );
+    } finally {
+        fixture.cleanup();
+    }
+});
+
+test("the exact Wrangler invocation carries the artifact digest in config, message, and evidence", () => {
+    const fixture = createFixture();
+    try {
+        const versionId = "11111111-1111-4111-8111-111111111111";
+        const versionTag = "peerbit_test_site_aaaaaaaaaaaa_receipt";
+        let invokedArguments;
+        const evidence = runWranglerVersionUpload({
+            wrangler: "/tools/wrangler",
+            configFile: fixture.configFile,
+            renderedConfig: fixture.renderedConfig,
+            site: fixture.site,
+            expectedCommit: COMMIT,
+            workerName: fixture.policy.productionWorker,
+            versionTag,
+            artifact: fixture.artifact,
+            environment: {
+                CLOUDFLARE_API_TOKEN: "test-token",
+                CLOUDFLARE_ACCOUNT_ID: "c".repeat(32),
+            },
+            runtime: {
+                runLogged: (_command, args, environment) => {
+                    invokedArguments = args;
+                    const privateConfig = JSON.parse(
+                        readFileSync(args[args.indexOf("--config") + 1], "utf8")
+                    );
+                    assert.equal(
+                        privateConfig.main,
+                        fixture.artifact.moduleFile
+                    );
+                    assert.equal(privateConfig.no_bundle, true);
+                    assert.equal(privateConfig.find_additional_modules, false);
+                    assert.equal(privateConfig.upload_source_maps, false);
+                    assert.equal(
+                        privateConfig.vars[CLOUDFLARE_ARTIFACT_DIGEST_BINDING],
+                        fixture.artifact.digest
+                    );
+                    writeFileSync(
+                        environment.WRANGLER_OUTPUT_FILE_PATH,
+                        `${JSON.stringify({
+                            type: "version-upload",
+                            version: 1,
+                            worker_name: fixture.policy.productionWorker,
+                            worker_tag: "worker-tag",
+                            version_id: versionId,
+                            worker_name_overridden: false,
+                        })}\n`
+                    );
+                },
+            },
+        });
+        assert.deepEqual(evidence, {
+            workerName: fixture.policy.productionWorker,
+            workerTag: "worker-tag",
+            versionId,
+            artifactManifestDigest: fixture.artifact.digest,
+        });
+        assert.ok(invokedArguments.includes("--no-bundle"));
+        assert.equal(
+            invokedArguments[invokedArguments.indexOf("--message") + 1],
+            artifactBoundVersionMessage({
+                siteId: fixture.site.id,
+                expectedCommit: COMMIT,
+                artifactManifestDigest: fixture.artifact.digest,
+            })
+        );
+    } finally {
+        fixture.cleanup();
+    }
+});
+
+test("changed static asset inputs fail before upload", () => {
+    const fixture = createFixture();
+    try {
+        writeFileSync(
+            path.join(fixture.assetsDirectory, "assets/app.js"),
+            "substituted();\n"
+        );
+        assert.throws(
+            () => revalidateCloudflareArtifactManifest(fixture.artifact),
+            /reviewed static-asset bytes changed/
+        );
+    } finally {
+        fixture.cleanup();
+    }
+});
+
+test("active module and exhaustive live asset proofs accept only reviewed bytes", async () => {
+    const fixture = createFixture();
+    try {
+        const { artifact, assetsDirectory } = fixture;
+        validateActiveWorkerModule({
+            artifact,
+            observed: {
+                name: "worker.mjs",
+                contentType: "application/javascript+module",
+                size: MODULE_BYTES.length,
+                sha256: createHash("sha256").update(MODULE_BYTES).digest("hex"),
+            },
+        });
+        assert.throws(
+            () =>
+                validateActiveWorkerModule({
+                    artifact,
+                    observed: {
+                        name: "worker.mjs",
+                        contentType: "application/javascript+module",
+                        size: MODULE_BYTES.length,
+                        sha256: "f".repeat(64),
+                    },
+                }),
+            /exact Worker version module set does not match/
+        );
+
+        const requested = [];
+        const serveReviewed = async (url, init) => {
+            assert.equal(init.redirect, "manual");
+            const pathname = decodeURIComponent(new URL(url).pathname);
+            requested.push(pathname);
+            if (pathname === CLOUDFLARE_ARTIFACT_PUBLIC_PATH) {
+                return new Response(readFileSync(artifact.manifestFile));
+            }
+            return new Response(
+                readFileSync(path.join(assetsDirectory, pathname.slice(1)))
+            );
+        };
+        await verifyLiveCloudflareArtifact({
+            origin: "https://test.apps.peerbit.org",
+            artifact,
+            request: serveReviewed,
+            concurrency: 2,
+        });
+        assert.deepEqual(
+            requested.sort(),
+            [
+                CLOUDFLARE_ARTIFACT_PUBLIC_PATH,
+                ...artifact.manifest.assets
+                    .filter(({ public: isPublic }) => isPublic)
+                    .map(({ path: assetPath }) => `/${assetPath}`),
+            ].sort()
+        );
+
+        await assert.rejects(
+            verifyLiveCloudflareArtifact({
+                origin: "https://test.apps.peerbit.org",
+                artifact,
+                request: async (url) => {
+                    const pathname = decodeURIComponent(new URL(url).pathname);
+                    if (pathname === CLOUDFLARE_ARTIFACT_PUBLIC_PATH) {
+                        return new Response(
+                            readFileSync(artifact.manifestFile)
+                        );
+                    }
+                    if (pathname === "/assets/app.js") {
+                        return new Response("wrong live asset\n");
+                    }
+                    return new Response(
+                        readFileSync(
+                            path.join(assetsDirectory, pathname.slice(1))
+                        )
+                    );
+                },
+            }),
+            /live bytes do not match the reviewed artifact manifest/
+        );
+    } finally {
+        fixture.cleanup();
+    }
+});

--- a/cloudflare/deployment-safety.test.mjs
+++ b/cloudflare/deployment-safety.test.mjs
@@ -554,6 +554,10 @@ test("Cloudflare Workers API lists the configured account exactly", async () => 
                             id: workerName,
                             tag: WORKER_TAGS.get("files"),
                             routes: [],
+                            tail_consumers: [
+                                { service: "tail-consumer-worker" },
+                            ],
+                            logpush: true,
                         },
                         {
                             id: "unrelated-account-worker",
@@ -570,10 +574,23 @@ test("Cloudflare Workers API lists the configured account exactly", async () => 
     assert.deepEqual(
         [...(await api.listWorkerScripts())],
         [
-            [workerName, { tag: WORKER_TAGS.get("files"), routes: [] }],
+            [
+                workerName,
+                {
+                    tag: WORKER_TAGS.get("files"),
+                    routes: [],
+                    tailConsumers: [{ service: "tail-consumer-worker" }],
+                    logpush: true,
+                },
+            ],
             [
                 "unrelated-account-worker",
-                { tag: "unrelated-worker-tag", routes: [] },
+                {
+                    tag: "unrelated-worker-tag",
+                    routes: [],
+                    tailConsumers: [],
+                    logpush: false,
+                },
             ],
         ]
     );

--- a/cloudflare/production-provisioning.md
+++ b/cloudflare/production-provisioning.md
@@ -1,0 +1,280 @@
+# One-time Cloudflare production provisioning
+
+This runbook seeds the seven reviewed application Workers and their seven exact
+`*.apps.peerbit.org` custom domains. The authoritative identities remain in
+`cloudflare/deployment-policy.json`; the provisioning script independently
+pins the same seven application IDs, production Workers, production hostnames,
+and preview Workers so a scope change requires code and policy review. A
+preview identity cannot be substituted with a duplicate, shadow, or retired
+legacy Worker through policy alone. The script never creates preview Workers,
+traditional Worker routes, or any resource outside that allowlist.
+
+Cloudflare's current model separates an uploaded Worker version from the
+deployment that sends traffic to it. The workflow uses that separation to
+upload a route-free version, disable both `workers.dev` and version Preview
+URLs, activate exactly that version at 100%, and attach the custom domain last.
+These are the relevant official references:
+
+- [Versions and deployments](https://developers.cloudflare.com/workers/versions-and-deployments/)
+- [`wrangler versions upload`](https://developers.cloudflare.com/workers/wrangler/commands/workers/#versions-upload)
+- [Worker scripts API](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/)
+- [Worker subdomain API](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/subdomain/)
+- [Worker deployments API](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/deployments/)
+- [Worker versions API](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/versions/)
+- [Worker Cron Trigger schedules API](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/schedules/)
+- [Queues list API](https://developers.cloudflare.com/api/resources/queues/methods/list/)
+- [Queue consumers list API](https://developers.cloudflare.com/api/resources/queues/subresources/consumers/methods/list/)
+- [Worker script content API](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/content/methods/get/)
+- [Worker custom-domain API](https://developers.cloudflare.com/api/resources/workers/subresources/domains/)
+- [Custom Domains](https://developers.cloudflare.com/workers/configuration/routing/custom-domains/)
+
+## Preconditions
+
+1. Run only from `master` at the exact commit to be made the initial baseline.
+   Copy its lowercase, full 40-character Git SHA; abbreviated SHAs are not
+   receipts.
+2. Keep GitHub's `cloudflare-production` environment protected by required
+   reviewers. Its existing `CLOUDFLARE_PRODUCTION_API_TOKEN` secret must have
+   the narrowly required Workers Scripts read/write access, including version,
+   deployment, subdomain, domain, Cron Trigger schedule, and active script
+   content reads, plus **Queue Read** for the separate account-wide Queue
+   consumer inventory. Its existing `CLOUDFLARE_ACCOUNT_ID` variable must
+   identify the reviewed account.
+3. Confirm that the `peerbit.org` zone is active in that account. Cloudflare
+   cannot attach a Custom Domain over a conflicting CNAME, so resolve any such
+   conflict manually before applying.
+4. Ensure no other Cloudflare production deployment is running. Both the
+   provisioning and routine deployment workflows use the
+   `cloudflare-examples-production` concurrency group.
+5. Never paste the API token, account ID, or a `workers.dev` hostname into an
+   issue or workflow log.
+
+## Read-only plan
+
+Dispatch **Provision Cloudflare production once** with:
+
+- `mode`: `plan`
+- `planned_commit`: `<the exact 40-character master SHA>`
+- `planned_state_digest`: `<64 zeroes>`
+- `confirm`: `plan-peerbit-production-<the exact 40-character master SHA>`
+
+For example, for planned commit
+`0123456789abcdef0123456789abcdef01234567`, enter exactly:
+
+- `planned_commit`: `0123456789abcdef0123456789abcdef01234567`
+- `planned_state_digest`: `0000000000000000000000000000000000000000000000000000000000000000`
+- `confirm`: `plan-peerbit-production-0123456789abcdef0123456789abcdef01234567`
+
+The protected environment supplies credentials only to the final read-only
+step. The plan reads the complete Worker and stable custom-domain inventories,
+the live public-subdomain state, deployments, every deployable version ID,
+immutable Worker tags, routes, Tail consumers, Logpush state, Cron schedules,
+active service-binding targets, and every Queue plus its separate consumer
+attachments. The Queue list is paginated and every complete account snapshot
+must be observed twice without change. The digest also binds the exact
+Cloudflare account ID so an account-variable change cannot reuse a receipt. It
+prints the full planned commit, reviewed
+Worker names, public custom domains, proposed actions, and a canonical
+`PLAN_STATE_SHA256` receipt. It sends no Cloudflare mutation.
+
+Before credentials are exposed, the workflow dry-runs each of the seven exact
+Wrangler bundles and creates a canonical artifact manifest. Each dry run must
+contain exactly one self-contained ES module: the upload config sets both
+`no_bundle: true` and `find_additional_modules: false`, explicitly disables
+source-map upload, and the receipt rejects any auxiliary JavaScript, Wasm,
+source-map, text, or data output. Each manifest
+hashes the exact module name, MIME type, bytes, normalized route-free
+runtime/config (including static-assets behavior), and every static-asset input
+path, byte length, and SHA-256 (including `release.json`; processing inputs such
+as `_headers` are marked non-public). The workflow also writes those exact
+canonical manifest bytes to
+`/peerbit-deployment-manifest.json` in the site's asset input. The artifact
+manifest digest is included in the plan receipt, so rebuilding different code,
+configuration, or assets cannot reuse a reviewed account-state receipt.
+
+Review all seven rows. Expected first-run actions are a route-free upload,
+public-subdomain disable, exact 100% activation, domain attachment, and live
+verification. Each existing allowlisted preview Worker with either public flag
+enabled has an explicit `disable-public-subdomains` action; a missing preview
+has no action and is never created. Any unknown `peerbit-examples-*` Worker,
+traditional route, wrong domain owner, split deployment, Tail consumer,
+Logpush attachment, Cron Trigger, queue/service attachment on a managed Worker,
+inbound service binding, Queue consumer attachment targeting any managed
+production or preview Worker, or malformed response blocks the run. Old
+inactive versions are listed as quarantined state: their annotations are never
+accepted as proof that this invocation uploaded them. The inspection records
+every production Worker's existence, immutable Worker tag, active and
+deployable version IDs, subdomain flags, schedules, domain state,
+artifact-manifest digest, and the canonical account Queue-consumer inventory in
+the signed plan receipt and apply-time invocation ledger.
+
+## Confirmed apply
+
+After reviewing the plan, copy both the exact full SHA and the exact lowercase
+`PLAN_STATE_SHA256` printed by that plan. Dispatch the same workflow from that
+unchanged `master` commit with:
+
+- `mode`: `apply`
+- `planned_commit`: `<the exact full SHA copied from the plan>`
+- `planned_state_digest`: `<the exact PLAN_STATE_SHA256 copied from the plan>`
+- `confirm`: `provision-peerbit-production-<full SHA>-<PLAN_STATE_SHA256>`
+
+For the example SHA above, enter exactly:
+
+- `planned_commit`: `0123456789abcdef0123456789abcdef01234567`
+- `planned_state_digest`: `<the 64-character digest printed by the plan>`
+- `confirm`: `provision-peerbit-production-0123456789abcdef0123456789abcdef01234567-<the same 64-character digest>`
+
+Both workflow jobs validate the 40-character commit and 64-character state
+receipt, require the commit to equal checked-out `github.sha`, and bind the
+apply confirmation to both. The provisioning CLI independently repeats those
+checks and recomputes the canonical account-state digest before dispatching any
+mutation. Any Worker tag, active/deployable version, route, domain, public flag,
+schedule, Tail/Logpush setting, or exposed service-binding drift forces a new
+reviewed plan. Artifact-manifest or Queue-consumer drift does the same. A
+mismatch exits nonzero; it is not treated as a skipped deploy.
+
+The workflow rebuilds all seven frontends and assets from the checked-out
+commit, tests the sources, dry-runs every locked Wrangler bundle, and then:
+
+1. Repeats the account-wide policy read before mutation and rejects unknown or
+   retired namespace Workers, any managed traditional route, and every
+   unreviewed Custom Domain attachment. This initial read creates one
+   invocation-wide production ledger: existence, immutable Worker tag, exact
+   active/deployable versions, attachments, and domain state are never silently
+   rebaselined. A
+   Worker missing at that read must remain missing until its own proved upload.
+2. Disables both public flags on every existing allowlisted preview **and
+   production** Worker. It requires exact `enabled: false`,
+   `previews_enabled: false` GET evidence for all of them before the first
+   production deployment mutation. Missing Workers remain missing. Ambiguous
+   responses continue only if that exact GET postcondition is observed.
+3. Rechecks the complete ledger, exact preview identities, zero Cron schedules,
+   zero Tail/Logpush attachments, active service-binding inventory, the exact
+   account-wide Queue-consumer inventory, and global false/false public-URL
+   fence before every upload, activation, and domain attachment and after every
+   mutation. A change to an earlier or unrelated site or Queue stops the
+   invocation; it is never accepted as a new baseline.
+4. Revalidates every artifact manifest immediately before upload, uploads its
+   exact prebuilt module with bundling disabled, and uploads one new route-free
+   version for every site on every apply. Its tag
+   contains a cryptographically random invocation nonce. No inactive version
+   from an earlier or ambiguous attempt is ever reused, even if its annotations
+   look exact. A new Worker/version identity is learned only when structured
+   evidence from this exact Wrangler invocation and a direct exact-version GET
+   agree on Worker tag, version ID, nonce-tag/message, runtime settings
+   (including cache, limits, migrations, placement, and usage model), reviewed
+   bindings, the artifact digest binding, and the version resource fingerprint.
+   For an omitted limits config, only Wrangler's equivalent omitted or plain
+   empty-object response is accepted; any limit field is rejected. Explicitly
+   configured limits must match exactly.
+   It also downloads that exact inactive version through the content API and
+   requires the multipart body to contain exactly the one reviewed ES module,
+   with no auxiliary modules or source maps. The same digest is carried by the
+   version message, same-invocation evidence, plan, and apply ledger.
+5. Allows only the just-uploaded Worker as a narrow public-URL transient, then
+   immediately disables both public flags and restores the global fence before
+   any other mutation.
+6. Activates exactly the tagged version at 100% through the deployments API,
+   then downloads content for that exact version ID again and requires the
+   entrypoint name, MIME type, length, SHA-256, and complete one-module
+   multipart set to match the reviewed artifact.
+7. Attaches exactly one reviewed Custom Domain to each Worker, after all
+   Workers have a verified active baseline. It never creates a traditional
+   route.
+8. Reuses the routine production deployment's strict account-wide attachment
+   policy, verifies the exact served artifact manifest and exhaustively hashes
+   every public live asset (including `release.json`) against it, runs the same
+   file-share relay and media-range browser smokes, then
+   rereads exact Worker identity, version resource fingerprint, domain, route,
+   schedule, Tail/Logpush, service-binding, Queue-consumer, active-module, and
+   subdomain state, including every existing allowlisted preview Worker.
+
+A rerun is deliberately not idempotent at the version-upload layer: after a new
+plan is reviewed, it uploads and proves seven fresh nonce-bound versions. This
+prevents a failed invocation's unproved leftover version from becoming trusted
+on a later run. Existing active versions and quarantined inactive IDs remain in
+the plan state until the fresh versions are proved and promoted. Use the routine
+transactional production workflow after the initial baseline exists.
+
+## Ambiguous responses and recovery
+
+Cloudflare does not expose compare-and-swap preconditions for version uploads,
+deployments, public-subdomain settings, or custom-domain attachment. Every
+post-dispatch transport, HTTP, malformed-body, empty-body, or invalid-evidence
+failure is therefore ambiguous. The script continues only when subsequent
+exact GETs prove the requested version tag, immutable Worker identity, 100%
+deployment, disabled subdomains, or custom-domain owner. Otherwise it stops
+with manual-recovery guidance.
+
+Cloudflare exposes exact script content for a requested version ID, but it does
+not expose an exact-version static-assets manifest that this workflow can
+compare before activation. Consequently, the inactive-version GET proves the
+reviewed runtime, handlers, cache options, bindings, artifact digest, and exact
+one-module script set. The artifact receipt binds every reviewed asset byte and
+static-assets behavior setting, while exact deployed asset-byte and behavior
+proof is necessarily performed through the custom domain after activation. The
+served manifest plus exhaustive path/length/SHA-256, 404, HTML, header, and
+Worker-first range/cache checks detect a wrong asset upload, but detection is
+post-activation. Any exact-version module, served-manifest, or live-asset
+mismatch is therefore an explicit manual-recovery condition: stop, inspect the
+named Worker's active deployment and assets, and do not blindly retry or attach
+further domains.
+
+For an upload that creates a previously missing Worker, GET state alone cannot
+establish that the invocation owns the new identity: another actor could have
+created it concurrently. The script also requires Wrangler's structured upload
+evidence to name the same Worker tag and version. If the upload response is
+lost without that evidence, it never learns or activates the Worker. Before
+stopping, it still targets the independently pinned exact Worker name to disable
+both public URL surfaces, requires a direct false/false GET, and rereads the
+invocation-wide fence without accepting the unproved identity or version. The
+manual-recovery error retains the original upload/proof failure and separately
+reports whether the exact cleanup and global post-cleanup fence were proved.
+The same failure-safe cleanup runs when Wrangler evidence is mismatched or the
+first post-upload account inspection fails.
+
+Do not blindly rerun an apply failure. First dispatch a new read-only plan and
+inspect the named Worker's versions, active deployment, routes, custom domain,
+and public-subdomain settings in Cloudflare. Partial runs intentionally leave
+proved inactive versions or exact active Workers in place; they do not delete
+or roll back resources whose ownership cannot be proved. Once the account
+matches a safe partial state, review its new state digest. The next apply keeps
+old inactive versions quarantined and uploads a fresh version for every site;
+it never resumes by adopting the ambiguous upload.
+
+After all seven sites have passed routine deployments in production, remove
+this one-time workflow in a separately reviewed pull request. Keep this
+runbook as the audit record.
+
+## Separate retired legacy Worker cleanup plan
+
+`peerbit-examples-legacy-stream-preview` is not part of the deployment policy
+and has no users. Provisioning deliberately does **not** delete it. Its presence
+blocks the plan so an unexpected namespace resource cannot be silently
+accepted.
+
+Cleanup is a separate, explicitly approved operation:
+
+1. Record approval using the exact phrase
+   `delete-peerbit-examples-legacy-stream-preview` outside the provisioning
+   workflow.
+2. Read the account Worker inventory and prove the identity is exactly
+   `peerbit-examples-legacy-stream-preview`. Confirm it is absent from
+   `cloudflare/deployment-policy.json` and `cloudflare/sites.json`.
+3. Prove it has no traditional routes, no Custom Domains, and no expected
+   `*.apps.peerbit.org` hostname. Read its public-subdomain state and require
+   both `enabled` and `previews_enabled` to be false. If either is true,
+   explicitly disable only that Worker's public subdomains under the same
+   cleanup approval and prove the exact false/false GET postcondition before
+   continuing. If any attachment or consumer exists, stop and review a
+   separate detachment/migration; do not broaden the deletion.
+4. Delete only that exact Worker in the Cloudflare dashboard or with the
+   [documented exact-script DELETE API](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/methods/delete/).
+   Do not use `force=true`, a prefix, loop, or wildcard; an attachment or
+   binding refusal is a reason to stop, not something to override.
+5. Read the full Worker and custom-domain inventories again, confirm only that
+   exact identity disappeared, then rerun the read-only provisioning plan.
+
+The production provisioning script contains no Worker-delete operation, so
+the cleanup cannot be triggered accidentally by either `plan` or `apply`.

--- a/cloudflare/production-provisioning.test.mjs
+++ b/cloudflare/production-provisioning.test.mjs
@@ -1,0 +1,3393 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import { loadCloudflareDeploymentData } from "../scripts/cloudflare-deployment-policy.mjs";
+import {
+    CloudflareWorkersApiError,
+    createCloudflareWorkersApi,
+} from "../scripts/cloudflare-workers-api.mjs";
+import {
+    PROVISIONING_CONFIRMATION_PREFIXES,
+    PROVISIONING_PLAN_STATE_SENTINEL,
+    createProvisioningVersionTag,
+    inspectProductionProvisioning,
+    parseProductionProvisioningArgs,
+    productionProvisioningConfirmation,
+    provisionProductionEntries as runProvisionProductionEntriesWithReceipt,
+} from "../scripts/provision-cloudflare-production.mjs";
+import {
+    CLOUDFLARE_ARTIFACT_DIGEST_BINDING,
+    artifactBoundVersionMessage,
+} from "../scripts/cloudflare-artifact-manifest.mjs";
+
+const COMMIT = "a".repeat(40);
+const OTHER_COMMIT = "b".repeat(40);
+const ACCOUNT_ID = "c".repeat(32);
+const ZONE_ID = "d".repeat(32);
+const API_TOKEN = "cloudflare-test-token";
+const LEGACY_NONCE = "1".repeat(32);
+const PLAN_DIGEST = "2".repeat(64);
+const clone = (value) => structuredClone(value);
+const { entries } = loadCloudflareDeploymentData();
+const artifactDigestFor = (siteId) =>
+    createHash("sha256").update(`artifact:${siteId}`).digest("hex");
+const artifacts = new Map(
+    entries.map(({ site, policy }) => {
+        const sha256 = createHash("sha256")
+            .update(`module:${site.id}`)
+            .digest("hex");
+        return [
+            site.id,
+            {
+                siteId: site.id,
+                workerName: policy.productionWorker,
+                commit: COMMIT,
+                digest: artifactDigestFor(site.id),
+                manifest: {
+                    module: {
+                        path: "module.js",
+                        contentType: "application/javascript+module",
+                        size: site.id.length,
+                        sha256,
+                    },
+                },
+            },
+        ];
+    })
+);
+const configs = new Map(
+    entries.map(({ site, policy }) => [
+        site.id,
+        {
+            file: `/reviewed/${site.id}.json`,
+            config: {
+                name: policy.productionWorker,
+                workers_dev: false,
+                preview_urls: false,
+                ...(site.id === "stream"
+                    ? {
+                          cache: {
+                              enabled: true,
+                              cross_version_cache: false,
+                          },
+                      }
+                    : {}),
+                routes: policy.productionHostnames.map((hostname) => ({
+                    pattern: hostname,
+                    custom_domain: true,
+                })),
+            },
+        },
+    ])
+);
+
+const provisionProductionEntriesWithReceipt = (input) =>
+    runProvisionProductionEntriesWithReceipt({
+        accountId: ACCOUNT_ID,
+        artifacts,
+        ...input,
+    });
+
+const provisionProductionEntries = async (input) => {
+    if (input.mode !== "apply" || input.plannedStateDigest != null) {
+        return provisionProductionEntriesWithReceipt(input);
+    }
+    const reviewed = await provisionProductionEntriesWithReceipt({
+        ...input,
+        mode: "plan",
+        log: () => {},
+    });
+    return provisionProductionEntriesWithReceipt({
+        ...input,
+        plannedStateDigest: reviewed.stateDigest,
+    });
+};
+
+const versionIdFor = (index) => {
+    const part = String(index + 1).padStart(8, "0");
+    return `${part}-1111-4111-8111-${String(index + 1).padStart(12, "0")}`;
+};
+
+const expectedMessage = (siteId, commit = COMMIT) =>
+    artifactBoundVersionMessage({
+        siteId,
+        expectedCommit: commit,
+        artifactManifestDigest: artifactDigestFor(siteId),
+    });
+
+const versionCacheOptions = (siteId) =>
+    siteId === "stream"
+        ? { enabled: true, cross_version_cache: false }
+        : undefined;
+
+const versionResources = (siteId, suffix = "baseline") => ({
+    bindings: [
+        {
+            name: CLOUDFLARE_ARTIFACT_DIGEST_BINDING,
+            type: "plain_text",
+            text: artifactDigestFor(siteId),
+        },
+    ],
+    script: {
+        etag: `etag-${siteId}-${suffix}`,
+        handlers: ["fetch"],
+        named_handlers: [],
+    },
+    script_runtime: {
+        compatibility_flags: [],
+        limits: {},
+        usage_model: "standard",
+    },
+});
+
+const createHarness = () => {
+    const scripts = new Map();
+    const domains = [];
+    const subdomains = new Map();
+    const deployments = new Map();
+    const versions = new Map();
+    const queueConsumerInventory = [];
+    const calls = [];
+    let uploadGeneration = 0;
+
+    const entryForWorker = (workerName) =>
+        entries.find(({ policy }) => policy.productionWorker === workerName);
+    const versionsFor = (workerName) => {
+        let workerVersions = versions.get(workerName);
+        if (!workerVersions) {
+            workerVersions = new Map();
+            versions.set(workerName, workerVersions);
+        }
+        return workerVersions;
+    };
+    const addWorker = ({
+        entry,
+        enabled = false,
+        previewsEnabled = false,
+        workerTag = `worker-tag-${entry.site.id}`,
+    }) => {
+        scripts.set(entry.policy.productionWorker, {
+            tag: workerTag,
+            routes: [],
+            tailConsumers: [],
+            logpush: false,
+        });
+        subdomains.set(entry.policy.productionWorker, {
+            enabled,
+            previewsEnabled,
+        });
+        deployments.set(entry.policy.productionWorker, []);
+        versionsFor(entry.policy.productionWorker);
+        return workerTag;
+    };
+    const addPreview = ({
+        entry,
+        enabled = false,
+        previewsEnabled = false,
+        workerTag = `preview-worker-tag-${entry.site.id}`,
+        routes = [],
+    }) => {
+        scripts.set(entry.policy.previewWorker, {
+            tag: workerTag,
+            routes: clone(routes),
+            tailConsumers: [],
+            logpush: false,
+        });
+        subdomains.set(entry.policy.previewWorker, {
+            enabled,
+            previewsEnabled,
+        });
+        return workerTag;
+    };
+    const addExactVersion = ({ entry, active = false, commit = COMMIT }) => {
+        if (!scripts.has(entry.policy.productionWorker)) addWorker({ entry });
+        const index = entries.findIndex(
+            ({ site }) => site.id === entry.site.id
+        );
+        const versionId = versionIdFor(index);
+        versionsFor(entry.policy.productionWorker).set(versionId, {
+            id: versionId,
+            annotations: {
+                "workers/tag": createProvisioningVersionTag({
+                    siteId: entry.site.id,
+                    expectedCommit: commit,
+                    invocationNonce: LEGACY_NONCE,
+                }),
+                "workers/message": expectedMessage(entry.site.id, commit),
+            },
+            resources: versionResources(entry.site.id),
+            ...(versionCacheOptions(entry.site.id)
+                ? { cache_options: versionCacheOptions(entry.site.id) }
+                : {}),
+        });
+        if (active) {
+            deployments.set(entry.policy.productionWorker, [
+                {
+                    versions: [{ version_id: versionId, percentage: 100 }],
+                },
+            ]);
+        }
+        return versionId;
+    };
+    const attachExactDomain = (entry) => {
+        domains.push({
+            id: `domain-${entry.site.id}`,
+            hostname: entry.policy.productionHostnames[0],
+            service: entry.policy.productionWorker,
+            environment: "production",
+            zoneId: ZONE_ID,
+            zoneName: "peerbit.org",
+        });
+    };
+    const seedExact = ({
+        entry,
+        active = true,
+        domain = active,
+        enabled = false,
+        previewsEnabled = false,
+    }) => {
+        addWorker({ entry, enabled, previewsEnabled });
+        const versionId = addExactVersion({ entry, active });
+        if (domain) attachExactDomain(entry);
+        return versionId;
+    };
+
+    const operations = {
+        listWorkerScripts: async () => {
+            calls.push(["list-scripts"]);
+            return new Map(
+                [...scripts].map(([name, metadata]) => [name, clone(metadata)])
+            );
+        },
+        listWorkerDomains: async () => {
+            calls.push(["list-domains"]);
+            return clone(domains);
+        },
+        getWorkerSubdomain: async (workerName) => {
+            calls.push(["get-subdomain", workerName]);
+            const state = subdomains.get(workerName);
+            if (!state) throw new Error("missing Worker subdomain state");
+            return clone(state);
+        },
+        listWorkerSchedules: async (workerName) => {
+            calls.push(["list-schedules", workerName]);
+            return [];
+        },
+        listQueueConsumerInventory: async () => {
+            calls.push(["list-queue-consumers"]);
+            return clone(queueConsumerInventory);
+        },
+        getWorkerDeployments: async (workerName) => {
+            calls.push(["get-deployments", workerName]);
+            return clone(deployments.get(workerName) ?? []);
+        },
+        listDeployableWorkerVersions: async (workerName) => {
+            calls.push(["list-versions", workerName]);
+            return [...(versions.get(workerName)?.keys() ?? [])];
+        },
+        getWorkerVersion: async (workerName, versionId) => {
+            calls.push(["get-version", workerName, versionId]);
+            const version = versions.get(workerName)?.get(versionId);
+            if (!version) throw new Error("missing Worker version");
+            return clone(version);
+        },
+        getWorkerVersionModule: async (workerName, versionId) => {
+            calls.push(["get-version-module", workerName, versionId]);
+            const entry = entryForWorker(workerName);
+            assert.ok(entry);
+            const module = artifacts.get(entry.site.id).manifest.module;
+            return {
+                name: "module.js",
+                contentType: "application/javascript+module",
+                size: module.size,
+                sha256: module.sha256,
+            };
+        },
+        upload: async ({
+            site,
+            policy,
+            expectedCommit,
+            versionTag,
+            artifact,
+        }) => {
+            calls.push(["upload", site.id]);
+            const workerTag =
+                scripts.get(policy.productionWorker)?.tag ??
+                addWorker({
+                    entry: { site, policy },
+                    enabled: true,
+                    previewsEnabled: true,
+                });
+            const index = entries.findIndex(
+                ({ site: value }) => value.id === site.id
+            );
+            uploadGeneration += 1;
+            const versionId = versionIdFor(
+                index + entries.length * uploadGeneration
+            );
+            versionsFor(policy.productionWorker).set(versionId, {
+                id: versionId,
+                annotations: {
+                    "workers/tag": versionTag,
+                    "workers/message": expectedMessage(site.id, expectedCommit),
+                },
+                resources: versionResources(site.id, versionTag),
+                ...(versionCacheOptions(site.id)
+                    ? { cache_options: versionCacheOptions(site.id) }
+                    : {}),
+            });
+            return {
+                workerName: policy.productionWorker,
+                workerTag,
+                versionId,
+                artifactManifestDigest: artifact.digest,
+            };
+        },
+        disableWorkerSubdomain: async (workerName) => {
+            calls.push(["disable-subdomain", workerName]);
+            subdomains.set(workerName, {
+                enabled: false,
+                previewsEnabled: false,
+            });
+            return clone(subdomains.get(workerName));
+        },
+        activate: async ({ workerName, versionId }) => {
+            calls.push(["activate", workerName, versionId]);
+            deployments.set(workerName, [
+                {
+                    versions: [{ version_id: versionId, percentage: 100 }],
+                },
+            ]);
+            return clone(deployments.get(workerName)[0]);
+        },
+        attachDomain: async ({ workerName, hostname }) => {
+            calls.push(["attach-domain", workerName, hostname]);
+            const entry = entryForWorker(workerName);
+            assert.ok(entry);
+            const attachment = {
+                id: `domain-${entry.site.id}`,
+                hostname,
+                service: workerName,
+                environment: "production",
+                zoneId: ZONE_ID,
+                zoneName: "peerbit.org",
+            };
+            domains.push(attachment);
+            return clone(attachment);
+        },
+        verify: async ({ site, expectedCommit }) => {
+            calls.push(["verify", site.id, expectedCommit]);
+        },
+    };
+    return {
+        scripts,
+        domains,
+        subdomains,
+        deployments,
+        versions,
+        queueConsumerInventory,
+        calls,
+        operations,
+        addWorker,
+        addPreview,
+        addExactVersion,
+        attachExactDomain,
+        seedExact,
+    };
+};
+
+const mutationCalls = (calls) =>
+    calls.filter(([name]) =>
+        ["upload", "disable-subdomain", "activate", "attach-domain"].includes(
+            name
+        )
+    );
+
+test("provisioning CLI requires mode-specific explicit confirmation", () => {
+    const planConfirmation = productionProvisioningConfirmation({
+        mode: "plan",
+        plannedCommit: COMMIT,
+    });
+    const applyConfirmation = productionProvisioningConfirmation({
+        mode: "apply",
+        plannedCommit: COMMIT,
+        plannedStateDigest: PLAN_DIGEST,
+    });
+    assert.deepEqual(
+        parseProductionProvisioningArgs([
+            "--mode",
+            "plan",
+            "--commit",
+            COMMIT,
+            "--planned-commit",
+            COMMIT,
+            "--planned-state-digest",
+            PROVISIONING_PLAN_STATE_SENTINEL,
+            "--confirm",
+            planConfirmation,
+        ]),
+        {
+            mode: "plan",
+            expectedCommit: COMMIT,
+            plannedCommit: COMMIT,
+            plannedStateDigest: PROVISIONING_PLAN_STATE_SENTINEL,
+        }
+    );
+    assert.deepEqual(
+        parseProductionProvisioningArgs([
+            "--confirm",
+            applyConfirmation,
+            "--mode",
+            "apply",
+            "--commit",
+            COMMIT,
+            "--planned-commit",
+            COMMIT,
+            "--planned-state-digest",
+            PLAN_DIGEST,
+        ]),
+        {
+            mode: "apply",
+            expectedCommit: COMMIT,
+            plannedCommit: COMMIT,
+            plannedStateDigest: PLAN_DIGEST,
+        }
+    );
+    for (const [name, argv, pattern] of [
+        [
+            "missing receipt",
+            [
+                "--mode",
+                "apply",
+                "--commit",
+                COMMIT,
+                "--confirm",
+                applyConfirmation,
+            ],
+            /Usage/,
+        ],
+        [
+            "short receipt",
+            [
+                "--mode",
+                "apply",
+                "--commit",
+                COMMIT,
+                "--planned-commit",
+                COMMIT.slice(0, 12),
+                "--planned-state-digest",
+                PLAN_DIGEST,
+                "--confirm",
+                applyConfirmation,
+            ],
+            /full planned commit receipt/,
+        ],
+        [
+            "different receipt",
+            [
+                "--mode",
+                "apply",
+                "--commit",
+                COMMIT,
+                "--planned-commit",
+                OTHER_COMMIT,
+                "--planned-state-digest",
+                PLAN_DIGEST,
+                "--confirm",
+                productionProvisioningConfirmation({
+                    mode: "apply",
+                    plannedCommit: OTHER_COMMIT,
+                    plannedStateDigest: PLAN_DIGEST,
+                }),
+            ],
+            /must equal the checked-out commit/,
+        ],
+        [
+            "generic confirmation",
+            [
+                "--mode",
+                "apply",
+                "--commit",
+                COMMIT,
+                "--planned-commit",
+                COMMIT,
+                "--planned-state-digest",
+                PLAN_DIGEST,
+                "--confirm",
+                PROVISIONING_CONFIRMATION_PREFIXES.apply,
+            ],
+            /SHA-bound confirmation phrase/,
+        ],
+        [
+            "confirmation for another SHA",
+            [
+                "--mode",
+                "plan",
+                "--commit",
+                COMMIT,
+                "--planned-commit",
+                COMMIT,
+                "--planned-state-digest",
+                PROVISIONING_PLAN_STATE_SENTINEL,
+                "--confirm",
+                productionProvisioningConfirmation({
+                    mode: "plan",
+                    plannedCommit: OTHER_COMMIT,
+                }),
+            ],
+            /SHA-bound confirmation phrase/,
+        ],
+    ]) {
+        assert.throws(
+            () => parseProductionProvisioningArgs(argv),
+            pattern,
+            name
+        );
+    }
+});
+
+test("read-only plan proposes all seven exact targets without mutations", async () => {
+    const harness = createHarness();
+    const logs = [];
+    const plan = await provisionProductionEntries({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "plan",
+        operations: harness.operations,
+        log: (line) => logs.push(line),
+    });
+    assert.equal(plan.length, 7);
+    assert.deepEqual(
+        plan.map(({ site, worker, hostname }) => [site, worker, hostname]),
+        entries.map(({ site, policy }) => [
+            site.id,
+            policy.productionWorker,
+            policy.productionHostnames[0],
+        ])
+    );
+    assert.ok(
+        plan.every(({ actions }) =>
+            actions.includes("attach-reviewed-custom-domain")
+        )
+    );
+    assert.deepEqual(
+        plan.map(({ previewWorker, previewExists, previewActions }) => [
+            previewWorker,
+            previewExists,
+            previewActions,
+        ]),
+        entries.map(({ policy }) => [policy.previewWorker, false, []])
+    );
+    assert.equal(
+        harness.calls.some(
+            ([name, worker]) =>
+                ["get-subdomain", "disable-subdomain"].includes(name) &&
+                entries.some(({ policy }) => policy.previewWorker === worker)
+        ),
+        false
+    );
+    assert.deepEqual(mutationCalls(harness.calls), []);
+    assert.match(logs.at(-1), /no Cloudflare mutations were dispatched/);
+});
+
+test("preview planning derives exact policy identities and handles every public flag combination", async () => {
+    const harness = createHarness();
+    const states = [
+        { enabled: true, previewsEnabled: false },
+        { enabled: false, previewsEnabled: true },
+        { enabled: true, previewsEnabled: true },
+        { enabled: false, previewsEnabled: false },
+    ];
+    states.forEach((state, index) =>
+        harness.addPreview({ entry: entries[index], ...state })
+    );
+
+    const plan = await provisionProductionEntries({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "plan",
+        operations: harness.operations,
+        log: () => {},
+    });
+    assert.deepEqual(
+        plan.map(({ previewWorker, previewExists, previewActions }) => [
+            previewWorker,
+            previewExists,
+            previewActions,
+        ]),
+        entries.map(({ policy }, index) => [
+            policy.previewWorker,
+            index < states.length,
+            index < 3 ? ["disable-public-subdomains"] : [],
+        ])
+    );
+    assert.deepEqual(mutationCalls(harness.calls), []);
+
+    harness.calls.length = 0;
+    await provisionProductionEntries({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "apply",
+        operations: harness.operations,
+        log: () => {},
+    });
+    const previewWorkers = new Set(
+        entries.map(({ policy }) => policy.previewWorker)
+    );
+    assert.deepEqual(
+        harness.calls
+            .filter(
+                ([name, worker]) =>
+                    name === "disable-subdomain" && previewWorkers.has(worker)
+            )
+            .map(([, worker]) => worker),
+        entries.slice(0, 3).map(({ policy }) => policy.previewWorker)
+    );
+    for (const entry of entries.slice(0, states.length)) {
+        assert.deepEqual(harness.subdomains.get(entry.policy.previewWorker), {
+            enabled: false,
+            previewsEnabled: false,
+        });
+    }
+    for (const entry of entries.slice(states.length)) {
+        assert.equal(harness.scripts.has(entry.policy.previewWorker), false);
+        assert.equal(
+            harness.calls.some(
+                ([name, worker]) =>
+                    name === "disable-subdomain" &&
+                    worker === entry.policy.previewWorker
+            ),
+            false
+        );
+    }
+});
+
+test("all preview disable GET postconditions precede the first production mutation", async () => {
+    const harness = createHarness();
+    for (const entry of entries) {
+        harness.addPreview({
+            entry,
+            enabled: true,
+            previewsEnabled: true,
+        });
+    }
+    await provisionProductionEntries({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "apply",
+        operations: harness.operations,
+        log: () => {},
+    });
+
+    const productionWorkers = new Set(
+        entries.map(({ policy }) => policy.productionWorker)
+    );
+    const firstProductionMutation = harness.calls.findIndex(
+        ([name, worker]) =>
+            ["upload", "activate", "attach-domain"].includes(name) ||
+            (name === "disable-subdomain" && productionWorkers.has(worker))
+    );
+    assert.ok(firstProductionMutation >= 0);
+    for (const { policy } of entries) {
+        const disabledAt = harness.calls.findIndex(
+            ([name, worker]) =>
+                name === "disable-subdomain" && worker === policy.previewWorker
+        );
+        assert.ok(disabledAt >= 0 && disabledAt < firstProductionMutation);
+        const provedAt = harness.calls.findIndex(
+            ([name, worker], index) =>
+                index > disabledAt &&
+                name === "get-subdomain" &&
+                worker === policy.previewWorker
+        );
+        assert.ok(provedAt > disabledAt && provedAt < firstProductionMutation);
+        assert.deepEqual(harness.subdomains.get(policy.previewWorker), {
+            enabled: false,
+            previewsEnabled: false,
+        });
+    }
+});
+
+test("all existing production public URLs are disabled and proved before the first upload", async () => {
+    const harness = createHarness();
+    const states = [
+        { enabled: true, previewsEnabled: false },
+        { enabled: false, previewsEnabled: true },
+        { enabled: true, previewsEnabled: true },
+    ];
+    states.forEach((state, index) =>
+        harness.seedExact({ entry: entries[index], ...state })
+    );
+
+    await provisionProductionEntries({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "apply",
+        operations: harness.operations,
+        log: () => {},
+    });
+    const firstUpload = harness.calls.findIndex(([name]) => name === "upload");
+    assert.ok(firstUpload >= 0);
+    for (const entry of entries.slice(0, states.length)) {
+        const worker = entry.policy.productionWorker;
+        const disabledAt = harness.calls.findIndex(
+            ([name, identity]) =>
+                name === "disable-subdomain" && identity === worker
+        );
+        const provedAt = harness.calls.findIndex(
+            ([name, identity], index) =>
+                index > disabledAt &&
+                name === "get-subdomain" &&
+                identity === worker
+        );
+        assert.ok(disabledAt >= 0 && disabledAt < firstUpload);
+        assert.ok(provedAt > disabledAt && provedAt < firstUpload);
+        assert.deepEqual(harness.subdomains.get(worker), {
+            enabled: false,
+            previewsEnabled: false,
+        });
+    }
+});
+
+test("provisioning rejects a rendered config that could publish a preview URL", async () => {
+    const harness = createHarness();
+    const unsafeConfigs = clone(configs);
+    unsafeConfigs.get("stream").config.preview_urls = true;
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs: unsafeConfigs,
+            expectedCommit: COMMIT,
+            mode: "plan",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /preview_urls must be disabled/
+    );
+    assert.deepEqual(harness.calls, []);
+});
+
+test("preview identities are independently pinned before every account read", async (t) => {
+    for (const [name, entryIndex, substitute] of [
+        ["duplicate", 1, entries[0].policy.previewWorker],
+        ["unreviewed", 1, "peerbit-examples-music-shadow-preview"],
+        ["retired legacy", 0, "peerbit-examples-legacy-stream-preview"],
+    ]) {
+        await t.test(name, async () => {
+            const harness = createHarness();
+            const invalidEntries = clone(entries);
+            invalidEntries[entryIndex].policy.previewWorker = substitute;
+            await assert.rejects(
+                inspectProductionProvisioning({
+                    entries: invalidEntries,
+                    configs,
+                    artifacts,
+                    expectedCommit: COMMIT,
+                    operations: harness.operations,
+                }),
+                /reviewed seven-application allowlist/
+            );
+            assert.deepEqual(harness.calls, []);
+        });
+    }
+});
+
+test("every confirmed apply uploads and activates seven fresh nonce-bound versions", async () => {
+    const harness = createHarness();
+    await provisionProductionEntries({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "apply",
+        operations: harness.operations,
+        log: () => {},
+    });
+    assert.equal(harness.calls.filter(([name]) => name === "upload").length, 7);
+    assert.equal(
+        harness.calls.filter(([name]) => name === "disable-subdomain").length,
+        7
+    );
+    assert.equal(
+        harness.calls.filter(([name]) => name === "activate").length,
+        7
+    );
+    assert.equal(
+        harness.calls.filter(([name]) => name === "attach-domain").length,
+        7
+    );
+    assert.equal(harness.calls.filter(([name]) => name === "verify").length, 7);
+    for (const { policy } of entries) {
+        assert.deepEqual(harness.subdomains.get(policy.productionWorker), {
+            enabled: false,
+            previewsEnabled: false,
+        });
+        assert.equal(harness.scripts.has(policy.previewWorker), false);
+        assert.equal(
+            harness.calls.some(
+                ([name, worker]) =>
+                    name === "disable-subdomain" &&
+                    worker === policy.previewWorker
+            ),
+            false
+        );
+        assert.equal(
+            harness.deployments.get(policy.productionWorker)[0].versions[0]
+                .percentage,
+            100
+        );
+    }
+
+    harness.calls.length = 0;
+    await provisionProductionEntries({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "apply",
+        operations: harness.operations,
+        log: () => {},
+    });
+    assert.equal(harness.calls.filter(([name]) => name === "upload").length, 7);
+    assert.equal(
+        harness.calls.filter(([name]) => name === "activate").length,
+        7
+    );
+    assert.equal(
+        harness.calls.filter(([name]) => name === "attach-domain").length,
+        0
+    );
+    assert.equal(harness.calls.filter(([name]) => name === "verify").length, 7);
+});
+
+test("partial state quarantines old versions and uploads seven fresh versions", async () => {
+    const harness = createHarness();
+    const partial = entries[0];
+    harness.addWorker({
+        entry: partial,
+        enabled: true,
+        previewsEnabled: true,
+    });
+    harness.addExactVersion({ entry: partial, active: false });
+    for (const entry of entries.slice(1)) harness.seedExact({ entry });
+
+    await provisionProductionEntries({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "apply",
+        operations: harness.operations,
+        log: () => {},
+    });
+    assert.deepEqual(
+        harness.calls
+            .filter(([name]) => name === "upload")
+            .map(([, site]) => site),
+        entries.map(({ site }) => site.id)
+    );
+    assert.deepEqual(
+        harness.calls
+            .filter(([name]) => name === "activate")
+            .map(([, worker]) => worker),
+        entries.map(({ policy }) => policy.productionWorker)
+    );
+    assert.deepEqual(
+        harness.calls
+            .filter(([name]) => name === "attach-domain")
+            .map(([, worker]) => worker),
+        [partial.policy.productionWorker]
+    );
+});
+
+test("apply requires the exact canonical state digest from a reviewed plan", async () => {
+    const harness = createHarness();
+    const reviewed = await provisionProductionEntriesWithReceipt({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "plan",
+        operations: harness.operations,
+        log: () => {},
+    });
+    assert.match(reviewed.stateDigest, /^[0-9a-f]{64}$/);
+    await assert.rejects(
+        provisionProductionEntriesWithReceipt({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /requires the exact state digest/
+    );
+    await assert.rejects(
+        provisionProductionEntriesWithReceipt({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            accountId: "e".repeat(32),
+            mode: "apply",
+            plannedStateDigest: reviewed.stateDigest,
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /state changed after review/
+    );
+    harness.addWorker({ entry: entries[0] });
+    await assert.rejects(
+        provisionProductionEntriesWithReceipt({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            plannedStateDigest: reviewed.stateDigest,
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /state changed after review/
+    );
+    assert.deepEqual(mutationCalls(harness.calls), []);
+});
+
+test("reviewed state receipts bind every pre-credential artifact digest", async () => {
+    const harness = createHarness();
+    const reviewed = await provisionProductionEntriesWithReceipt({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "plan",
+        operations: harness.operations,
+        log: () => {},
+    });
+    const changedArtifacts = new Map(artifacts);
+    changedArtifacts.set("stream", {
+        ...changedArtifacts.get("stream"),
+        digest: createHash("sha256")
+            .update("different reviewed stream artifact")
+            .digest("hex"),
+    });
+    await assert.rejects(
+        provisionProductionEntriesWithReceipt({
+            entries,
+            configs,
+            artifacts: changedArtifacts,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            plannedStateDigest: reviewed.stateDigest,
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /state changed after review/
+    );
+    assert.deepEqual(mutationCalls(harness.calls), []);
+});
+
+test("reviewed state receipts bind tags, versions, domains, and public flags", async (t) => {
+    for (const [name, arrange, drift] of [
+        [
+            "immutable Worker tag",
+            (harness) => harness.addWorker({ entry: entries[0] }),
+            (harness) => {
+                harness.scripts.get(entries[0].policy.productionWorker).tag =
+                    "replacement-worker-tag";
+            },
+        ],
+        [
+            "deployable version inventory",
+            (harness) => harness.seedExact({ entry: entries[0] }),
+            (harness) => {
+                const versionId = versionIdFor(600);
+                harness.versions
+                    .get(entries[0].policy.productionWorker)
+                    .set(versionId, {
+                        id: versionId,
+                        annotations: {},
+                        resources: versionResources("forged"),
+                    });
+            },
+        ],
+        [
+            "custom domain",
+            (harness) => harness.seedExact({ entry: entries[0] }),
+            (harness) => harness.domains.splice(0),
+        ],
+        [
+            "public subdomain flags",
+            (harness) => harness.addPreview({ entry: entries[0] }),
+            (harness) =>
+                harness.subdomains.set(entries[0].policy.previewWorker, {
+                    enabled: true,
+                    previewsEnabled: false,
+                }),
+        ],
+        [
+            "account Queue consumer inventory",
+            (harness) =>
+                harness.queueConsumerInventory.push({
+                    queueId: "queue-a",
+                    queueName: "first-queue",
+                    consumers: [],
+                }),
+            (harness) =>
+                harness.queueConsumerInventory[0].consumers.push({
+                    consumerId: "consumer-a",
+                    type: "http_pull",
+                    scriptName: null,
+                    queueName: "first-queue",
+                    deadLetterQueue: "",
+                    settings: {},
+                }),
+        ],
+    ]) {
+        await t.test(name, async () => {
+            const harness = createHarness();
+            arrange(harness);
+            const reviewed = await provisionProductionEntriesWithReceipt({
+                entries,
+                configs,
+                expectedCommit: COMMIT,
+                mode: "plan",
+                operations: harness.operations,
+                log: () => {},
+            });
+            drift(harness);
+            await assert.rejects(
+                provisionProductionEntriesWithReceipt({
+                    entries,
+                    configs,
+                    expectedCommit: COMMIT,
+                    mode: "apply",
+                    plannedStateDigest: reviewed.stateDigest,
+                    operations: harness.operations,
+                    log: () => {},
+                }),
+                /state changed after review/
+            );
+            assert.deepEqual(mutationCalls(harness.calls), []);
+        });
+    }
+});
+
+test("tail consumers, Logpush, and Cron schedules all block before mutation", async (t) => {
+    for (const [name, mutate, pattern] of [
+        [
+            "tail consumer",
+            (harness) => {
+                harness.addWorker({ entry: entries[0] });
+                harness.scripts
+                    .get(entries[0].policy.productionWorker)
+                    .tailConsumers.push({ service: "tail-worker" });
+            },
+            /Tail Worker consumers or Logpush/,
+        ],
+        [
+            "Logpush",
+            (harness) => {
+                harness.addWorker({ entry: entries[0] });
+                harness.scripts.get(
+                    entries[0].policy.productionWorker
+                ).logpush = true;
+            },
+            /Tail Worker consumers or Logpush/,
+        ],
+        [
+            "Cron Trigger",
+            (harness) => {
+                harness.addWorker({ entry: entries[0] });
+                const original = harness.operations.listWorkerSchedules;
+                harness.operations.listWorkerSchedules = async (workerName) =>
+                    workerName === entries[0].policy.productionWorker
+                        ? ["* * * * *"]
+                        : original(workerName);
+            },
+            /Cron Trigger schedules must be empty/,
+        ],
+        [
+            "inbound service binding",
+            (harness) => {
+                const workerName = "unrelated-account-worker";
+                const versionId = versionIdFor(500);
+                harness.scripts.set(workerName, {
+                    tag: "unrelated-tag",
+                    routes: [],
+                    tailConsumers: [],
+                    logpush: false,
+                });
+                harness.deployments.set(workerName, [
+                    {
+                        versions: [{ version_id: versionId, percentage: 100 }],
+                    },
+                ]);
+                harness.versions.set(
+                    workerName,
+                    new Map([
+                        [
+                            versionId,
+                            {
+                                id: versionId,
+                                resources: {
+                                    ...versionResources("unrelated"),
+                                    bindings: [
+                                        {
+                                            name: "TARGET",
+                                            type: "service",
+                                            service:
+                                                entries[0].policy
+                                                    .productionWorker,
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    ])
+                );
+            },
+            /unreviewed inbound attachment/,
+        ],
+        [
+            "managed queue binding",
+            (harness) => {
+                const entry = entries[0];
+                const versionId = harness.seedExact({ entry });
+                harness.versions
+                    .get(entry.policy.productionWorker)
+                    .get(versionId)
+                    .resources.bindings.push({
+                        name: "QUEUE",
+                        type: "queue",
+                        queue_name: "unreviewed",
+                    });
+            },
+            /unreviewed queue or service binding/,
+        ],
+        [
+            "managed queue handler",
+            (harness) => {
+                const entry = entries[0];
+                const versionId = harness.seedExact({ entry });
+                harness.versions
+                    .get(entry.policy.productionWorker)
+                    .get(versionId).resources.script.handlers = ["queue"];
+            },
+            /unreviewed queue, scheduled, email, tail, or other event handler/,
+        ],
+    ]) {
+        await t.test(name, async () => {
+            const harness = createHarness();
+            mutate(harness);
+            await assert.rejects(
+                provisionProductionEntriesWithReceipt({
+                    entries,
+                    configs,
+                    expectedCommit: COMMIT,
+                    mode: "plan",
+                    operations: harness.operations,
+                    log: () => {},
+                }),
+                pattern
+            );
+            assert.deepEqual(mutationCalls(harness.calls), []);
+        });
+    }
+});
+
+test("separate Queue consumer attachments to production or preview Workers block before mutation", async (t) => {
+    for (const [name, scriptName] of [
+        ["production Worker", entries[0].policy.productionWorker],
+        ["preview Worker", entries[0].policy.previewWorker],
+    ]) {
+        await t.test(name, async () => {
+            const harness = createHarness();
+            harness.queueConsumerInventory.push({
+                queueId: "queue-a",
+                queueName: "first-queue",
+                consumers: [
+                    {
+                        consumerId: "consumer-a",
+                        type: "worker",
+                        scriptName,
+                        queueName: "first-queue",
+                        deadLetterQueue: "",
+                        settings: {},
+                    },
+                ],
+            });
+            await assert.rejects(
+                provisionProductionEntriesWithReceipt({
+                    entries,
+                    configs,
+                    expectedCommit: COMMIT,
+                    mode: "plan",
+                    operations: harness.operations,
+                    log: () => {},
+                }),
+                /unreviewed Cloudflare Queue consumer attachment/
+            );
+            assert.deepEqual(mutationCalls(harness.calls), []);
+        });
+    }
+});
+
+test("forged uploaded resources and bindings cannot authorize activation", async (t) => {
+    for (const [name, mutate, targetSiteId = "stream"] of [
+        [
+            "unexpected cache options",
+            (version) =>
+                (version.cache_options = {
+                    enabled: true,
+                    cross_version_cache: false,
+                }),
+            "music",
+        ],
+        [
+            "missing reviewed cache options",
+            (version) => delete version.cache_options,
+        ],
+        [
+            "cross-version cache enabled",
+            (version) => (version.cache_options.cross_version_cache = true),
+        ],
+        [
+            "unreviewed nonempty resource limits",
+            (version) =>
+                (version.resources.script_runtime.limits = { cpu_ms: 50 }),
+        ],
+        [
+            "unknown resource limit",
+            (version) =>
+                (version.resources.script_runtime.limits = {
+                    future_limit: 1,
+                }),
+        ],
+        [
+            "null resource limits",
+            (version) => (version.resources.script_runtime.limits = null),
+        ],
+        [
+            "array resource limits",
+            (version) => (version.resources.script_runtime.limits = []),
+        ],
+        [
+            "non-plain resource limits",
+            (version) =>
+                (version.resources.script_runtime.limits = new Date(0)),
+        ],
+        [
+            "unreviewed Durable Object migration",
+            (version) =>
+                (version.resources.script_runtime.migration_tag = "v1"),
+        ],
+        [
+            "unreviewed placement",
+            (version) =>
+                (version.resources.script.placement = { mode: "smart" }),
+        ],
+        [
+            "unreviewed usage model",
+            (version) =>
+                (version.resources.script_runtime.usage_model = "unbound"),
+        ],
+        [
+            "unknown runtime field",
+            (version) => (version.resources.script_runtime.unreviewed = true),
+        ],
+        [
+            "unknown script field",
+            (version) => (version.resources.script.unreviewed = true),
+        ],
+        [
+            "unknown resource field",
+            (version) => (version.resources.unreviewed = true),
+        ],
+        [
+            "missing script etag",
+            (version) => delete version.resources.script.etag,
+        ],
+        [
+            "queue event handler",
+            (version) => (version.resources.script.handlers = ["queue"]),
+        ],
+        [
+            "named event handler",
+            (version) =>
+                (version.resources.script.named_handlers = ["namedFetch"]),
+        ],
+        [
+            "service binding",
+            (version) =>
+                version.resources.bindings.push({
+                    name: "UNREVIEWED",
+                    type: "service",
+                    service: "other-worker",
+                }),
+        ],
+        [
+            "queue binding",
+            (version) =>
+                version.resources.bindings.push({
+                    name: "UNREVIEWED",
+                    type: "queue",
+                    queue_name: "other-queue",
+                }),
+        ],
+        [
+            "assets binding",
+            (version) =>
+                version.resources.bindings.push({
+                    name: "ASSETS",
+                    type: "assets",
+                }),
+        ],
+        [
+            "plain text substitution",
+            (version) =>
+                version.resources.bindings.push({
+                    name: "FORGED",
+                    type: "plain_text",
+                    text: "forged",
+                }),
+        ],
+    ]) {
+        await t.test(name, async () => {
+            const harness = createHarness();
+            const reviewed = await provisionProductionEntriesWithReceipt({
+                entries,
+                configs,
+                expectedCommit: COMMIT,
+                mode: "plan",
+                operations: harness.operations,
+                log: () => {},
+            });
+            const upload = harness.operations.upload;
+            harness.operations.upload = async (input) => {
+                const evidence = await upload(input);
+                if (input.site.id === targetSiteId) {
+                    mutate(
+                        harness.versions
+                            .get(input.policy.productionWorker)
+                            .get(evidence.versionId)
+                    );
+                }
+                return evidence;
+            };
+            await assert.rejects(
+                provisionProductionEntriesWithReceipt({
+                    entries,
+                    configs,
+                    expectedCommit: COMMIT,
+                    mode: "apply",
+                    plannedStateDigest: reviewed.stateDigest,
+                    operations: harness.operations,
+                    log: () => {},
+                }),
+                /resource evidence|event handlers|unreviewed service, queue, secret, storage|assets binding|plain-text bindings|cache options|limits|migrations|placement|usage model|unreviewed fields/
+            );
+            assert.equal(
+                harness.calls.some(
+                    ([operation, workerName]) =>
+                        operation === "activate" &&
+                        workerName ===
+                            entries.find(({ site }) => site.id === targetSiteId)
+                                .policy.productionWorker
+                ),
+                false
+            );
+        });
+    }
+});
+
+test("omitted and plain-empty default limits keep one fingerprint through every candidate fence", async () => {
+    const harness = createHarness();
+    const reviewed = await provisionProductionEntriesWithReceipt({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "plan",
+        operations: harness.operations,
+        log: () => {},
+    });
+    const candidateIds = new Set();
+    const upload = harness.operations.upload;
+    harness.operations.upload = async (input) => {
+        const evidence = await upload(input);
+        candidateIds.add(evidence.versionId);
+        return evidence;
+    };
+    const getWorkerVersion = harness.operations.getWorkerVersion;
+    let emptyReads = 0;
+    let omittedReads = 0;
+    harness.operations.getWorkerVersion = async (workerName, versionId) => {
+        const version = await getWorkerVersion(workerName, versionId);
+        if (candidateIds.has(versionId)) {
+            if ((emptyReads + omittedReads) % 2 === 0) {
+                emptyReads += 1;
+                assert.deepEqual(version.resources.script_runtime.limits, {});
+            } else {
+                omittedReads += 1;
+                delete version.resources.script_runtime.limits;
+            }
+        }
+        return version;
+    };
+
+    await provisionProductionEntriesWithReceipt({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "apply",
+        plannedStateDigest: reviewed.stateDigest,
+        operations: harness.operations,
+        log: () => {},
+    });
+    assert.ok(emptyReads > 0);
+    assert.ok(omittedReads > 0);
+    assert.equal(
+        harness.calls.filter(([operation]) => operation === "activate").length,
+        entries.length
+    );
+});
+
+test("an explicitly reviewed limits object still requires an exact match", async (t) => {
+    for (const [name, actualLimits, succeeds] of [
+        ["exact", { cpu_ms: 25 }, true],
+        ["different", { cpu_ms: 50 }, false],
+        ["missing", undefined, false],
+    ]) {
+        await t.test(name, async () => {
+            const harness = createHarness();
+            const limitedConfigs = new Map(
+                [...configs].map(([siteId, rendered]) => [
+                    siteId,
+                    clone(rendered),
+                ])
+            );
+            limitedConfigs.get("stream").config.limits = { cpu_ms: 25 };
+            const reviewed = await provisionProductionEntriesWithReceipt({
+                entries,
+                configs: limitedConfigs,
+                expectedCommit: COMMIT,
+                mode: "plan",
+                operations: harness.operations,
+                log: () => {},
+            });
+            const upload = harness.operations.upload;
+            harness.operations.upload = async (input) => {
+                const evidence = await upload(input);
+                if (input.site.id === "stream") {
+                    const runtime = harness.versions
+                        .get(input.policy.productionWorker)
+                        .get(evidence.versionId).resources.script_runtime;
+                    if (actualLimits === undefined) delete runtime.limits;
+                    else runtime.limits = clone(actualLimits);
+                }
+                return evidence;
+            };
+            const apply = provisionProductionEntriesWithReceipt({
+                entries,
+                configs: limitedConfigs,
+                expectedCommit: COMMIT,
+                mode: "apply",
+                plannedStateDigest: reviewed.stateDigest,
+                operations: harness.operations,
+                log: () => {},
+            });
+            if (succeeds) {
+                await apply;
+                assert.equal(
+                    harness.calls.filter(
+                        ([operation]) => operation === "activate"
+                    ).length,
+                    entries.length
+                );
+            } else {
+                await assert.rejects(apply, /limits do not match/);
+                assert.equal(
+                    harness.calls.some(
+                        ([operation, workerName]) =>
+                            operation === "activate" &&
+                            workerName ===
+                                entries.find(({ site }) => site.id === "stream")
+                                    .policy.productionWorker
+                    ),
+                    false
+                );
+            }
+        });
+    }
+});
+
+test("an exact uploaded version resource substitution is caught before activation", async () => {
+    const harness = createHarness();
+    const reviewed = await provisionProductionEntriesWithReceipt({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "plan",
+        operations: harness.operations,
+        log: () => {},
+    });
+    const upload = harness.operations.upload;
+    let uploadedVersionId;
+    harness.operations.upload = async (input) => {
+        const evidence = await upload(input);
+        if (input.site.id === "stream") uploadedVersionId = evidence.versionId;
+        return evidence;
+    };
+    const getVersion = harness.operations.getWorkerVersion;
+    let candidateReads = 0;
+    harness.operations.getWorkerVersion = async (workerName, versionId) => {
+        const version = await getVersion(workerName, versionId);
+        if (versionId === uploadedVersionId && ++candidateReads >= 2) {
+            version.resources.script.etag = "substituted-resource-etag";
+        }
+        return version;
+    };
+    await assert.rejects(
+        provisionProductionEntriesWithReceipt({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            plannedStateDigest: reviewed.stateDigest,
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /resource fingerprint changed/
+    );
+    assert.equal(
+        harness.calls.some(([operation]) => operation === "activate"),
+        false
+    );
+});
+
+test("a concurrent same-Worker version addition is never learned with the upload", async () => {
+    const harness = createHarness();
+    const reviewed = await provisionProductionEntriesWithReceipt({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "plan",
+        operations: harness.operations,
+        log: () => {},
+    });
+    const upload = harness.operations.upload;
+    harness.operations.upload = async (input) => {
+        const evidence = await upload(input);
+        if (input.site.id === "stream") {
+            const externalVersionId = versionIdFor(700);
+            harness.versions
+                .get(input.policy.productionWorker)
+                .set(externalVersionId, {
+                    id: externalVersionId,
+                    annotations: {},
+                    resources: versionResources("external"),
+                });
+        }
+        return evidence;
+    };
+    await assert.rejects(
+        provisionProductionEntriesWithReceipt({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            plannedStateDigest: reviewed.stateDigest,
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /exact inactive uploaded Worker\/version transition was not observed/
+    );
+    assert.equal(
+        harness.calls.some(([operation]) => operation === "activate"),
+        false
+    );
+});
+
+test("Queue consumer drift after upload is caught by the mutation-time ledger before activation", async () => {
+    const harness = createHarness();
+    const reviewed = await provisionProductionEntriesWithReceipt({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "plan",
+        operations: harness.operations,
+        log: () => {},
+    });
+    const upload = harness.operations.upload;
+    harness.operations.upload = async (input) => {
+        const evidence = await upload(input);
+        if (input.site.id === "stream") {
+            harness.queueConsumerInventory.push({
+                queueId: "queue-a",
+                queueName: "first-queue",
+                consumers: [
+                    {
+                        consumerId: "consumer-a",
+                        type: "http_pull",
+                        scriptName: null,
+                        queueName: "first-queue",
+                        deadLetterQueue: "",
+                        settings: {},
+                    },
+                ],
+            });
+        }
+        return evidence;
+    };
+    await assert.rejects(
+        provisionProductionEntriesWithReceipt({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            plannedStateDigest: reviewed.stateDigest,
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /Queue consumer attachment inventory changed/
+    );
+    assert.equal(
+        harness.calls.some(([operation]) => operation === "activate"),
+        false
+    );
+});
+
+test("a lost upload response can never be adopted by a later apply", async () => {
+    const harness = createHarness();
+    const firstPlan = await provisionProductionEntriesWithReceipt({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "plan",
+        operations: harness.operations,
+        log: () => {},
+    });
+    const upload = harness.operations.upload;
+    harness.operations.upload = async (input) => {
+        await upload(input);
+        throw new Error("lost response after Cloudflare stored the version");
+    };
+    await assert.rejects(
+        provisionProductionEntriesWithReceipt({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            plannedStateDigest: firstPlan.stateDigest,
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /same-invocation structured Wrangler upload evidence is missing/
+    );
+    const streamWorker = entries[0].policy.productionWorker;
+    const leftover = [...harness.versions.get(streamWorker).keys()];
+    assert.equal(leftover.length, 1);
+
+    harness.operations.upload = upload;
+    harness.calls.length = 0;
+    const secondPlan = await provisionProductionEntriesWithReceipt({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "plan",
+        operations: harness.operations,
+        log: () => {},
+    });
+    assert.deepEqual(secondPlan[0].quarantinedVersionIds, leftover);
+    await provisionProductionEntriesWithReceipt({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "apply",
+        plannedStateDigest: secondPlan.stateDigest,
+        operations: harness.operations,
+        log: () => {},
+    });
+    const activated = harness.calls.find(
+        ([operation, worker]) =>
+            operation === "activate" && worker === streamWorker
+    )[2];
+    assert.notEqual(activated, leftover[0]);
+    assert.equal(harness.calls.filter(([name]) => name === "upload").length, 7);
+});
+
+test("each rerun uses a distinct unpredictable version tag", async () => {
+    const harness = createHarness();
+    await provisionProductionEntries({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "apply",
+        operations: harness.operations,
+        log: () => {},
+    });
+    await provisionProductionEntries({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "apply",
+        operations: harness.operations,
+        log: () => {},
+    });
+    for (const { site, policy } of entries) {
+        const tags = [
+            ...harness.versions.get(policy.productionWorker).values(),
+        ].map((version) => version.annotations["workers/tag"]);
+        assert.equal(new Set(tags).size, 2);
+        assert.ok(
+            tags.every((tag) =>
+                new RegExp(
+                    `^peerbit_bootstrap_${site.id}_${COMMIT.slice(0, 12)}_[0-9a-f]{32}$`
+                ).test(tag)
+            )
+        );
+    }
+});
+
+test("an existing Worker is disabled and proved both before and after upload", async () => {
+    const harness = createHarness();
+    const target = entries[0];
+    harness.addWorker({
+        entry: target,
+        enabled: true,
+        previewsEnabled: true,
+    });
+    for (const entry of entries.slice(1)) harness.seedExact({ entry });
+
+    await provisionProductionEntries({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "apply",
+        operations: harness.operations,
+        log: () => {},
+    });
+    const relevant = harness.calls
+        .filter(
+            ([name, workerOrSite]) =>
+                (name === "upload" && workerOrSite === target.site.id) ||
+                (["disable-subdomain", "activate"].includes(name) &&
+                    workerOrSite === target.policy.productionWorker)
+        )
+        .map(([name]) => name);
+    assert.deepEqual(relevant, [
+        "disable-subdomain",
+        "upload",
+        "disable-subdomain",
+        "activate",
+    ]);
+});
+
+test("unexpected namespace, route, domain, and release state fail before preview remediation", async (t) => {
+    const cases = [
+        [
+            "retired Worker",
+            (harness) => {
+                harness.scripts.set("peerbit-examples-legacy-stream-preview", {
+                    tag: "legacy-tag",
+                    routes: [],
+                });
+            },
+        ],
+        [
+            "unknown managed Worker",
+            (harness) => {
+                harness.scripts.set("peerbit-examples-unreviewed", {
+                    tag: "unknown-tag",
+                    routes: [],
+                });
+            },
+        ],
+        [
+            "allowlisted preview route",
+            (harness) => {
+                const preview = entries[0].policy.previewWorker;
+                harness.scripts.get(preview).routes.push({
+                    id: "preview-route",
+                    pattern: "preview.peerbit.org/*",
+                    script: preview,
+                });
+            },
+        ],
+        [
+            "managed route",
+            (harness) => {
+                harness.scripts.set("unrelated-worker", {
+                    tag: "unrelated-tag",
+                    routes: [
+                        {
+                            id: "route-1",
+                            pattern: "files.apps.peerbit.org/*",
+                            script: "unrelated-worker",
+                        },
+                    ],
+                });
+            },
+        ],
+        [
+            "allowlisted preview custom domain",
+            (harness) => {
+                harness.domains.push({
+                    id: "preview-domain",
+                    hostname: "preview.peerbit.org",
+                    service: entries[0].policy.previewWorker,
+                    environment: "production",
+                    zoneId: ZONE_ID,
+                    zoneName: "peerbit.org",
+                });
+            },
+        ],
+        [
+            "wrong domain owner",
+            (harness) => {
+                harness.scripts.set("unrelated-worker", {
+                    tag: "unrelated-tag",
+                    routes: [],
+                });
+                harness.domains.push({
+                    id: "wrong-domain",
+                    hostname: "files.apps.peerbit.org",
+                    service: "unrelated-worker",
+                    environment: "production",
+                    zoneId: ZONE_ID,
+                    zoneName: "peerbit.org",
+                });
+            },
+        ],
+    ];
+    for (const [name, mutate] of cases) {
+        await t.test(name, async () => {
+            const harness = createHarness();
+            for (const entry of entries) {
+                harness.addPreview({
+                    entry,
+                    enabled: true,
+                    previewsEnabled: true,
+                });
+            }
+            mutate(harness);
+            await assert.rejects(
+                provisionProductionEntries({
+                    entries,
+                    configs,
+                    expectedCommit: COMMIT,
+                    mode: "apply",
+                    operations: harness.operations,
+                    log: () => {},
+                })
+            );
+            assert.deepEqual(mutationCalls(harness.calls), []);
+        });
+    }
+});
+
+test("a reviewed different active baseline is replaced only by a fresh proved version", async () => {
+    const harness = createHarness();
+    for (const entry of entries) harness.seedExact({ entry });
+    const target = entries[0];
+    harness.addExactVersion({
+        entry: target,
+        active: true,
+        commit: OTHER_COMMIT,
+    });
+    await provisionProductionEntries({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "apply",
+        operations: harness.operations,
+        log: () => {},
+    });
+    assert.equal(harness.calls.filter(([name]) => name === "upload").length, 7);
+    assert.equal(
+        harness.calls.filter(([name]) => name === "activate").length,
+        7
+    );
+});
+
+test("a production Worker missing initially cannot appear before its owned upload", async () => {
+    const harness = createHarness();
+    const target = entries[0];
+    const originalList = harness.operations.listWorkerScripts;
+    let reads = 0;
+    harness.operations.listWorkerScripts = async () => {
+        reads += 1;
+        if (reads === 2) harness.addWorker({ entry: target });
+        return originalList();
+    };
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /Cloudflare provisioning state changed after review/
+    );
+    assert.deepEqual(mutationCalls(harness.calls), []);
+});
+
+test("a cross-site Worker replacement after upload is never rebaselined", async () => {
+    const harness = createHarness();
+    const target = entries[0];
+    const victim = entries[1];
+    for (const entry of entries.slice(1)) harness.seedExact({ entry });
+    const originalUpload = harness.operations.upload;
+    harness.operations.upload = async (input) => {
+        const evidence = await originalUpload(input);
+        harness.scripts.set(victim.policy.productionWorker, {
+            tag: "replacement-cross-site-worker-tag",
+            routes: [],
+        });
+        return evidence;
+    };
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /invocation production ledger changed workerTag/
+    );
+    assert.deepEqual(mutationCalls(harness.calls), [
+        ["upload", target.site.id],
+        ["disable-subdomain", target.policy.productionWorker],
+    ]);
+    assert.deepEqual(harness.subdomains.get(target.policy.productionWorker), {
+        enabled: false,
+        previewsEnabled: false,
+    });
+    assert.equal(
+        harness.calls.some(([name]) =>
+            ["activate", "attach-domain"].includes(name)
+        ),
+        false
+    );
+});
+
+test("an earlier production public URL re-enable blocks every later domain mutation", async () => {
+    const harness = createHarness();
+    for (const entry of entries) {
+        harness.seedExact({ entry, active: true, domain: false });
+    }
+    const earlier = entries[0];
+    const originalAttach = harness.operations.attachDomain;
+    const originalList = harness.operations.listWorkerScripts;
+    let armed = false;
+    let readsAfterFirstAttachment = 0;
+    harness.operations.attachDomain = async (input) => {
+        const attachment = await originalAttach(input);
+        if (input.workerName === earlier.policy.productionWorker) armed = true;
+        return attachment;
+    };
+    harness.operations.listWorkerScripts = async () => {
+        if (armed) {
+            readsAfterFirstAttachment += 1;
+            if (readsAfterFirstAttachment === 2) {
+                harness.subdomains.set(earlier.policy.productionWorker, {
+                    enabled: true,
+                    previewsEnabled: false,
+                });
+            }
+        }
+        return originalList();
+    };
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /existing production Worker must have workers\.dev and Preview URLs disabled before a custom-domain attachment/
+    );
+    assert.deepEqual(
+        harness.calls
+            .filter(([name]) => name === "attach-domain")
+            .map(([, worker]) => worker),
+        [earlier.policy.productionWorker]
+    );
+});
+
+test("ambiguous upload, subdomain, activation, and domain responses require exact GET postconditions", async () => {
+    const harness = createHarness();
+    const logs = [];
+    for (const [operationName, methodName] of [
+        ["upload", "upload"],
+        ["disable-subdomain", "disableWorkerSubdomain"],
+        ["activate", "activate"],
+        ["attach-domain", "attachDomain"],
+    ]) {
+        const original = harness.operations[methodName];
+        harness.operations[methodName] = async (...args) => {
+            const evidence = await original(...args);
+            const error = new Error(
+                `${operationName} response lost after dispatch`
+            );
+            if (methodName === "upload") {
+                error.deploymentEvidence = evidence;
+            }
+            throw error;
+        };
+    }
+    await provisionProductionEntries({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "apply",
+        operations: harness.operations,
+        log: (line) => logs.push(line),
+    });
+    assert.ok(logs.some((line) => /ambiguous upload response/.test(line)));
+    assert.ok(
+        logs.some((line) => /ambiguous public-subdomain response/.test(line))
+    );
+    assert.ok(logs.some((line) => /ambiguous activation response/.test(line)));
+    assert.ok(logs.some((line) => /ambiguous domain response/.test(line)));
+});
+
+test("every ambiguous preview disable response resumes only after an exact disabled GET", async (t) => {
+    for (const responseKind of [
+        "transport failure",
+        "well-formed 400",
+        "500",
+        "malformed 200",
+        "empty 200",
+    ]) {
+        await t.test(responseKind, async () => {
+            const harness = createHarness();
+            for (const entry of entries) harness.seedExact({ entry });
+            const target = entries[0];
+            harness.addPreview({
+                entry: target,
+                enabled: true,
+                previewsEnabled: true,
+            });
+            const originalDisable = harness.operations.disableWorkerSubdomain;
+            harness.operations.disableWorkerSubdomain = async (workerName) => {
+                await originalDisable(workerName);
+                throw new Error(`${responseKind} after mutation dispatch`);
+            };
+            const logs = [];
+            await provisionProductionEntries({
+                entries,
+                configs,
+                expectedCommit: COMMIT,
+                mode: "apply",
+                operations: harness.operations,
+                log: (line) => logs.push(line),
+            });
+            const disabledAt = harness.calls.findIndex(
+                ([name, worker]) =>
+                    name === "disable-subdomain" &&
+                    worker === target.policy.previewWorker
+            );
+            const provedAt = harness.calls.findIndex(
+                ([name, worker], index) =>
+                    index > disabledAt &&
+                    name === "get-subdomain" &&
+                    worker === target.policy.previewWorker
+            );
+            assert.ok(disabledAt >= 0 && provedAt > disabledAt);
+            assert.deepEqual(
+                harness.subdomains.get(target.policy.previewWorker),
+                { enabled: false, previewsEnabled: false }
+            );
+            assert.ok(
+                logs.some((line) =>
+                    /ambiguous public-subdomain response/.test(line)
+                )
+            );
+            assert.equal(
+                harness.calls.filter(([name]) => name === "upload").length,
+                7
+            );
+            assert.equal(
+                harness.calls.filter(([name]) => name === "activate").length,
+                7
+            );
+        });
+    }
+});
+
+test("an unproved preview disable ambiguity stops before every production mutation", async () => {
+    const harness = createHarness();
+    for (const entry of entries) harness.seedExact({ entry });
+    const target = entries[0];
+    harness.addPreview({
+        entry: target,
+        enabled: true,
+        previewsEnabled: true,
+    });
+    harness.operations.disableWorkerSubdomain = async (workerName) => {
+        harness.calls.push(["disable-subdomain", workerName]);
+        throw new Error("transport failure without proved application");
+    };
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /do not retry mutations blindly/
+    );
+    assert.deepEqual(mutationCalls(harness.calls), [
+        ["disable-subdomain", target.policy.previewWorker],
+    ]);
+    assert.deepEqual(harness.subdomains.get(target.policy.previewWorker), {
+        enabled: true,
+        previewsEnabled: true,
+    });
+});
+
+test("a preview Worker identity replacement during fencing blocks production", async () => {
+    const harness = createHarness();
+    for (const entry of entries) harness.seedExact({ entry });
+    const target = entries[0];
+    harness.addPreview({
+        entry: target,
+        enabled: true,
+        previewsEnabled: true,
+    });
+    const originalDisable = harness.operations.disableWorkerSubdomain;
+    harness.operations.disableWorkerSubdomain = async (workerName) => {
+        const result = await originalDisable(workerName);
+        harness.scripts.set(workerName, {
+            tag: "replacement-preview-worker-tag",
+            routes: [],
+        });
+        return result;
+    };
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /preview Worker identity changed/
+    );
+    assert.deepEqual(mutationCalls(harness.calls), [
+        ["disable-subdomain", target.policy.previewWorker],
+    ]);
+});
+
+test("a preview Worker re-enabled during upload blocks activation", async () => {
+    const harness = createHarness();
+    const target = entries[0];
+    harness.addPreview({
+        entry: target,
+        enabled: true,
+        previewsEnabled: true,
+    });
+    const originalUpload = harness.operations.upload;
+    harness.operations.upload = async (input) => {
+        const evidence = await originalUpload(input);
+        harness.subdomains.set(target.policy.previewWorker, {
+            enabled: true,
+            previewsEnabled: false,
+        });
+        return evidence;
+    };
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /existing preview Worker must have .* Preview URLs disabled after a route-free version upload/
+    );
+    assert.deepEqual(
+        mutationCalls(harness.calls).map(([name, identity]) => [
+            name,
+            identity,
+        ]),
+        [
+            ["disable-subdomain", target.policy.previewWorker],
+            ["upload", target.site.id],
+            ["disable-subdomain", target.policy.productionWorker],
+        ]
+    );
+    assert.deepEqual(harness.subdomains.get(target.policy.productionWorker), {
+        enabled: false,
+        previewsEnabled: false,
+    });
+    assert.equal(
+        harness.calls.some(([name]) => name === "activate"),
+        false
+    );
+});
+
+test("an unproved ambiguous upload stops before activation and domain mutation", async () => {
+    const harness = createHarness();
+    const target = entries[0];
+    harness.operations.upload = async ({ site }) => {
+        harness.calls.push(["upload", site.id]);
+        throw new Error("lost response without applying upload");
+    };
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /do not retry mutations blindly/
+    );
+    assert.deepEqual(mutationCalls(harness.calls), [
+        ["upload", target.site.id],
+        ["disable-subdomain", target.policy.productionWorker],
+    ]);
+    assert.equal(
+        harness.calls.some(([name]) => name === "activate"),
+        false
+    );
+    assert.equal(
+        harness.calls.some(([name]) => name === "attach-domain"),
+        false
+    );
+});
+
+test("an applied new upload without Wrangler evidence cannot establish Worker identity", async () => {
+    const harness = createHarness();
+    const target = entries[0];
+    const originalUpload = harness.operations.upload;
+    harness.operations.upload = async (input) => {
+        await originalUpload(input);
+        throw new Error("lost response after applying upload");
+    };
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        (error) => {
+            assert.match(
+                error.message,
+                /upload response: lost response after applying upload/
+            );
+            assert.match(error.message, /post-upload proof:/);
+            assert.match(
+                error.message,
+                /exact-name public-URL failure cleanup was proved false\/false by GET/
+            );
+            assert.match(
+                error.message,
+                /post-cleanup invocation fence was proved/
+            );
+            return true;
+        }
+    );
+    assert.deepEqual(mutationCalls(harness.calls), [
+        ["upload", target.site.id],
+        ["disable-subdomain", target.policy.productionWorker],
+    ]);
+    assert.deepEqual(harness.subdomains.get(target.policy.productionWorker), {
+        enabled: false,
+        previewsEnabled: false,
+    });
+    assert.equal(
+        harness.calls.some(([name]) =>
+            ["activate", "attach-domain"].includes(name)
+        ),
+        false
+    );
+});
+
+test("successful upload output must match exact GET-confirmed ownership", async () => {
+    const harness = createHarness();
+    const target = entries[0];
+    const originalUpload = harness.operations.upload;
+    harness.operations.upload = async (input) => {
+        const evidence = await originalUpload(input);
+        return { ...evidence, workerTag: "wrong-worker-tag" };
+    };
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        (error) => {
+            assert.match(
+                error.message,
+                /Wrangler upload evidence does not match/
+            );
+            assert.match(
+                error.message,
+                /exact-name public-URL failure cleanup was proved false\/false by GET/
+            );
+            return true;
+        }
+    );
+    assert.deepEqual(mutationCalls(harness.calls), [
+        ["upload", target.site.id],
+        ["disable-subdomain", target.policy.productionWorker],
+    ]);
+    assert.deepEqual(harness.subdomains.get(target.policy.productionWorker), {
+        enabled: false,
+        previewsEnabled: false,
+    });
+    assert.equal(
+        harness.calls.some(([name]) =>
+            ["activate", "attach-domain"].includes(name)
+        ),
+        false
+    );
+});
+
+test("a post-upload inspection failure still closes the exact public URL surfaces", async () => {
+    const harness = createHarness();
+    const target = entries[0];
+    const originalUpload = harness.operations.upload;
+    const originalList = harness.operations.listWorkerScripts;
+    let failNextInventoryRead = false;
+    harness.operations.upload = async (input) => {
+        const evidence = await originalUpload(input);
+        failNextInventoryRead = true;
+        return evidence;
+    };
+    harness.operations.listWorkerScripts = async () => {
+        if (failNextInventoryRead) {
+            failNextInventoryRead = false;
+            throw new Error("post-upload Worker inventory read failed");
+        }
+        return originalList();
+    };
+
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        (error) => {
+            assert.match(
+                error.message,
+                /post-upload proof: post-upload Worker inventory read failed/
+            );
+            assert.match(
+                error.message,
+                /exact-name public-URL failure cleanup was proved false\/false by GET/
+            );
+            assert.match(
+                error.message,
+                /post-cleanup invocation fence was proved/
+            );
+            return true;
+        }
+    );
+    assert.deepEqual(mutationCalls(harness.calls), [
+        ["upload", target.site.id],
+        ["disable-subdomain", target.policy.productionWorker],
+    ]);
+    assert.deepEqual(harness.subdomains.get(target.policy.productionWorker), {
+        enabled: false,
+        previewsEnabled: false,
+    });
+    assert.equal(
+        harness.calls.some(([name]) =>
+            ["activate", "attach-domain"].includes(name)
+        ),
+        false
+    );
+});
+
+test("a failed upload preserves both the primary and public-URL cleanup diagnostics", async () => {
+    const harness = createHarness();
+    const target = entries[0];
+    const originalUpload = harness.operations.upload;
+    const originalDisable = harness.operations.disableWorkerSubdomain;
+    harness.operations.upload = async (input) => {
+        await originalUpload(input);
+        throw new Error("original upload response diagnostic");
+    };
+    harness.operations.disableWorkerSubdomain = async (workerName) => {
+        if (workerName === target.policy.productionWorker) {
+            harness.calls.push(["disable-subdomain", workerName]);
+            throw new Error("failure cleanup dispatch diagnostic");
+        }
+        return originalDisable(workerName);
+    };
+
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        (error) => {
+            assert.match(
+                error.message,
+                /upload response: original upload response diagnostic/
+            );
+            assert.match(
+                error.message,
+                /exact-name public-URL failure cleanup was not proved:.*failure cleanup dispatch diagnostic/
+            );
+            assert.match(
+                error.message,
+                /post-cleanup invocation fence was not proved/
+            );
+            return true;
+        }
+    );
+    assert.deepEqual(mutationCalls(harness.calls), [
+        ["upload", target.site.id],
+        ["disable-subdomain", target.policy.productionWorker],
+    ]);
+    assert.equal(
+        harness.calls.some(([name]) =>
+            ["activate", "attach-domain"].includes(name)
+        ),
+        false
+    );
+});
+
+test("live verification and its final policy fence are required for success", async () => {
+    const harness = createHarness();
+    for (const entry of entries) harness.seedExact({ entry });
+    const originalVerify = harness.operations.verify;
+    harness.operations.verify = async (input) => {
+        await originalVerify(input);
+        if (input.site.id === "files") {
+            harness.domains.find(
+                ({ hostname }) => hostname === "files.apps.peerbit.org"
+            ).service = "unrelated-worker";
+        }
+    };
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /outside the exact provisioning policy|not exactly owned|custom domains must exactly equal/
+    );
+    assert.equal(harness.calls.filter(([name]) => name === "upload").length, 7);
+    assert.equal(
+        harness.calls.filter(([name]) => name === "activate").length,
+        7
+    );
+});
+
+test("wrong exact-version module bytes require manual recovery before any later mutation", async () => {
+    const harness = createHarness();
+    const getWorkerVersionModule = harness.operations.getWorkerVersionModule;
+    harness.operations.getWorkerVersionModule = async (
+        workerName,
+        versionId
+    ) => {
+        const observed = await getWorkerVersionModule(workerName, versionId);
+        const activeVersion = harness.deployments
+            .get(workerName)?.[0]
+            ?.versions?.find(
+                ({ percentage }) => percentage === 100
+            )?.version_id;
+        return workerName === entries[0].policy.productionWorker &&
+            activeVersion === versionId
+            ? { ...observed, sha256: "f".repeat(64) }
+            : observed;
+    };
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /exact 100% activation could not be proved.*do not retry mutations blindly/
+    );
+    assert.equal(
+        harness.calls.filter(([name]) => name === "activate").length,
+        1
+    );
+    assert.equal(
+        harness.calls.some(([name]) => name === "attach-domain"),
+        false
+    );
+    assert.equal(
+        harness.calls.some(
+            ([name, siteId]) => name === "upload" && siteId !== "stream"
+        ),
+        false
+    );
+});
+
+test("final verification rechecks every existing preview Worker", async () => {
+    const harness = createHarness();
+    for (const entry of entries) {
+        harness.seedExact({ entry });
+        harness.addPreview({ entry });
+    }
+    const drifted = entries[0].policy.previewWorker;
+    const originalVerify = harness.operations.verify;
+    harness.operations.verify = async (input) => {
+        await originalVerify(input);
+        if (input.site.id === "files") {
+            harness.subdomains.set(drifted, {
+                enabled: false,
+                previewsEnabled: true,
+            });
+        }
+    };
+    await assert.rejects(
+        provisionProductionEntries({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /workers\.dev and (?:Worker )?Preview URLs must both be disabled|existing preview Worker must have workers\.dev and Preview URLs disabled after provisioning/
+    );
+    assert.equal(harness.calls.filter(([name]) => name === "upload").length, 7);
+    assert.equal(
+        harness.calls.filter(([name]) => name === "activate").length,
+        7
+    );
+    for (const { policy } of entries) {
+        assert.ok(
+            harness.calls.some(
+                ([name, worker]) =>
+                    name === "get-subdomain" && worker === policy.previewWorker
+            )
+        );
+    }
+});
+
+test("manual-recovery diagnostics redact token, account, and workers.dev slug", async () => {
+    const harness = createHarness();
+    const oldToken = process.env.CLOUDFLARE_API_TOKEN;
+    const oldAccount = process.env.CLOUDFLARE_ACCOUNT_ID;
+    process.env.CLOUDFLARE_API_TOKEN = API_TOKEN;
+    process.env.CLOUDFLARE_ACCOUNT_ID = ACCOUNT_ID;
+    harness.operations.upload = async ({ site }) => {
+        harness.calls.push(["upload", site.id]);
+        throw new Error(
+            `${API_TOKEN} ${ACCOUNT_ID} https://v-worker.private-account.workers.dev./path`
+        );
+    };
+    try {
+        await assert.rejects(
+            provisionProductionEntries({
+                entries,
+                configs,
+                expectedCommit: COMMIT,
+                mode: "apply",
+                operations: harness.operations,
+                log: () => {},
+            }),
+            (error) => {
+                assert.doesNotMatch(error.message, new RegExp(API_TOKEN));
+                assert.doesNotMatch(error.message, new RegExp(ACCOUNT_ID));
+                assert.doesNotMatch(error.message, /private-account/i);
+                assert.doesNotMatch(error.message, /workers\.dev/i);
+                return true;
+            }
+        );
+    } finally {
+        if (oldToken == null) delete process.env.CLOUDFLARE_API_TOKEN;
+        else process.env.CLOUDFLARE_API_TOKEN = oldToken;
+        if (oldAccount == null) delete process.env.CLOUDFLARE_ACCOUNT_ID;
+        else process.env.CLOUDFLARE_ACCOUNT_ID = oldAccount;
+    }
+});
+
+test("Cloudflare provisioning adapters use exact documented endpoints and bodies", async () => {
+    const workerName = entries[0].policy.productionWorker;
+    const hostname = entries[0].policy.productionHostnames[0];
+    const requests = [];
+    const api = createCloudflareWorkersApi({
+        accountId: ACCOUNT_ID,
+        apiToken: API_TOKEN,
+        request: async (url, init) => {
+            requests.push([url, init.method, init.body]);
+            if (url.endsWith("/deployments")) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: { deployments: [] },
+                    })
+                );
+            }
+            if (url.endsWith("/versions?deployable=true")) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: {
+                            items: [{ id: versionIdFor(0), number: 1 }],
+                        },
+                    })
+                );
+            }
+            if (url.endsWith("/subdomain")) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: {
+                            enabled: false,
+                            previews_enabled: false,
+                        },
+                    })
+                );
+            }
+            if (url.endsWith("/schedules")) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: { schedules: [] },
+                    })
+                );
+            }
+            if (url.endsWith("/workers/domains")) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: {
+                            id: "domain-stream",
+                            hostname,
+                            service: workerName,
+                            environment: "production",
+                            zone_id: ZONE_ID,
+                            zone_name: "peerbit.org",
+                        },
+                    })
+                );
+            }
+            return new Response("not found", { status: 404 });
+        },
+    });
+    assert.deepEqual(await api.getWorkerDeployments(workerName), []);
+    assert.deepEqual(await api.listWorkerSchedules(workerName), []);
+    assert.deepEqual(await api.listDeployableWorkerVersions(workerName), [
+        versionIdFor(0),
+    ]);
+    assert.deepEqual(await api.disableWorkerSubdomain(workerName), {
+        enabled: false,
+        previewsEnabled: false,
+    });
+    assert.equal(
+        (await api.attachWorkerDomain({ workerName, hostname })).hostname,
+        hostname
+    );
+    const root = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/workers`;
+    assert.deepEqual(requests, [
+        [`${root}/scripts/${workerName}/deployments`, "GET", undefined],
+        [`${root}/scripts/${workerName}/schedules`, "GET", undefined],
+        [
+            `${root}/scripts/${workerName}/versions?deployable=true`,
+            "GET",
+            undefined,
+        ],
+        [
+            `${root}/scripts/${workerName}/subdomain`,
+            "POST",
+            JSON.stringify({ enabled: false, previews_enabled: false }),
+        ],
+        [
+            `${root}/domains`,
+            "PUT",
+            JSON.stringify({
+                hostname,
+                service: workerName,
+                environment: "production",
+            }),
+        ],
+    ]);
+});
+
+test("Cron schedule inventory accepts only Cloudflare's exact documented envelope", async (t) => {
+    const workerName = entries[0].policy.productionWorker;
+    const invoke = async (result) => {
+        const api = createCloudflareWorkersApi({
+            accountId: ACCOUNT_ID,
+            apiToken: API_TOKEN,
+            request: async () =>
+                new Response(JSON.stringify({ success: true, result })),
+        });
+        return api.listWorkerSchedules(workerName);
+    };
+
+    assert.deepEqual(
+        await invoke({
+            schedules: [{ cron: "5 * * * *" }, { cron: "* * * * *" }],
+        }),
+        ["* * * * *", "5 * * * *"]
+    );
+    assert.deepEqual(await invoke({ schedules: [] }), []);
+
+    for (const [name, result] of [
+        ["legacy top-level array", []],
+        ["missing schedules", {}],
+        ["non-array schedules", { schedules: {} }],
+        ["extra envelope field", { schedules: [], extra: true }],
+        ["null envelope", null],
+    ]) {
+        await t.test(name, async () => {
+            await assert.rejects(invoke(result), CloudflareWorkersApiError);
+        });
+    }
+});
+
+test("Queue consumer inventory paginates the account and canonicalizes two complete snapshots", async () => {
+    const root = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/queues`;
+    const requests = [];
+    let queueAConsumerReads = 0;
+    const api = createCloudflareWorkersApi({
+        accountId: ACCOUNT_ID,
+        apiToken: API_TOKEN,
+        request: async (url, init) => {
+            requests.push([url, init.method]);
+            if (url === `${root}?page=1&per_page=100`) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: [
+                            {
+                                queue_id: "queue-b",
+                                queue_name: "second-queue",
+                                consumers_total_count: 1,
+                            },
+                        ],
+                        result_info: {
+                            count: 1,
+                            page: 1,
+                            per_page: 1,
+                            total_count: 2,
+                            total_pages: 2,
+                        },
+                    })
+                );
+            }
+            if (url === `${root}?page=2&per_page=100`) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: [
+                            {
+                                queue_id: "queue-a",
+                                queue_name: "first-queue",
+                                consumers_total_count: 1,
+                            },
+                        ],
+                        result_info: {
+                            count: 1,
+                            page: 2,
+                            per_page: 1,
+                            total_count: 2,
+                            total_pages: 2,
+                        },
+                    })
+                );
+            }
+            if (url === `${root}/queue-a/consumers`) {
+                const reverseKeys = queueAConsumerReads++ > 0;
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: [
+                            {
+                                consumer_id: "consumer-a",
+                                type: "worker",
+                                queue_name: "first-queue",
+                                script_name: "external-worker",
+                                dead_letter_queue: "failed-queue",
+                                settings: reverseKeys
+                                    ? { max_batch_size: 10, max_retries: 3 }
+                                    : { max_retries: 3, max_batch_size: 10 },
+                            },
+                        ],
+                    })
+                );
+            }
+            if (url === `${root}/queue-b/consumers`) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: [
+                            {
+                                consumer_id: "consumer-b",
+                                type: "http_pull",
+                                queue_name: "second-queue",
+                                settings: {},
+                            },
+                        ],
+                    })
+                );
+            }
+            return new Response("not found", { status: 404 });
+        },
+    });
+
+    assert.deepEqual(await api.listQueueConsumerInventory(), [
+        {
+            queueId: "queue-a",
+            queueName: "first-queue",
+            consumers: [
+                {
+                    consumerId: "consumer-a",
+                    type: "worker",
+                    scriptName: "external-worker",
+                    queueName: "first-queue",
+                    deadLetterQueue: "failed-queue",
+                    settings: { max_batch_size: 10, max_retries: 3 },
+                },
+            ],
+        },
+        {
+            queueId: "queue-b",
+            queueName: "second-queue",
+            consumers: [
+                {
+                    consumerId: "consumer-b",
+                    type: "http_pull",
+                    scriptName: null,
+                    queueName: "second-queue",
+                    deadLetterQueue: "",
+                    settings: {},
+                },
+            ],
+        },
+    ]);
+    assert.deepEqual(requests, [
+        [`${root}?page=1&per_page=100`, "GET"],
+        [`${root}/queue-b/consumers`, "GET"],
+        [`${root}?page=2&per_page=100`, "GET"],
+        [`${root}/queue-a/consumers`, "GET"],
+        [`${root}?page=1&per_page=100`, "GET"],
+        [`${root}/queue-b/consumers`, "GET"],
+        [`${root}?page=2&per_page=100`, "GET"],
+        [`${root}/queue-a/consumers`, "GET"],
+    ]);
+});
+
+test("Queue consumer inventory fails closed on malformed, incomplete, duplicate, or unstable reads", async (t) => {
+    const root = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/queues`;
+    const queuePage = (queues, overrides = {}) => ({
+        success: true,
+        result: queues,
+        result_info: {
+            count: queues.length,
+            page: 1,
+            per_page: 100,
+            total_count: queues.length,
+            total_pages: queues.length === 0 ? 0 : 1,
+            ...overrides,
+        },
+    });
+    const queue = {
+        queue_id: "queue-a",
+        queue_name: "first-queue",
+        consumers_total_count: 1,
+    };
+    const workerConsumer = {
+        consumer_id: "consumer-a",
+        type: "worker",
+        queue_name: "first-queue",
+        script_name: "external-worker",
+        settings: {},
+    };
+    const invoke = async (request) => {
+        const api = createCloudflareWorkersApi({
+            accountId: ACCOUNT_ID,
+            apiToken: API_TOKEN,
+            request,
+        });
+        return api.listQueueConsumerInventory();
+    };
+
+    await t.test("malformed pagination", async () => {
+        await assert.rejects(
+            invoke(
+                async () =>
+                    new Response(
+                        JSON.stringify(queuePage([queue], { count: 2 }))
+                    )
+            ),
+            CloudflareWorkersApiError
+        );
+    });
+
+    await t.test("consumer count mismatch", async () => {
+        await assert.rejects(
+            invoke(
+                async (url) =>
+                    new Response(
+                        JSON.stringify(
+                            url.includes("/consumers")
+                                ? { success: true, result: [] }
+                                : queuePage([queue])
+                        )
+                    )
+            ),
+            CloudflareWorkersApiError
+        );
+    });
+
+    await t.test("duplicate Queue identity", async () => {
+        const duplicates = [
+            queue,
+            {
+                ...queue,
+                queue_name: "different-name",
+                consumers_total_count: 0,
+            },
+        ];
+        await assert.rejects(
+            invoke(
+                async (url) =>
+                    new Response(
+                        JSON.stringify(
+                            url.includes("/consumers")
+                                ? { success: true, result: [workerConsumer] }
+                                : queuePage(duplicates)
+                        )
+                    )
+            ),
+            CloudflareWorkersApiError
+        );
+    });
+
+    await t.test("malformed consumer", async () => {
+        await assert.rejects(
+            invoke(
+                async (url) =>
+                    new Response(
+                        JSON.stringify(
+                            url.includes("/consumers")
+                                ? {
+                                      success: true,
+                                      result: [
+                                          {
+                                              ...workerConsumer,
+                                              script_name: "../managed",
+                                          },
+                                      ],
+                                  }
+                                : queuePage([queue])
+                        )
+                    )
+            ),
+            CloudflareWorkersApiError
+        );
+    });
+
+    await t.test("inventory never stabilizes", async () => {
+        let consumerReads = 0;
+        await assert.rejects(
+            invoke(
+                async (url) =>
+                    new Response(
+                        JSON.stringify(
+                            url.includes("/consumers")
+                                ? {
+                                      success: true,
+                                      result: [
+                                          {
+                                              ...workerConsumer,
+                                              settings: {
+                                                  max_batch_size:
+                                                      ++consumerReads,
+                                              },
+                                          },
+                                      ],
+                                  }
+                                : queuePage([queue])
+                        )
+                    )
+            ),
+            /did not remain stable/
+        );
+        assert.equal(consumerReads, 3);
+    });
+});
+
+test("exact Worker version module adapter hashes the complete multipart set", async () => {
+    const workerName = entries[0].policy.productionWorker;
+    const versionId = versionIdFor(0);
+    const bytes = Buffer.from(
+        "export default { fetch() { return new Response('ok') } };"
+    );
+    const form = new FormData();
+    form.set(
+        "module.js",
+        new Blob([bytes], { type: "application/javascript+module" }),
+        "module.js"
+    );
+    let requestedUrl;
+    const api = createCloudflareWorkersApi({
+        accountId: ACCOUNT_ID,
+        apiToken: API_TOKEN,
+        request: async (url) => {
+            requestedUrl = url;
+            return new Response(form, {
+                headers: { "cf-entrypoint": "module.js" },
+            });
+        },
+    });
+    assert.deepEqual(await api.getWorkerVersionModule(workerName, versionId), {
+        name: "module.js",
+        contentType: "application/javascript+module",
+        size: bytes.length,
+        sha256: createHash("sha256").update(bytes).digest("hex"),
+    });
+    assert.match(
+        requestedUrl,
+        new RegExp(`/content/v2\\?version=${versionId}$`)
+    );
+});
+
+test("exact Worker version module adapter rejects every ambiguous or auxiliary part", async (t) => {
+    const workerName = entries[0].policy.productionWorker;
+    const versionId = versionIdFor(0);
+    const moduleBytes = Buffer.from("export default { fetch() {} };\n");
+    const invoke = async ({ configure, entrypoint = "module.js" }) => {
+        const form = new FormData();
+        form.set(
+            "module.js",
+            new Blob([moduleBytes], {
+                type: "application/javascript+module",
+            }),
+            "module.js"
+        );
+        configure?.(form);
+        const api = createCloudflareWorkersApi({
+            accountId: ACCOUNT_ID,
+            apiToken: API_TOKEN,
+            request: async () =>
+                new Response(form, {
+                    headers: entrypoint ? { "cf-entrypoint": entrypoint } : {},
+                }),
+        });
+        return api.getWorkerVersionModule(workerName, versionId);
+    };
+
+    await t.test("missing cf-entrypoint", async () => {
+        await assert.rejects(
+            invoke({ entrypoint: "" }),
+            /no unambiguous exact Worker version entrypoint/
+        );
+    });
+    await t.test("auxiliary Wasm module", async () => {
+        await assert.rejects(
+            invoke({
+                configure: (form) =>
+                    form.set(
+                        "rogue.wasm",
+                        new Blob([Buffer.from([0, 97, 115, 109])], {
+                            type: "application/wasm",
+                        }),
+                        "rogue.wasm"
+                    ),
+            }),
+            /additional, missing, or malformed exact Worker version module/
+        );
+    });
+    await t.test("unexpected metadata part", async () => {
+        await assert.rejects(
+            invoke({
+                configure: (form) =>
+                    form.set(
+                        "metadata",
+                        JSON.stringify({ main_module: "module.js" })
+                    ),
+            }),
+            /additional, missing, or malformed exact Worker version module/
+        );
+    });
+    await t.test("wrong module MIME", async () => {
+        await assert.rejects(
+            invoke({
+                configure: (form) =>
+                    form.set(
+                        "module.js",
+                        new Blob([moduleBytes], {
+                            type: "application/javascript",
+                        }),
+                        "module.js"
+                    ),
+            }),
+            /additional, missing, or malformed exact Worker version module/
+        );
+    });
+});
+
+test("every provisioning mutation response failure is indeterminate", async (t) => {
+    const workerName = entries[0].policy.productionWorker;
+    const hostname = entries[0].policy.productionHostnames[0];
+    const adapters = [
+        {
+            name: "subdomain",
+            invoke: (api) => api.disableWorkerSubdomain(workerName),
+            invalidEvidence: {
+                success: true,
+                result: { enabled: true, previews_enabled: false },
+            },
+        },
+        {
+            name: "domain",
+            invoke: (api) => api.attachWorkerDomain({ workerName, hostname }),
+            invalidEvidence: {
+                success: true,
+                result: {
+                    id: "domain-stream",
+                    hostname,
+                    service: "wrong-worker",
+                    environment: "production",
+                    zone_id: ZONE_ID,
+                    zone_name: "peerbit.org",
+                },
+            },
+        },
+    ];
+    const responses = [
+        [
+            "well-formed 400",
+            () =>
+                new Response(
+                    JSON.stringify({
+                        success: false,
+                        errors: [{ code: 1000, message: "failed" }],
+                    }),
+                    { status: 400 }
+                ),
+        ],
+        [
+            "500",
+            () =>
+                new Response(
+                    JSON.stringify({
+                        success: false,
+                        errors: [{ code: 1000, message: "failed" }],
+                    }),
+                    { status: 500 }
+                ),
+        ],
+        ["malformed 200", () => new Response("{")],
+        ["empty 200", () => new Response("")],
+    ];
+    for (const adapter of adapters) {
+        await t.test(adapter.name, async (adapterTest) => {
+            for (const [name, response] of [
+                ...responses,
+                [
+                    "invalid exact evidence",
+                    () => new Response(JSON.stringify(adapter.invalidEvidence)),
+                ],
+            ]) {
+                await adapterTest.test(name, async () => {
+                    const api = createCloudflareWorkersApi({
+                        accountId: ACCOUNT_ID,
+                        apiToken: API_TOKEN,
+                        request: async () => response(),
+                    });
+                    await assert.rejects(adapter.invoke(api), (error) => {
+                        assert.ok(error instanceof CloudflareWorkersApiError);
+                        assert.equal(error.indeterminateMutation, true);
+                        return true;
+                    });
+                });
+            }
+            await adapterTest.test("transport failure", async () => {
+                const api = createCloudflareWorkersApi({
+                    accountId: ACCOUNT_ID,
+                    apiToken: API_TOKEN,
+                    request: async () => {
+                        throw new Error("connection lost");
+                    },
+                });
+                await assert.rejects(adapter.invoke(api), (error) => {
+                    assert.ok(error instanceof CloudflareWorkersApiError);
+                    assert.equal(error.indeterminateMutation, true);
+                    return true;
+                });
+            });
+        });
+    }
+});
+
+test("provisioning mutation local validation dispatches nothing", async () => {
+    let requests = 0;
+    const api = createCloudflareWorkersApi({
+        accountId: ACCOUNT_ID,
+        apiToken: API_TOKEN,
+        request: async () => {
+            requests += 1;
+            throw new Error("must not dispatch");
+        },
+    });
+    await assert.rejects(api.disableWorkerSubdomain("../wrong"));
+    await assert.rejects(
+        api.attachWorkerDomain({
+            workerName: entries[0].policy.productionWorker,
+            hostname: "files.apps.peerbit.org.",
+        })
+    );
+    assert.equal(requests, 0);
+});
+
+test("malformed account Worker identities fail closed", async () => {
+    const api = createCloudflareWorkersApi({
+        accountId: ACCOUNT_ID,
+        apiToken: API_TOKEN,
+        request: async () =>
+            new Response(
+                JSON.stringify({
+                    success: true,
+                    result: [
+                        {
+                            id: "../../not-a-worker",
+                            tag: "tag",
+                            routes: [],
+                        },
+                    ],
+                })
+            ),
+    });
+    await assert.rejects(api.listWorkerScripts(), (error) => {
+        assert.ok(error instanceof CloudflareWorkersApiError);
+        assert.equal(error.indeterminateMutation, false);
+        return true;
+    });
+});
+
+test("malformed Tail, Logpush, and Cron inventory responses fail closed", async (t) => {
+    for (const [name, result] of [
+        [
+            "Tail consumers",
+            [
+                {
+                    id: entries[0].policy.productionWorker,
+                    tag: "tag",
+                    routes: [],
+                    tail_consumers: {},
+                },
+            ],
+        ],
+        [
+            "Logpush",
+            [
+                {
+                    id: entries[0].policy.productionWorker,
+                    tag: "tag",
+                    routes: [],
+                    logpush: "yes",
+                },
+            ],
+        ],
+    ]) {
+        await t.test(name, async () => {
+            const api = createCloudflareWorkersApi({
+                accountId: ACCOUNT_ID,
+                apiToken: API_TOKEN,
+                request: async () =>
+                    new Response(JSON.stringify({ success: true, result })),
+            });
+            await assert.rejects(api.listWorkerScripts());
+        });
+    }
+    await t.test("Cron schedules", async () => {
+        const api = createCloudflareWorkersApi({
+            accountId: ACCOUNT_ID,
+            apiToken: API_TOKEN,
+            request: async () =>
+                new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: {
+                            schedules: [
+                                { cron: "* * * * *" },
+                                { cron: "* * * * *" },
+                            ],
+                        },
+                    })
+                ),
+        });
+        await assert.rejects(
+            api.listWorkerSchedules(entries[0].policy.productionWorker)
+        );
+    });
+});
+
+test("inspection exposes only exact policy-derived actions", async () => {
+    const harness = createHarness();
+    for (const entry of entries) {
+        harness.addPreview({ entry, enabled: true });
+    }
+    const inspection = await inspectProductionProvisioning({
+        entries,
+        configs,
+        artifacts,
+        expectedCommit: COMMIT,
+        operations: harness.operations,
+    });
+    assert.deepEqual(
+        inspection.plans.map(({ site, workerName, hostname }) => [
+            site.id,
+            workerName,
+            hostname,
+        ]),
+        entries.map(({ site, policy }) => [
+            site.id,
+            policy.productionWorker,
+            policy.productionHostnames[0],
+        ])
+    );
+    assert.deepEqual(
+        inspection.previewPlans.map(
+            ({ site, workerName, workerExists, actions }) => [
+                site.id,
+                workerName,
+                workerExists,
+                actions,
+            ]
+        ),
+        entries.map(({ site, policy }) => [
+            site.id,
+            policy.previewWorker,
+            true,
+            ["disable-public-subdomains"],
+        ])
+    );
+});

--- a/cloudflare/workflow-safety.test.mjs
+++ b/cloudflare/workflow-safety.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
@@ -9,6 +10,33 @@ const readWorkflow = (name) =>
 
 const previewWorkflow = readWorkflow("cloudflare-preview.yml");
 const productionWorkflow = readWorkflow("cloudflare-production.yml");
+const provisioningWorkflow = readWorkflow(
+    "cloudflare-production-provision.yml"
+);
+
+const receiptValidationScripts = () => {
+    const stepMarker =
+        "            - name: Validate SHA-bound dispatch receipt";
+    const runMarker = "              run: |\n";
+    return provisioningWorkflow
+        .split(stepMarker)
+        .slice(1)
+        .map((block) => {
+            const source = block.split(runMarker, 2)[1];
+            assert.equal(typeof source, "string");
+            const lines = [];
+            for (const line of source.split("\n")) {
+                if (line.startsWith("                  ")) {
+                    lines.push(line.slice(18));
+                } else if (line.length === 0) {
+                    lines.push("");
+                } else {
+                    break;
+                }
+            }
+            return lines.join("\n");
+        });
+};
 
 test("credentialed production shell receives target and commit through env", () => {
     assert.match(
@@ -33,7 +61,11 @@ test("credentialed production shell receives target and commit through env", () 
 });
 
 test("Cloudflare workflows carry no Supabase build configuration", () => {
-    for (const workflow of [previewWorkflow, productionWorkflow]) {
+    for (const workflow of [
+        previewWorkflow,
+        productionWorkflow,
+        provisioningWorkflow,
+    ]) {
         assert.doesNotMatch(workflow, /VITE_SUPABASE_/);
     }
 });
@@ -70,14 +102,317 @@ test("production deployment remains manually gated", () => {
 });
 
 test("locked Wrangler is installed before its source contract tests", () => {
-    for (const workflow of [previewWorkflow, productionWorkflow]) {
+    for (const workflow of [
+        previewWorkflow,
+        productionWorkflow,
+        provisioningWorkflow,
+    ]) {
         const install = workflow.indexOf(
-            "npm ci --ignore-scripts --no-audit --no-fund --prefix tools/wrangler"
+            "npm ci --no-audit --no-fund --prefix tools/wrangler"
+        );
+        const toolchain = workflow.indexOf(
+            "node scripts/validate-wrangler-toolchain.mjs"
         );
         const safetyTests = workflow.indexOf(
             "node --test cloudflare/*.test.mjs"
         );
         assert.ok(install >= 0);
-        assert.ok(safetyTests > install);
+        assert.ok(toolchain > install);
+        assert.ok(safetyTests > toolchain);
+    }
+});
+
+test("one-time provisioning is protected, explicit, and serialized with routine deploys", () => {
+    assert.match(provisioningWorkflow, /^on:\n\s+workflow_dispatch:/m);
+    assert.doesNotMatch(provisioningWorkflow, /^\s+(?:push|pull_request):/m);
+    assert.match(
+        provisioningWorkflow,
+        /planned_commit:\n\s+description:[^\n]+\n\s+required: true\n\s+type: string/
+    );
+    assert.match(
+        provisioningWorkflow,
+        /planned_state_digest:\n\s+description:[^\n]+\n\s+required: true\n\s+type: string/
+    );
+    assert.equal(
+        (
+            provisioningWorkflow.match(
+                /- name: Validate SHA-bound dispatch receipt/g
+            ) ?? []
+        ).length,
+        2
+    );
+    assert.match(provisioningWorkflow, /if: always\(\)/);
+    assert.match(
+        provisioningWorkflow,
+        /\[\[ ! "\$PROVISION_PLANNED_COMMIT" =~ \^\[0-9a-fA-F\]\{40\}\$ \]\]/
+    );
+    assert.match(
+        provisioningWorkflow,
+        /if \[\[ "\$planned_commit" != "\$checked_out_commit" \]\]/
+    );
+    assert.match(
+        provisioningWorkflow,
+        /"\$PROVISION_CONFIRM" != "\$confirmation"/
+    );
+    assert.match(
+        provisioningWorkflow,
+        /VALIDATE_RESULT: \$\{\{ needs\.validate\.result \}\}/
+    );
+    assert.equal(
+        (provisioningWorkflow.match(/ref: \$\{\{ github\.sha \}\}/g) ?? [])
+            .length,
+        2
+    );
+    assert.doesNotMatch(
+        provisioningWorkflow,
+        /inputs\.confirm == '(?:plan|provision)-peerbit-production'/
+    );
+    assert.match(provisioningWorkflow, /environment: cloudflare-production/);
+    assert.match(provisioningWorkflow, /group: cloudflare-examples-production/);
+    assert.match(
+        provisioningWorkflow,
+        /CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_PRODUCTION_API_TOKEN \}\}/
+    );
+    assert.match(
+        provisioningWorkflow,
+        /CLOUDFLARE_ACCOUNT_ID: \$\{\{ vars\.CLOUDFLARE_ACCOUNT_ID \}\}/
+    );
+    assert.match(provisioningWorkflow, /--mode "\$PROVISION_MODE"/);
+    assert.match(provisioningWorkflow, /--commit "\$PROVISION_COMMIT"/);
+    assert.match(
+        provisioningWorkflow,
+        /--planned-commit "\$PROVISION_PLANNED_COMMIT"/
+    );
+    assert.match(
+        provisioningWorkflow,
+        /--planned-state-digest "\$PROVISION_PLANNED_STATE_DIGEST"/
+    );
+    assert.match(provisioningWorkflow, /--confirm "\$PROVISION_CONFIRM"/);
+    assert.doesNotMatch(
+        provisioningWorkflow,
+        /--(?:mode|commit|planned-commit|planned-state-digest|confirm)[^\n]*\$\{\{/
+    );
+});
+
+test("both provisioning jobs reject adversarial commit receipts with a nonzero step", () => {
+    const commit = "a".repeat(40);
+    const otherCommit = "b".repeat(40);
+    const sentinel = "0".repeat(64);
+    const digest = "1".repeat(64);
+    const receiptScripts = receiptValidationScripts();
+    assert.equal(receiptScripts.length, 2);
+    const cases = [
+        {
+            name: "valid plan",
+            mode: "plan",
+            plannedCommit: commit,
+            checkedOutCommit: commit,
+            confirm: `plan-peerbit-production-${commit}`,
+            stateDigest: sentinel,
+            ref: "refs/heads/master",
+            succeeds: true,
+        },
+        {
+            name: "valid uppercase receipt",
+            mode: "apply",
+            plannedCommit: commit.toUpperCase(),
+            checkedOutCommit: commit,
+            confirm: `provision-peerbit-production-${commit}-${digest}`,
+            stateDigest: digest,
+            ref: "refs/heads/master",
+            succeeds: true,
+        },
+        {
+            name: "short receipt",
+            mode: "apply",
+            plannedCommit: commit.slice(0, 12),
+            checkedOutCommit: commit,
+            confirm: `provision-peerbit-production-${commit}`,
+            stateDigest: digest,
+            ref: "refs/heads/master",
+            succeeds: false,
+        },
+        {
+            name: "different planned commit",
+            mode: "apply",
+            plannedCommit: otherCommit,
+            checkedOutCommit: commit,
+            confirm: `provision-peerbit-production-${otherCommit}`,
+            stateDigest: digest,
+            ref: "refs/heads/master",
+            succeeds: false,
+        },
+        {
+            name: "generic confirmation",
+            mode: "apply",
+            plannedCommit: commit,
+            checkedOutCommit: commit,
+            confirm: "provision-peerbit-production",
+            stateDigest: digest,
+            ref: "refs/heads/master",
+            succeeds: false,
+        },
+        {
+            name: "plan with nonzero state receipt",
+            mode: "plan",
+            plannedCommit: commit,
+            checkedOutCommit: commit,
+            confirm: `plan-peerbit-production-${commit}`,
+            stateDigest: digest,
+            ref: "refs/heads/master",
+            succeeds: false,
+        },
+        {
+            name: "apply with plan sentinel",
+            mode: "apply",
+            plannedCommit: commit,
+            checkedOutCommit: commit,
+            confirm: `provision-peerbit-production-${commit}-${sentinel}`,
+            stateDigest: sentinel,
+            ref: "refs/heads/master",
+            succeeds: false,
+        },
+        {
+            name: "confirmation bound to another commit",
+            mode: "plan",
+            plannedCommit: commit,
+            checkedOutCommit: commit,
+            confirm: `plan-peerbit-production-${otherCommit}`,
+            stateDigest: sentinel,
+            ref: "refs/heads/master",
+            succeeds: false,
+        },
+        {
+            name: "non-master ref",
+            mode: "plan",
+            plannedCommit: commit,
+            checkedOutCommit: commit,
+            confirm: `plan-peerbit-production-${commit}`,
+            stateDigest: sentinel,
+            ref: "refs/heads/not-master",
+            succeeds: false,
+        },
+        {
+            name: "invalid mode",
+            mode: "destroy",
+            plannedCommit: commit,
+            checkedOutCommit: commit,
+            confirm: `plan-peerbit-production-${commit}`,
+            stateDigest: sentinel,
+            ref: "refs/heads/master",
+            succeeds: false,
+        },
+        {
+            name: "malformed checked-out commit",
+            mode: "plan",
+            plannedCommit: commit,
+            checkedOutCommit: "not-a-commit",
+            confirm: `plan-peerbit-production-${commit}`,
+            stateDigest: sentinel,
+            ref: "refs/heads/master",
+            succeeds: false,
+        },
+    ];
+
+    for (const [jobIndex, script] of receiptScripts.entries()) {
+        const jobName = jobIndex === 0 ? "validate" : "provision";
+        for (const input of cases) {
+            const result = spawnSync("bash", ["-c", script], {
+                encoding: "utf8",
+                env: {
+                    ...process.env,
+                    GITHUB_REF: input.ref,
+                    PROVISION_MODE: input.mode,
+                    PROVISION_CONFIRM: input.confirm,
+                    PROVISION_PLANNED_COMMIT: input.plannedCommit,
+                    PROVISION_PLANNED_STATE_DIGEST: input.stateDigest,
+                    PROVISION_COMMIT: input.checkedOutCommit,
+                },
+            });
+            assert.equal(
+                result.status === 0,
+                input.succeeds,
+                `${jobName}/${input.name}: ${result.stderr}`
+            );
+        }
+    }
+});
+
+test("one-time provisioning rebuilds exact bundles and never invokes Worker delete", () => {
+    assert.match(
+        provisioningWorkflow,
+        /node scripts\/render-cloudflare-configs\.mjs --mode production/
+    );
+    assert.match(provisioningWorkflow, /wrangler versions upload/);
+    assert.match(provisioningWorkflow, /--dry-run/);
+    assert.equal(
+        (
+            provisioningWorkflow.match(
+                /node scripts\/create-cloudflare-artifact-manifests\.mjs/g
+            ) ?? []
+        ).length,
+        2
+    );
+    assert.equal(
+        (
+            provisioningWorkflow.match(
+                /output="\$PWD\/\.wrangler-dry-run\/\$\(basename "\$config" \.jsonc\)"/g
+            ) ?? []
+        ).length,
+        2
+    );
+    assert.equal(
+        (provisioningWorkflow.match(/--outdir "\$output"/g) ?? []).length,
+        2
+    );
+    assert.match(
+        provisioningWorkflow,
+        /node scripts\/provision-cloudflare-production\.mjs/
+    );
+    assert.match(
+        provisioningWorkflow,
+        /Install Chromium for live baseline checks\n\s+if: inputs\.mode == 'apply'/
+    );
+    assert.doesNotMatch(
+        provisioningWorkflow,
+        /wrangler delete|workers\/scripts\/.*DELETE/
+    );
+    const lastManifest = provisioningWorkflow.lastIndexOf(
+        "node scripts/create-cloudflare-artifact-manifests.mjs"
+    );
+    const credentialedProvision = provisioningWorkflow.indexOf(
+        "CLOUDFLARE_API_TOKEN:"
+    );
+    assert.ok(lastManifest >= 0);
+    assert.ok(credentialedProvision > lastManifest);
+    assert.doesNotMatch(
+        provisioningWorkflow.slice(
+            provisioningWorkflow.indexOf(
+                "- name: Rebuild reviewed inputs without deployment credentials"
+            ),
+            credentialedProvision
+        ),
+        /CLOUDFLARE_API_TOKEN|CLOUDFLARE_ACCOUNT_ID/
+    );
+
+    const source = readFileSync(
+        path.join(repoRoot, "scripts/provision-cloudflare-production.mjs"),
+        "utf8"
+    );
+    assert.doesNotMatch(source, /method:\s*["']DELETE["']/);
+    assert.doesNotMatch(source, /wrangler["'],\s*\[[^\]]*["']delete["']/s);
+});
+
+test("every action in Cloudflare workflows is pinned to a full commit", () => {
+    for (const workflow of [
+        previewWorkflow,
+        productionWorkflow,
+        provisioningWorkflow,
+    ]) {
+        const uses = workflow.match(/^\s+-?\s*uses:\s*([^\s#]+)/gm) ?? [];
+        assert.ok(uses.length > 0);
+        for (const line of uses) {
+            assert.match(line, /@[0-9a-f]{40}$/i);
+        }
     }
 });

--- a/scripts/cloudflare-artifact-manifest.mjs
+++ b/scripts/cloudflare-artifact-manifest.mjs
@@ -1,0 +1,669 @@
+import { createHash } from "node:crypto";
+import {
+    lstatSync,
+    readFileSync,
+    readdirSync,
+    realpathSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { repoRoot } from "./cloudflare-deployment-policy.mjs";
+
+const FULL_GIT_COMMIT = /^[0-9a-f]{40}$/i;
+const SHA256 = /^[0-9a-f]{64}$/;
+const SAFE_SITE_ID = /^[a-z][a-z0-9-]*$/;
+const SAFE_WORKER_NAME = /^(?=.{1,63}$)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+const SAFE_RELATIVE_PATH = /^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[^\\\0]+$/;
+const MAX_FILES = 20_000;
+const WORKER_MODULE_CONTENT_TYPE = "application/javascript+module";
+const FORBIDDEN_AUXILIARY_MODULE_CONFIG_KEYS = Object.freeze([
+    "base_dir",
+    "data_blobs",
+    "preserve_file_names",
+    "python_modules",
+    "rules",
+    "text_blobs",
+    "unsafe",
+    "wasm_modules",
+]);
+
+export const CLOUDFLARE_ARTIFACT_DIRECTORY = path.join(
+    repoRoot,
+    ".wrangler-dry-run"
+);
+export const CLOUDFLARE_ARTIFACT_MANIFEST_FILE =
+    "deployment-artifact-manifest.json";
+export const CLOUDFLARE_ARTIFACT_PUBLIC_PATH =
+    "/peerbit-deployment-manifest.json";
+export const CLOUDFLARE_ARTIFACT_DIGEST_BINDING =
+    "PEERBIT_ARTIFACT_MANIFEST_SHA256";
+
+const canonicalize = (value) => {
+    if (Array.isArray(value)) return value.map(canonicalize);
+    if (value && typeof value === "object") {
+        return Object.fromEntries(
+            Object.keys(value)
+                .sort()
+                .map((key) => [key, canonicalize(value[key])])
+        );
+    }
+    return value;
+};
+
+const canonicalBytes = (value) =>
+    Buffer.from(`${JSON.stringify(canonicalize(value))}\n`, "utf8");
+
+const sameCanonicalValue = (left, right) =>
+    JSON.stringify(canonicalize(left)) === JSON.stringify(canonicalize(right));
+
+const deepFreeze = (value) => {
+    if (value && typeof value === "object" && !Object.isFrozen(value)) {
+        for (const child of Object.values(value)) deepFreeze(child);
+        Object.freeze(value);
+    }
+    return value;
+};
+
+const sha256 = (bytes) => createHash("sha256").update(bytes).digest("hex");
+
+const assertInside = (root, candidate, label) => {
+    const relative = path.relative(root, candidate);
+    if (
+        relative.length === 0 ||
+        relative.startsWith("..") ||
+        path.isAbsolute(relative)
+    ) {
+        throw new Error(`${label} must resolve inside ${root}`);
+    }
+    return candidate;
+};
+
+const resolveConfigPath = ({ configFile, value, label }) => {
+    if (typeof value !== "string" || value.length === 0) {
+        throw new Error(`${label} is missing`);
+    }
+    return assertInside(
+        repoRoot,
+        path.resolve(path.dirname(configFile), value),
+        label
+    );
+};
+
+const posixRelative = (root, file) => {
+    const relative = path.relative(root, file).split(path.sep).join("/");
+    if (!SAFE_RELATIVE_PATH.test(relative)) {
+        throw new Error(`Unsafe artifact path ${JSON.stringify(relative)}`);
+    }
+    return relative;
+};
+
+const fileRecord = (root, file, extra = {}) => {
+    const stat = lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+        throw new Error(
+            `Cloudflare artifact input must be a regular file: ${file}`
+        );
+    }
+    const bytes = readFileSync(file);
+    return {
+        path: posixRelative(root, file),
+        size: bytes.length,
+        sha256: sha256(bytes),
+        ...extra,
+    };
+};
+
+const walk = (root, directory = root) => {
+    const files = [];
+    for (const entry of readdirSync(directory, { withFileTypes: true }).sort(
+        (left, right) => left.name.localeCompare(right.name)
+    )) {
+        const file = path.join(directory, entry.name);
+        const stat = lstatSync(file);
+        if (stat.isSymbolicLink()) {
+            throw new Error(
+                `Cloudflare artifact inputs may not be symlinks: ${file}`
+            );
+        }
+        if (stat.isDirectory()) files.push(...walk(root, file));
+        else if (stat.isFile()) files.push(file);
+        else throw new Error(`Unsupported Cloudflare artifact input: ${file}`);
+    }
+    if (files.length > MAX_FILES) {
+        throw new Error(`Cloudflare artifact input exceeds ${MAX_FILES} files`);
+    }
+    return files;
+};
+
+const normalizeRouteFreeConfig = ({ renderedConfig, modulePath }) => {
+    if (
+        !renderedConfig ||
+        typeof renderedConfig !== "object" ||
+        Array.isArray(renderedConfig) ||
+        renderedConfig.workers_dev !== false ||
+        renderedConfig.preview_urls !== false ||
+        !Array.isArray(renderedConfig.routes) ||
+        renderedConfig.routes.length !== 1 ||
+        renderedConfig.vars?.[CLOUDFLARE_ARTIFACT_DIGEST_BINDING] != null
+    ) {
+        throw new Error(
+            "Artifact manifest requires an exact private production config without the reserved digest binding"
+        );
+    }
+    if (renderedConfig.upload_source_maps !== false) {
+        throw new Error(
+            "Artifact manifest requires Wrangler source-map upload to be explicitly disabled"
+        );
+    }
+    if (
+        renderedConfig.find_additional_modules != null &&
+        renderedConfig.find_additional_modules !== false
+    ) {
+        throw new Error(
+            "Artifact manifest forbids Wrangler auxiliary-module discovery"
+        );
+    }
+    for (const key of FORBIDDEN_AUXILIARY_MODULE_CONFIG_KEYS) {
+        if (key in renderedConfig) {
+            throw new Error(
+                `Artifact manifest forbids auxiliary-module setting ${key}`
+            );
+        }
+    }
+    const config = structuredClone(renderedConfig);
+    delete config.$schema;
+    delete config.routes;
+    delete config.route;
+    delete config.domains;
+    config.main = modulePath;
+    config.no_bundle = true;
+    // Wrangler defaults this to true when no_bundle is true. The reviewed
+    // applications intentionally upload one self-contained ES module, so the
+    // false value must be explicit and artifact-bound.
+    config.find_additional_modules = false;
+    if (!config.assets || typeof config.assets !== "object") {
+        throw new Error("Artifact manifest requires a static-assets directory");
+    }
+    config.assets.directory = "<reviewed-static-assets>";
+    return canonicalize(config);
+};
+
+const validateManifestShape = (manifest) => {
+    if (
+        !manifest ||
+        typeof manifest !== "object" ||
+        Array.isArray(manifest) ||
+        manifest.schema !== 1 ||
+        !SAFE_SITE_ID.test(manifest.site || "") ||
+        !SAFE_WORKER_NAME.test(manifest.worker || "") ||
+        !FULL_GIT_COMMIT.test(manifest.commit || "") ||
+        !manifest.deploymentConfig ||
+        typeof manifest.deploymentConfig !== "object" ||
+        !manifest.module ||
+        typeof manifest.module !== "object" ||
+        !SAFE_RELATIVE_PATH.test(manifest.module.path || "") ||
+        !Number.isSafeInteger(manifest.module.size) ||
+        manifest.module.size < 0 ||
+        !SHA256.test(manifest.module.sha256 || "") ||
+        manifest.module.contentType !== WORKER_MODULE_CONTENT_TYPE ||
+        !Array.isArray(manifest.assets) ||
+        manifest.assets.length === 0 ||
+        manifest.assets.length > MAX_FILES
+    ) {
+        throw new Error("Cloudflare deployment artifact manifest is malformed");
+    }
+    const paths = new Set();
+    for (const asset of manifest.assets) {
+        if (
+            !asset ||
+            typeof asset !== "object" ||
+            Array.isArray(asset) ||
+            !SAFE_RELATIVE_PATH.test(asset.path || "") ||
+            paths.has(asset.path) ||
+            !Number.isSafeInteger(asset.size) ||
+            asset.size < 0 ||
+            !SHA256.test(asset.sha256 || "") ||
+            typeof asset.public !== "boolean"
+        ) {
+            throw new Error(
+                "Cloudflare deployment artifact manifest has an invalid asset record"
+            );
+        }
+        paths.add(asset.path);
+    }
+    if (
+        !paths.has("release.json") ||
+        manifest.assets.find((asset) => asset.path === "release.json")
+            ?.public !== true
+    ) {
+        throw new Error(
+            "Cloudflare deployment artifact manifest must include public release.json"
+        );
+    }
+    return manifest;
+};
+
+const isPublicAsset = (relative) =>
+    !["_headers", "_redirects"].includes(path.posix.basename(relative));
+
+const findMainModule = (artifactDirectory) => {
+    const files = walk(artifactDirectory);
+    const nonRuntimeOutputs = new Set([
+        "README.md",
+        CLOUDFLARE_ARTIFACT_MANIFEST_FILE,
+    ]);
+    const candidates = files.filter(
+        (file) => !nonRuntimeOutputs.has(posixRelative(artifactDirectory, file))
+    );
+    if (candidates.length !== 1 || !/\.(?:m?js)$/.test(candidates[0])) {
+        throw new Error(
+            `Expected exactly one Wrangler runtime-module output in ${artifactDirectory}, found ${candidates.length}`
+        );
+    }
+    return candidates[0];
+};
+
+const readCanonicalManifest = (manifestFile) => {
+    const bytes = readFileSync(manifestFile);
+    let manifest;
+    try {
+        manifest = validateManifestShape(JSON.parse(bytes.toString("utf8")));
+    } catch (error) {
+        throw new Error(`${manifestFile}: ${error.message}`);
+    }
+    if (!bytes.equals(canonicalBytes(manifest))) {
+        throw new Error(`${manifestFile}: artifact manifest is not canonical`);
+    }
+    return { manifest, bytes, digest: sha256(bytes) };
+};
+
+const assetDirectoryFor = ({ configFile, renderedConfig }) => {
+    const directory = resolveConfigPath({
+        configFile,
+        value: renderedConfig.assets?.directory,
+        label: `${renderedConfig.name}: assets.directory`,
+    });
+    const canonical = realpathSync(directory);
+    assertInside(
+        repoRoot,
+        canonical,
+        `${renderedConfig.name}: assets.directory`
+    );
+    return canonical;
+};
+
+const manifestFileFor = (artifactDirectory) =>
+    path.join(artifactDirectory, CLOUDFLARE_ARTIFACT_MANIFEST_FILE);
+
+const servedManifestFileFor = (assetsDirectory) =>
+    path.join(assetsDirectory, CLOUDFLARE_ARTIFACT_PUBLIC_PATH.slice(1));
+
+const artifactDirectoryFor = ({ artifactRoot, siteId }) => {
+    const canonicalRoot = realpathSync(artifactRoot);
+    assertInside(repoRoot, canonicalRoot, "Cloudflare artifact root");
+    const candidate = path.join(artifactRoot, siteId);
+    const stat = lstatSync(candidate);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        throw new Error(
+            `${siteId}: artifact directory must be a real directory`
+        );
+    }
+    return assertInside(
+        canonicalRoot,
+        realpathSync(candidate),
+        `${siteId}: artifact directory`
+    );
+};
+
+export const createCloudflareArtifactManifest = ({
+    site,
+    policy,
+    configFile,
+    renderedConfig,
+    expectedCommit,
+    artifactRoot = CLOUDFLARE_ARTIFACT_DIRECTORY,
+}) => {
+    if (
+        site?.id !== policy?.id ||
+        renderedConfig?.name !== policy?.productionWorker ||
+        !FULL_GIT_COMMIT.test(expectedCommit || "")
+    ) {
+        throw new Error("Cloudflare artifact manifest identity is invalid");
+    }
+    const artifactDirectory = artifactDirectoryFor({
+        artifactRoot,
+        siteId: site.id,
+    });
+    const manifestFile = manifestFileFor(artifactDirectory);
+    rmSync(manifestFile, { force: true });
+    const moduleFile = findMainModule(artifactDirectory);
+    const assetsDirectory = assetDirectoryFor({ configFile, renderedConfig });
+    const servedManifestFile = servedManifestFileFor(assetsDirectory);
+    rmSync(servedManifestFile, { force: true });
+
+    const module = fileRecord(artifactDirectory, moduleFile, {
+        contentType: WORKER_MODULE_CONTENT_TYPE,
+    });
+    const assets = walk(assetsDirectory)
+        .map((file) => {
+            const relative = posixRelative(assetsDirectory, file);
+            return fileRecord(assetsDirectory, file, {
+                public: isPublicAsset(relative),
+            });
+        })
+        .sort((left, right) => left.path.localeCompare(right.path));
+    const manifest = validateManifestShape({
+        schema: 1,
+        site: site.id,
+        worker: policy.productionWorker,
+        commit: expectedCommit.toLowerCase(),
+        deploymentConfig: normalizeRouteFreeConfig({
+            renderedConfig,
+            modulePath: module.path,
+        }),
+        module,
+        assets,
+    });
+    const bytes = canonicalBytes(manifest);
+    writeFileSync(manifestFile, bytes, { mode: 0o444, flag: "wx" });
+    writeFileSync(servedManifestFile, bytes, { mode: 0o444, flag: "wx" });
+    return loadCloudflareArtifactManifest({
+        site,
+        policy,
+        configFile,
+        renderedConfig,
+        expectedCommit,
+        artifactRoot,
+    });
+};
+
+export const loadCloudflareArtifactManifest = ({
+    site,
+    policy,
+    configFile,
+    renderedConfig,
+    expectedCommit,
+    artifactRoot = CLOUDFLARE_ARTIFACT_DIRECTORY,
+}) => {
+    const artifactDirectory = artifactDirectoryFor({
+        artifactRoot,
+        siteId: site.id,
+    });
+    const manifestFile = manifestFileFor(artifactDirectory);
+    const { manifest, bytes, digest } = readCanonicalManifest(manifestFile);
+    if (
+        manifest.site !== site.id ||
+        manifest.worker !== policy.productionWorker ||
+        manifest.commit !== expectedCommit.toLowerCase()
+    ) {
+        throw new Error(
+            `${site.id}: artifact manifest identity does not match`
+        );
+    }
+    const expectedConfig = normalizeRouteFreeConfig({
+        renderedConfig,
+        modulePath: manifest.module.path,
+    });
+    if (!sameCanonicalValue(manifest.deploymentConfig, expectedConfig)) {
+        throw new Error(
+            `${site.id}: artifact manifest runtime/config does not match the reviewed config`
+        );
+    }
+    const moduleFile = assertInside(
+        artifactDirectory,
+        path.resolve(artifactDirectory, manifest.module.path),
+        `${site.id}: artifact module`
+    );
+    if (
+        realpathSync(findMainModule(artifactDirectory)) !==
+        realpathSync(moduleFile)
+    ) {
+        throw new Error(
+            `${site.id}: Wrangler dry-run output contains an unreviewed runtime module`
+        );
+    }
+    if (
+        !sameCanonicalValue(
+            fileRecord(artifactDirectory, moduleFile, {
+                contentType: WORKER_MODULE_CONTENT_TYPE,
+            }),
+            manifest.module
+        )
+    ) {
+        throw new Error(`${site.id}: reviewed main-module bytes changed`);
+    }
+    const assetsDirectory = assetDirectoryFor({ configFile, renderedConfig });
+    const servedManifestFile = servedManifestFileFor(assetsDirectory);
+    const actualAssets = walk(assetsDirectory)
+        .filter((file) => file !== servedManifestFile)
+        .map((file) => {
+            const relative = posixRelative(assetsDirectory, file);
+            return fileRecord(assetsDirectory, file, {
+                public: isPublicAsset(relative),
+            });
+        })
+        .sort((left, right) => left.path.localeCompare(right.path));
+    if (!sameCanonicalValue(actualAssets, manifest.assets)) {
+        throw new Error(`${site.id}: reviewed static-asset bytes changed`);
+    }
+    if (
+        !statSync(servedManifestFile).isFile() ||
+        !readFileSync(servedManifestFile).equals(bytes)
+    ) {
+        throw new Error(`${site.id}: served artifact manifest bytes changed`);
+    }
+    return Object.freeze({
+        siteId: site.id,
+        workerName: policy.productionWorker,
+        commit: manifest.commit,
+        digest,
+        manifest: deepFreeze(manifest),
+        manifestFile,
+        moduleFile,
+        assetsDirectory,
+    });
+};
+
+export const loadCloudflareArtifactManifestSet = ({
+    entries,
+    configs,
+    expectedCommit,
+    artifactRoot = CLOUDFLARE_ARTIFACT_DIRECTORY,
+}) =>
+    new Map(
+        entries.map(({ site, policy }) => {
+            const rendered = configs.get(site.id);
+            if (!rendered) {
+                throw new Error(
+                    `${site.id}: rendered production config is missing`
+                );
+            }
+            return [
+                site.id,
+                loadCloudflareArtifactManifest({
+                    site,
+                    policy,
+                    configFile: rendered.file,
+                    renderedConfig: rendered.config,
+                    expectedCommit,
+                    artifactRoot,
+                }),
+            ];
+        })
+    );
+
+export const revalidateCloudflareArtifactManifest = (artifact) => {
+    if (!artifact || !SHA256.test(artifact.digest || "")) {
+        throw new Error("Cloudflare artifact evidence is missing or malformed");
+    }
+    const { manifest, bytes, digest } = readCanonicalManifest(
+        artifact.manifestFile
+    );
+    if (
+        digest !== artifact.digest ||
+        !sameCanonicalValue(manifest, artifact.manifest)
+    ) {
+        throw new Error(`${artifact.siteId}: artifact manifest digest changed`);
+    }
+    if (
+        !readFileSync(servedManifestFileFor(artifact.assetsDirectory)).equals(
+            bytes
+        )
+    ) {
+        throw new Error(
+            `${artifact.siteId}: served artifact manifest bytes changed`
+        );
+    }
+    if (
+        realpathSync(findMainModule(path.dirname(artifact.manifestFile))) !==
+        realpathSync(artifact.moduleFile)
+    ) {
+        throw new Error(
+            `${artifact.siteId}: Wrangler dry-run output contains an unreviewed runtime module`
+        );
+    }
+    const module = fileRecord(
+        path.dirname(artifact.manifestFile),
+        artifact.moduleFile,
+        { contentType: WORKER_MODULE_CONTENT_TYPE }
+    );
+    if (!sameCanonicalValue(module, artifact.manifest.module)) {
+        throw new Error(
+            `${artifact.siteId}: reviewed main-module bytes changed`
+        );
+    }
+    const actualAssets = walk(artifact.assetsDirectory)
+        .filter(
+            (file) => file !== servedManifestFileFor(artifact.assetsDirectory)
+        )
+        .map((file) => {
+            const relative = posixRelative(artifact.assetsDirectory, file);
+            return fileRecord(artifact.assetsDirectory, file, {
+                public: isPublicAsset(relative),
+            });
+        })
+        .sort((left, right) => left.path.localeCompare(right.path));
+    if (!sameCanonicalValue(actualAssets, artifact.manifest.assets)) {
+        throw new Error(
+            `${artifact.siteId}: reviewed static-asset bytes changed`
+        );
+    }
+    return artifact;
+};
+
+export const validateCloudflareArtifactDeploymentConfig = ({
+    artifact,
+    renderedConfig,
+}) => {
+    if (!artifact?.manifest?.module) {
+        throw new Error("Cloudflare artifact evidence is missing or malformed");
+    }
+    const observed = normalizeRouteFreeConfig({
+        renderedConfig,
+        modulePath: artifact.manifest.module.path,
+    });
+    if (!sameCanonicalValue(observed, artifact.manifest.deploymentConfig)) {
+        throw new Error(
+            `${artifact.siteId}: reviewed route-free runtime/config changed`
+        );
+    }
+    return artifact;
+};
+
+export const artifactBoundVersionMessage = ({
+    siteId,
+    expectedCommit,
+    artifactManifestDigest,
+}) => {
+    if (
+        !SAFE_SITE_ID.test(siteId || "") ||
+        !FULL_GIT_COMMIT.test(expectedCommit || "") ||
+        !SHA256.test(artifactManifestDigest || "")
+    ) {
+        throw new Error("Artifact-bound Worker version identity is malformed");
+    }
+    return `peerbit-examples ${siteId} ${expectedCommit.toLowerCase()} artifact-sha256:${artifactManifestDigest}`;
+};
+
+export const validateActiveWorkerModule = ({ artifact, observed }) => {
+    const expected = artifact?.manifest?.module;
+    if (
+        !expected ||
+        !observed ||
+        typeof observed !== "object" ||
+        Array.isArray(observed) ||
+        observed.name !== path.posix.basename(expected.path) ||
+        observed.size !== expected.size ||
+        observed.sha256 !== expected.sha256 ||
+        observed.contentType !== expected.contentType
+    ) {
+        throw new Error(
+            `${artifact?.siteId ?? "unknown"}: exact Worker version module set does not match the reviewed artifact manifest`
+        );
+    }
+};
+
+const publicAssetUrl = (origin, relative) =>
+    `${origin}/${relative
+        .split("/")
+        .map((segment) => encodeURIComponent(segment))
+        .join("/")}`;
+
+export const verifyLiveCloudflareArtifact = async ({
+    origin,
+    artifact,
+    request = fetch,
+    concurrency = 6,
+}) => {
+    if (!Number.isSafeInteger(concurrency) || concurrency < 1) {
+        throw new Error("Live artifact verification concurrency is invalid");
+    }
+    revalidateCloudflareArtifactManifest(artifact);
+    const expectedManifest = readFileSync(artifact.manifestFile);
+    const manifestResponse = await request(
+        `${origin}${CLOUDFLARE_ARTIFACT_PUBLIC_PATH}`,
+        { redirect: "manual" }
+    );
+    if (manifestResponse.status !== 200) {
+        throw new Error(
+            `${origin}${CLOUDFLARE_ARTIFACT_PUBLIC_PATH}: HTTP ${manifestResponse.status}`
+        );
+    }
+    const liveManifest = Buffer.from(await manifestResponse.arrayBuffer());
+    if (
+        sha256(liveManifest) !== artifact.digest ||
+        !liveManifest.equals(expectedManifest)
+    ) {
+        throw new Error(`${origin}: live artifact manifest bytes do not match`);
+    }
+
+    const publicAssets = artifact.manifest.assets.filter(
+        (asset) => asset.public
+    );
+    let cursor = 0;
+    const workers = Array.from(
+        { length: Math.max(1, Math.min(concurrency, publicAssets.length)) },
+        async () => {
+            while (cursor < publicAssets.length) {
+                const asset = publicAssets[cursor++];
+                const url = publicAssetUrl(origin, asset.path);
+                const response = await request(url, { redirect: "manual" });
+                if (response.status !== 200) {
+                    throw new Error(`${url}: HTTP ${response.status}`);
+                }
+                const bytes = Buffer.from(await response.arrayBuffer());
+                if (
+                    bytes.length !== asset.size ||
+                    sha256(bytes) !== asset.sha256
+                ) {
+                    throw new Error(
+                        `${url}: live bytes do not match the reviewed artifact manifest`
+                    );
+                }
+            }
+        }
+    );
+    await Promise.all(workers);
+};

--- a/scripts/cloudflare-workers-api.mjs
+++ b/scripts/cloudflare-workers-api.mjs
@@ -1,5 +1,7 @@
+import { createHash } from "node:crypto";
+
 const CLOUDFLARE_ACCOUNT_ID = /^[0-9a-f]{32}$/i;
-const WORKER_NAME = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+const WORKER_NAME = /^(?=.{1,63}$)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
 const DNS_HOSTNAME =
     /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const VERSION_ID =
@@ -8,9 +10,27 @@ const CLOUDFLARE_API_BASE_URL = "https://api.cloudflare.com/client/v4";
 const CUSTOM_DOMAIN_PAGE_SIZE = 100;
 const MAX_CUSTOM_DOMAIN_PAGES = 1_000;
 const MAX_CUSTOM_DOMAIN_SNAPSHOT_ATTEMPTS = 3;
+const QUEUE_PAGE_SIZE = 100;
+const MAX_QUEUE_PAGES = 1_000;
+const MAX_QUEUE_SNAPSHOT_ATTEMPTS = 3;
+const CLOUDFLARE_RESOURCE_ID = /^(?=.{1,32}$)[A-Za-z0-9_-]+$/;
+const QUEUE_NAME = /^(?=.{1,63}$)[A-Za-z0-9_-]+$/;
+const MAX_DEPLOYABLE_WORKER_VERSIONS = 10_000;
 const WORKERS_DEV_REFERENCE =
     /(?<![a-z0-9-])(?:(?:[a-z][a-z0-9+.-]*:)?\/\/)?(?:[a-z0-9-]+\.)*workers\.dev(?:\.(?![a-z0-9-])|(?![a-z0-9.-]))(?::[0-9]+)?(?:[/?#][^\s<>"']*)?/gi;
 const WORKERS_DEV_REDACTION = "[REDACTED_WORKERS_DEV_REFERENCE]";
+
+const canonicalizeJson = (value) => {
+    if (Array.isArray(value)) return value.map(canonicalizeJson);
+    if (value && typeof value === "object") {
+        return Object.fromEntries(
+            Object.keys(value)
+                .sort()
+                .map((key) => [key, canonicalizeJson(value[key])])
+        );
+    }
+    return value;
+};
 
 const redactText = (value, secrets, { maxLength } = {}) => {
     const text = value instanceof Error ? value.message : String(value);
@@ -156,6 +176,7 @@ export const createCloudflareWorkersApi = ({
     }
     const scriptsUrl = `${CLOUDFLARE_API_BASE_URL}/accounts/${accountId}/workers/scripts`;
     const domainsUrl = `${CLOUDFLARE_API_BASE_URL}/accounts/${accountId}/workers/domains`;
+    const queuesUrl = `${CLOUDFLARE_API_BASE_URL}/accounts/${accountId}/queues`;
     const secrets = [apiToken, accountId];
     const call = async ({ operation, url, method = "GET", body }) => {
         let response;
@@ -218,6 +239,50 @@ export const createCloudflareWorkersApi = ({
         }
         return versionId;
     };
+    const parseSubdomainState = ({
+        result,
+        operation,
+        indeterminateMutation = false,
+    }) => {
+        const keys =
+            result && typeof result === "object" && !Array.isArray(result)
+                ? Object.keys(result).sort()
+                : [];
+        if (
+            keys.length !== 2 ||
+            keys[0] !== "enabled" ||
+            keys[1] !== "previews_enabled" ||
+            typeof result.enabled !== "boolean" ||
+            typeof result.previews_enabled !== "boolean"
+        ) {
+            invalidResult({
+                operation,
+                message:
+                    "Cloudflare returned invalid or ambiguous Worker subdomain state",
+                indeterminateMutation,
+            });
+        }
+        return {
+            enabled: result.enabled,
+            previewsEnabled: result.previews_enabled,
+        };
+    };
+    const readWorkerDeployments = async (
+        workerName,
+        operation = `read deployments for ${workerName}`
+    ) => {
+        const payload = await call({
+            operation,
+            url: `${workerResourceUrl(workerName)}/deployments`,
+        });
+        if (!Array.isArray(payload.result?.deployments)) {
+            invalidResult({
+                operation,
+                message: "Cloudflare returned an invalid deployment list",
+            });
+        }
+        return payload.result.deployments;
+    };
 
     return {
         listWorkerScripts: async () => {
@@ -238,13 +303,16 @@ export const createCloudflareWorkersApi = ({
             const scripts = new Map();
             for (const script of payload.result) {
                 if (
-                    typeof script?.id !== "string" ||
-                    script.id.length === 0 ||
+                    !WORKER_NAME.test(script?.id || "") ||
                     scripts.has(script.id) ||
                     (script.tag != null &&
                         (typeof script.tag !== "string" ||
                             script.tag.length === 0)) ||
-                    !Array.isArray(script.routes)
+                    !Array.isArray(script.routes) ||
+                    (script.tail_consumers != null &&
+                        !Array.isArray(script.tail_consumers)) ||
+                    (script.logpush != null &&
+                        typeof script.logpush !== "boolean")
                 ) {
                     throw new CloudflareWorkersApiError({
                         operation: "list account Worker scripts",
@@ -285,7 +353,12 @@ export const createCloudflareWorkersApi = ({
                         script: route.script,
                     });
                 }
-                scripts.set(script.id, { tag: script.tag, routes });
+                scripts.set(script.id, {
+                    tag: script.tag,
+                    routes,
+                    tailConsumers: structuredClone(script.tail_consumers ?? []),
+                    logpush: script.logpush ?? false,
+                });
             }
             return scripts;
         },
@@ -433,39 +506,396 @@ export const createCloudflareWorkersApi = ({
                 operation,
                 url: `${workerResourceUrl(workerName)}/subdomain`,
             });
+            return parseSubdomainState({ result: payload.result, operation });
+        },
+        listWorkerSchedules: async (workerName) => {
+            const operation = `list Cron Trigger schedules for ${workerName}`;
+            const payload = await call({
+                operation,
+                url: `${workerResourceUrl(workerName)}/schedules`,
+            });
             const result = payload.result;
             const keys =
                 result && typeof result === "object" && !Array.isArray(result)
                     ? Object.keys(result).sort()
                     : [];
             if (
-                keys.length !== 2 ||
-                keys[0] !== "enabled" ||
-                keys[1] !== "previews_enabled" ||
-                typeof result.enabled !== "boolean" ||
-                typeof result.previews_enabled !== "boolean"
+                keys.length !== 1 ||
+                keys[0] !== "schedules" ||
+                !Array.isArray(result.schedules)
             ) {
                 invalidResult({
                     operation,
                     message:
-                        "Cloudflare returned invalid or ambiguous Worker subdomain state",
+                        "Cloudflare returned an invalid Cron Trigger schedule list",
+                });
+            }
+            const crons = [];
+            const seen = new Set();
+            for (const schedule of result.schedules) {
+                if (
+                    !schedule ||
+                    typeof schedule !== "object" ||
+                    Array.isArray(schedule) ||
+                    typeof schedule.cron !== "string" ||
+                    schedule.cron.length === 0 ||
+                    seen.has(schedule.cron)
+                ) {
+                    invalidResult({
+                        operation,
+                        message:
+                            "Cloudflare returned an invalid or ambiguous Cron Trigger schedule",
+                    });
+                }
+                seen.add(schedule.cron);
+                crons.push(schedule.cron);
+            }
+            return crons.sort();
+        },
+        listQueueConsumerInventory: async () => {
+            const operation = "list account Queue consumer attachments";
+            const normalizeConsumer = ({ consumer, queueName }) => {
+                if (
+                    !consumer ||
+                    typeof consumer !== "object" ||
+                    Array.isArray(consumer) ||
+                    !CLOUDFLARE_RESOURCE_ID.test(consumer.consumer_id || "") ||
+                    !["worker", "http_pull"].includes(consumer.type) ||
+                    (consumer.queue_name != null &&
+                        consumer.queue_name !== queueName) ||
+                    (consumer.created_on != null &&
+                        (typeof consumer.created_on !== "string" ||
+                            Number.isNaN(Date.parse(consumer.created_on)))) ||
+                    (consumer.dead_letter_queue != null &&
+                        typeof consumer.dead_letter_queue !== "string") ||
+                    (consumer.settings != null &&
+                        (!consumer.settings ||
+                            typeof consumer.settings !== "object" ||
+                            Array.isArray(consumer.settings))) ||
+                    (consumer.type === "worker" &&
+                        !WORKER_NAME.test(consumer.script_name || "")) ||
+                    (consumer.type === "http_pull" &&
+                        consumer.script_name != null)
+                ) {
+                    invalidResult({
+                        operation,
+                        message:
+                            "Cloudflare returned an invalid Queue consumer attachment",
+                    });
+                }
+                return {
+                    consumerId: consumer.consumer_id,
+                    type: consumer.type,
+                    scriptName:
+                        consumer.type === "worker"
+                            ? consumer.script_name
+                            : null,
+                    queueName,
+                    deadLetterQueue: consumer.dead_letter_queue ?? "",
+                    // Cloudflare does not promise object-key order. Normalize
+                    // nested settings so two semantically identical complete
+                    // snapshots have one stable ledger representation.
+                    settings: canonicalizeJson(consumer.settings ?? {}),
+                };
+            };
+            const readSnapshot = async () => {
+                const queues = [];
+                const queueIds = new Set();
+                const queueNames = new Set();
+                let expectedTotalCount;
+                let expectedTotalPages;
+                let expectedPerPage;
+
+                for (let page = 1; page <= MAX_QUEUE_PAGES; page += 1) {
+                    const payload = await call({
+                        operation,
+                        url: `${queuesUrl}?page=${page}&per_page=${QUEUE_PAGE_SIZE}`,
+                    });
+                    const result = payload.result;
+                    const info = payload.result_info;
+                    const validInfo =
+                        Array.isArray(result) &&
+                        info &&
+                        typeof info === "object" &&
+                        Number.isSafeInteger(info.count) &&
+                        info.count >= 0 &&
+                        info.count === result.length &&
+                        Number.isSafeInteger(info.page) &&
+                        info.page === page &&
+                        Number.isSafeInteger(info.per_page) &&
+                        info.per_page > 0 &&
+                        info.count <= info.per_page &&
+                        Number.isSafeInteger(info.total_count) &&
+                        info.total_count >= 0 &&
+                        Number.isSafeInteger(info.total_pages) &&
+                        info.total_pages >= 0 &&
+                        info.total_pages <= MAX_QUEUE_PAGES &&
+                        (info.total_count === 0
+                            ? info.total_pages === 0 || info.total_pages === 1
+                            : info.total_pages ===
+                              Math.ceil(info.total_count / info.per_page)) &&
+                        page <= Math.max(info.total_pages, 1);
+                    if (!validInfo) {
+                        invalidResult({
+                            operation,
+                            message:
+                                "Cloudflare returned invalid or ambiguous Queue pagination",
+                        });
+                    }
+                    expectedTotalCount ??= info.total_count;
+                    expectedTotalPages ??= info.total_pages;
+                    expectedPerPage ??= info.per_page;
+                    if (
+                        info.total_count !== expectedTotalCount ||
+                        info.total_pages !== expectedTotalPages ||
+                        info.per_page !== expectedPerPage
+                    ) {
+                        invalidResult({
+                            operation,
+                            message:
+                                "Cloudflare Queue pagination changed while it was being read",
+                        });
+                    }
+
+                    for (const queue of result) {
+                        if (
+                            !queue ||
+                            typeof queue !== "object" ||
+                            Array.isArray(queue) ||
+                            !CLOUDFLARE_RESOURCE_ID.test(
+                                queue.queue_id || ""
+                            ) ||
+                            queueIds.has(queue.queue_id) ||
+                            !QUEUE_NAME.test(queue.queue_name || "") ||
+                            queueNames.has(queue.queue_name) ||
+                            !Number.isSafeInteger(
+                                queue.consumers_total_count
+                            ) ||
+                            queue.consumers_total_count < 0
+                        ) {
+                            invalidResult({
+                                operation,
+                                message:
+                                    "Cloudflare returned an invalid or ambiguous Queue identity",
+                            });
+                        }
+                        queueIds.add(queue.queue_id);
+                        queueNames.add(queue.queue_name);
+                        const consumerPayload = await call({
+                            operation,
+                            url: `${queuesUrl}/${encodeURIComponent(
+                                queue.queue_id
+                            )}/consumers`,
+                        });
+                        if (
+                            !Array.isArray(consumerPayload.result) ||
+                            consumerPayload.result.length !==
+                                queue.consumers_total_count
+                        ) {
+                            invalidResult({
+                                operation,
+                                message:
+                                    "Cloudflare returned an incomplete Queue consumer inventory",
+                            });
+                        }
+                        const consumerIds = new Set();
+                        const consumers = consumerPayload.result.map(
+                            (consumer) => {
+                                const normalized = normalizeConsumer({
+                                    consumer,
+                                    queueName: queue.queue_name,
+                                });
+                                if (consumerIds.has(normalized.consumerId)) {
+                                    invalidResult({
+                                        operation,
+                                        message:
+                                            "Cloudflare returned a duplicate Queue consumer identity",
+                                    });
+                                }
+                                consumerIds.add(normalized.consumerId);
+                                return normalized;
+                            }
+                        );
+                        queues.push({
+                            queueId: queue.queue_id,
+                            queueName: queue.queue_name,
+                            consumers: consumers.sort((left, right) =>
+                                left.consumerId.localeCompare(right.consumerId)
+                            ),
+                        });
+                    }
+                    if (page >= info.total_pages) break;
+                }
+                if (
+                    expectedTotalCount == null ||
+                    expectedTotalPages == null ||
+                    queues.length !== expectedTotalCount
+                ) {
+                    invalidResult({
+                        operation,
+                        message:
+                            "Cloudflare returned an incomplete account Queue inventory",
+                    });
+                }
+                return queues.sort((left, right) =>
+                    left.queueId.localeCompare(right.queueId)
+                );
+            };
+
+            let previousCanonicalSnapshot;
+            for (
+                let attempt = 1;
+                attempt <= MAX_QUEUE_SNAPSHOT_ATTEMPTS;
+                attempt += 1
+            ) {
+                const snapshot = await readSnapshot();
+                const canonicalSnapshot = JSON.stringify(snapshot);
+                if (canonicalSnapshot === previousCanonicalSnapshot) {
+                    return snapshot;
+                }
+                previousCanonicalSnapshot = canonicalSnapshot;
+            }
+            invalidResult({
+                operation,
+                message:
+                    "Cloudflare Queue consumer inventory did not remain stable across complete snapshots",
+            });
+        },
+        getWorkerVersionModule: async (workerName, versionId) => {
+            const validVersionId = requireVersionId(versionId);
+            const operation = `download exact Worker version module for ${workerName} ${validVersionId}`;
+            const url = `${workerResourceUrl(workerName)}/content/v2?version=${encodeURIComponent(validVersionId)}`;
+            let response;
+            try {
+                response = await request(url, {
+                    headers: { Authorization: `Bearer ${apiToken}` },
+                    signal: AbortSignal.timeout(15_000),
+                });
+            } catch (cause) {
+                throw new CloudflareWorkersApiError({
+                    operation,
+                    cause,
+                    secrets,
+                });
+            }
+            if (!response.ok) {
+                await parseResponse({ response, operation, secrets });
+            }
+            if (
+                !response.headers
+                    .get("content-type")
+                    ?.toLowerCase()
+                    .startsWith("multipart/form-data")
+            ) {
+                invalidResult({
+                    operation,
+                    message:
+                        "Cloudflare returned non-multipart exact Worker version content",
+                });
+            }
+            const mainModule = response.headers.get("cf-entrypoint");
+            if (
+                typeof mainModule !== "string" ||
+                mainModule.length === 0 ||
+                mainModule.length > 255
+            ) {
+                invalidResult({
+                    operation,
+                    message:
+                        "Cloudflare returned no unambiguous exact Worker version entrypoint",
+                });
+            }
+            let form;
+            try {
+                form = await response.formData();
+            } catch {
+                invalidResult({
+                    operation,
+                    message:
+                        "Cloudflare returned malformed exact Worker version multipart content",
+                });
+            }
+            const parts = [...form.entries()];
+            if (
+                !WORKER_NAME.test(workerName || "") ||
+                parts.length !== 1 ||
+                parts[0][0] !== mainModule ||
+                typeof parts[0][1] === "string" ||
+                typeof parts[0][1]?.arrayBuffer !== "function" ||
+                parts[0][1].name !== mainModule ||
+                parts[0][1].type !== "application/javascript+module"
+            ) {
+                invalidResult({
+                    operation,
+                    message:
+                        "Cloudflare returned an additional, missing, or malformed exact Worker version module",
+                });
+            }
+            let bytes;
+            try {
+                bytes = Buffer.from(await parts[0][1].arrayBuffer());
+            } catch {
+                invalidResult({
+                    operation,
+                    message:
+                        "Cloudflare exact Worker version module bytes could not be read",
                 });
             }
             return {
-                enabled: result.enabled,
-                previewsEnabled: result.previews_enabled,
+                name: mainModule,
+                contentType: parts[0][1].type,
+                size: bytes.length,
+                sha256: createHash("sha256").update(bytes).digest("hex"),
             };
+        },
+        getWorkerDeployments: readWorkerDeployments,
+        listDeployableWorkerVersions: async (workerName) => {
+            const operation = `list deployable Worker versions for ${workerName}`;
+            const payload = await call({
+                operation,
+                url: `${workerResourceUrl(workerName)}/versions?deployable=true`,
+            });
+            const items = payload.result?.items;
+            if (
+                !Array.isArray(items) ||
+                items.length > MAX_DEPLOYABLE_WORKER_VERSIONS
+            ) {
+                invalidResult({
+                    operation,
+                    message:
+                        "Cloudflare returned an invalid deployable Worker version list",
+                });
+            }
+            const versionIds = [];
+            const seen = new Set();
+            for (const item of items) {
+                if (
+                    !item ||
+                    typeof item !== "object" ||
+                    !VERSION_ID.test(item.id || "") ||
+                    seen.has(item.id)
+                ) {
+                    invalidResult({
+                        operation,
+                        message:
+                            "Cloudflare returned an invalid or ambiguous deployable Worker version identity",
+                    });
+                }
+                seen.add(item.id);
+                versionIds.push(item.id);
+            }
+            return versionIds;
         },
         getCurrentDeployment: async (workerName) => {
             const operation = `read active deployment for ${workerName}`;
-            const payload = await call({
-                operation,
-                url: `${workerResourceUrl(workerName)}/deployments`,
-            });
+            const deployments = await readWorkerDeployments(
+                workerName,
+                operation
+            );
             if (
-                !Array.isArray(payload.result?.deployments) ||
-                !payload.result.deployments[0] ||
-                typeof payload.result.deployments[0] !== "object"
+                !deployments[0] ||
+                typeof deployments[0] !== "object" ||
+                Array.isArray(deployments[0])
             ) {
                 invalidResult({
                     operation,
@@ -475,7 +905,7 @@ export const createCloudflareWorkersApi = ({
             // Cloudflare documents the first item as the deployment actively
             // serving traffic. Returning only it prevents callers from
             // accidentally treating an older history item as current.
-            return payload.result.deployments[0];
+            return deployments[0];
         },
         getWorkerVersion: async (workerName, versionId) => {
             const validVersionId = requireVersionId(versionId);
@@ -540,6 +970,86 @@ export const createCloudflareWorkersApi = ({
                 });
             }
             return result;
+        },
+        disableWorkerSubdomain: async (workerName) => {
+            const operation = `disable workers.dev and Preview URLs for ${workerName}`;
+            const payload = await call({
+                operation,
+                url: `${workerResourceUrl(workerName)}/subdomain`,
+                method: "POST",
+                body: { enabled: false, previews_enabled: false },
+            });
+            const state = parseSubdomainState({
+                result: payload.result,
+                operation,
+                indeterminateMutation: true,
+            });
+            if (state.enabled || state.previewsEnabled) {
+                invalidResult({
+                    operation,
+                    message:
+                        "Cloudflare did not confirm disabled Worker subdomain state",
+                    indeterminateMutation: true,
+                });
+            }
+            return state;
+        },
+        attachWorkerDomain: async ({ workerName, hostname }) => {
+            if (!WORKER_NAME.test(workerName || "")) {
+                throw new Error(
+                    "Cloudflare Worker name is missing or malformed"
+                );
+            }
+            if (
+                typeof hostname !== "string" ||
+                hostname !== hostname.toLowerCase() ||
+                hostname.trim() !== hostname ||
+                !DNS_HOSTNAME.test(hostname)
+            ) {
+                throw new Error(
+                    "Cloudflare custom domain hostname is missing or malformed"
+                );
+            }
+            const operation = `attach reviewed custom domain ${hostname} to ${workerName}`;
+            const payload = await call({
+                operation,
+                url: domainsUrl,
+                method: "PUT",
+                body: {
+                    hostname,
+                    service: workerName,
+                    environment: "production",
+                },
+            });
+            const result = payload.result;
+            if (
+                !result ||
+                typeof result !== "object" ||
+                Array.isArray(result) ||
+                typeof result.id !== "string" ||
+                result.id.length === 0 ||
+                result.hostname !== hostname ||
+                result.service !== workerName ||
+                result.environment !== "production" ||
+                !CLOUDFLARE_ACCOUNT_ID.test(result.zone_id || "") ||
+                typeof result.zone_name !== "string" ||
+                result.zone_name.length === 0
+            ) {
+                invalidResult({
+                    operation,
+                    message:
+                        "Cloudflare returned invalid custom-domain attachment evidence",
+                    indeterminateMutation: true,
+                });
+            }
+            return {
+                id: result.id,
+                hostname: result.hostname,
+                service: result.service,
+                environment: result.environment,
+                zoneId: result.zone_id,
+                zoneName: result.zone_name.toLowerCase(),
+            };
         },
     };
 };

--- a/scripts/create-cloudflare-artifact-manifests.mjs
+++ b/scripts/create-cloudflare-artifact-manifests.mjs
@@ -1,0 +1,45 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import {
+    loadCloudflareDeploymentData,
+    repoRoot,
+    validateRenderedCloudflareConfigSet,
+} from "./cloudflare-deployment-policy.mjs";
+import {
+    CLOUDFLARE_ARTIFACT_DIRECTORY,
+    createCloudflareArtifactManifest,
+} from "./cloudflare-artifact-manifest.mjs";
+
+const expectedCommit = (
+    process.env.COMMIT_HASH ||
+    execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: repoRoot,
+        encoding: "utf8",
+    })
+).trim();
+
+if (!/^[0-9a-f]{40}$/i.test(expectedCommit)) {
+    throw new Error("Cloudflare artifact manifests require a full Git commit");
+}
+
+const { entries } = loadCloudflareDeploymentData();
+const configs = validateRenderedCloudflareConfigSet({
+    directory: path.join(repoRoot, ".wrangler-config"),
+    entries,
+    mode: "production",
+});
+
+for (const { site, policy } of entries) {
+    const rendered = configs.get(site.id);
+    const artifact = createCloudflareArtifactManifest({
+        site,
+        policy,
+        configFile: rendered.file,
+        renderedConfig: rendered.config,
+        expectedCommit,
+        artifactRoot: CLOUDFLARE_ARTIFACT_DIRECTORY,
+    });
+    console.log(
+        `${site.id}: ARTIFACT_MANIFEST_SHA256=${artifact.digest} (${artifact.manifest.assets.length} asset inputs)`
+    );
+}

--- a/scripts/deploy-cloudflare-production.mjs
+++ b/scripts/deploy-cloudflare-production.mjs
@@ -24,6 +24,12 @@ import {
     isIndeterminateCloudflareMutationError,
     redactCloudflareCredentials,
 } from "./cloudflare-workers-api.mjs";
+import {
+    CLOUDFLARE_ARTIFACT_DIGEST_BINDING,
+    artifactBoundVersionMessage,
+    revalidateCloudflareArtifactManifest,
+    validateCloudflareArtifactDeploymentConfig,
+} from "./cloudflare-artifact-manifest.mjs";
 
 const VERSION_ID =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -207,7 +213,7 @@ export const createInvocationVersionTag = ({
     return tag;
 };
 
-const readWorkerScriptMap = async (operations) => {
+export const readWorkerScriptMap = async (operations) => {
     const scripts = await operations.listWorkerScripts();
     if (
         !(scripts instanceof Map) ||
@@ -240,7 +246,7 @@ const readWorkerScriptMap = async (operations) => {
     return scripts;
 };
 
-const readWorkerDomainInventory = async (operations) => {
+export const readWorkerDomainInventory = async (operations) => {
     const domains = await operations.listWorkerDomains();
     const ids = new Set();
     const hostnames = new Set();
@@ -296,7 +302,11 @@ const routeTargetsManagedAppHostname = (pattern) => {
     return managedAppHostname(authority);
 };
 
-const validateProductionAttachmentInventory = ({ plans, scripts, domains }) => {
+export const validateProductionAttachmentInventory = ({
+    plans,
+    scripts,
+    domains,
+}) => {
     const expectedByHostname = new Map();
     const policyWorkerNames = new Set();
     for (const plan of plans) {
@@ -423,7 +433,7 @@ const validateProductionAttachmentInventory = ({ plans, scripts, domains }) => {
     }
 };
 
-const readAndValidateWorkerSubdomains = async ({
+export const readAndValidateWorkerSubdomains = async ({
     plans,
     scripts,
     operations,
@@ -459,7 +469,7 @@ const readAndValidateWorkerSubdomains = async ({
     }
 };
 
-const readAndValidateProductionAttachments = async ({
+export const readAndValidateProductionAttachments = async ({
     plans,
     operations,
     scripts: providedScripts,
@@ -471,7 +481,7 @@ const readAndValidateProductionAttachments = async ({
     return scripts;
 };
 
-const productionWorkerConfig = ({ site, policy, configs }) => {
+export const productionWorkerConfig = ({ site, policy, configs }) => {
     if (policy.id !== site.id) {
         throw new Error(
             `${site.id}: Cloudflare policy identity does not match site`
@@ -1356,6 +1366,7 @@ export const createRouteFreeWranglerConfig = ({
     configFile,
     renderedConfig,
     workerName,
+    artifact,
     root = repoRoot,
 }) => {
     if (
@@ -1394,7 +1405,29 @@ export const createRouteFreeWranglerConfig = ({
     const privateConfig = structuredClone(renderedConfig);
     delete privateConfig.$schema;
     delete privateConfig.routes;
-    if ("main" in privateConfig) {
+    if (artifact) {
+        revalidateCloudflareArtifactManifest(artifact);
+        validateCloudflareArtifactDeploymentConfig({
+            artifact,
+            renderedConfig,
+        });
+        if (
+            artifact.workerName !== workerName ||
+            artifact.siteId == null ||
+            artifact.manifest?.deploymentConfig?.name !== workerName
+        ) {
+            throw new Error(
+                `${workerName}: reviewed deployment artifact identity is invalid`
+            );
+        }
+        privateConfig.main = artifact.moduleFile;
+        privateConfig.no_bundle = true;
+        privateConfig.find_additional_modules = false;
+        privateConfig.vars = {
+            ...(privateConfig.vars ?? {}),
+            [CLOUDFLARE_ARTIFACT_DIGEST_BINDING]: artifact.digest,
+        };
+    } else if ("main" in privateConfig) {
         privateConfig.main = resolveTemporaryConfigPath({
             configFile,
             value: privateConfig.main,
@@ -1430,6 +1463,7 @@ export const runWranglerVersionUpload = ({
     expectedCommit,
     workerName,
     versionTag,
+    artifact,
     environment = deploymentEnvironment,
     runtime = {},
 }) => {
@@ -1453,10 +1487,12 @@ export const runWranglerVersionUpload = ({
     const privateConfigFile = path.join(outputDirectory, "deploy.json");
     const outputFile = path.join(outputDirectory, "deploy.ndjson");
     try {
+        if (artifact) revalidateCloudflareArtifactManifest(artifact);
         const privateConfig = createRouteFreeWranglerConfig({
             configFile,
             renderedConfig,
             workerName,
+            artifact,
         });
         writeTemporaryConfig(
             privateConfigFile,
@@ -1477,10 +1513,17 @@ export const runWranglerVersionUpload = ({
                     "--config",
                     privateConfigFile,
                     "--strict",
+                    ...(artifact ? ["--no-bundle"] : []),
                     "--tag",
                     versionTag,
                     "--message",
-                    `peerbit-examples ${site.id} ${expectedCommit}`,
+                    artifact
+                        ? artifactBoundVersionMessage({
+                              siteId: site.id,
+                              expectedCommit,
+                              artifactManifestDigest: artifact.digest,
+                          })
+                        : `peerbit-examples ${site.id} ${expectedCommit}`,
                 ],
                 {
                     ...environment,
@@ -1509,6 +1552,9 @@ export const runWranglerVersionUpload = ({
                 outputExists(outputFile) ? readOutput(outputFile, "utf8") : "",
                 workerName
             );
+            if (artifact) {
+                deploymentEvidence.artifactManifestDigest = artifact.digest;
+            }
         } catch (error) {
             if (!commandError) throw error;
         }

--- a/scripts/provision-cloudflare-production.mjs
+++ b/scripts/provision-cloudflare-production.mjs
@@ -1,0 +1,2484 @@
+import { spawnSync } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    APP_PRODUCTION_SUFFIX,
+    CLOUDFLARE_WORKER_NAMESPACE_PREFIX,
+    loadCloudflareDeploymentData,
+    repoRoot,
+    validateRenderedCloudflareConfig,
+    validateRenderedCloudflareConfigSet,
+} from "./cloudflare-deployment-policy.mjs";
+import {
+    createCloudflareWorkersApi,
+    redactCloudflareCredentials,
+} from "./cloudflare-workers-api.mjs";
+import {
+    productionWorkerConfig,
+    productionSmokeEnvironment,
+    readAndValidateProductionAttachments,
+    readSingleVersionDeployment,
+    readWorkerDomainInventory,
+    readWorkerScriptMap,
+    runWranglerVersionUpload,
+    withoutCloudflareDeploymentCredentials,
+} from "./deploy-cloudflare-production.mjs";
+import {
+    CLOUDFLARE_ARTIFACT_DIGEST_BINDING,
+    artifactBoundVersionMessage,
+    loadCloudflareArtifactManifestSet,
+    validateActiveWorkerModule,
+} from "./cloudflare-artifact-manifest.mjs";
+
+const FULL_GIT_COMMIT = /^[0-9a-f]{40}$/i;
+const CLOUDFLARE_ACCOUNT_ID = /^[0-9a-f]{32}$/i;
+const VERSION_ID =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const VERSION_TAG = /^[A-Za-z0-9_-]{1,100}$/;
+const INVOCATION_NONCE = /^[0-9a-f]{32}$/;
+const STATE_DIGEST = /^[0-9a-f]{64}$/;
+const WORKER_NAME = /^(?=.{1,63}$)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+const MAX_DIAGNOSTIC_LENGTH = 2_000;
+const RETIRED_LEGACY_WORKER = "peerbit-examples-legacy-stream-preview";
+
+export const PROVISIONING_CONFIRMATION_PREFIXES = Object.freeze({
+    plan: "plan-peerbit-production",
+    apply: "provision-peerbit-production",
+});
+
+export const PROVISIONING_PLAN_STATE_SENTINEL = "0".repeat(64);
+
+export const productionProvisioningConfirmation = ({
+    mode,
+    plannedCommit,
+    plannedStateDigest,
+}) => {
+    if (mode !== "plan" && mode !== "apply") {
+        throw new Error("Provisioning mode must be plan or apply");
+    }
+    if (!FULL_GIT_COMMIT.test(plannedCommit || "")) {
+        throw new Error(
+            "Provisioning requires an explicit full planned commit receipt"
+        );
+    }
+    if (mode === "apply" && !STATE_DIGEST.test(plannedStateDigest || "")) {
+        throw new Error(
+            "Apply requires the exact SHA-256 state digest emitted by the reviewed plan"
+        );
+    }
+    return `${PROVISIONING_CONFIRMATION_PREFIXES[mode]}-${plannedCommit.toLowerCase()}${
+        mode === "apply" ? `-${plannedStateDigest.toLowerCase()}` : ""
+    }`;
+};
+
+const REVIEWED_PROVISIONING_TARGETS = Object.freeze([
+    [
+        "stream",
+        "peerbit-examples-stream",
+        "stream.apps.peerbit.org",
+        "peerbit-examples-stream-preview",
+    ],
+    [
+        "music",
+        "peerbit-examples-music",
+        "music.apps.peerbit.org",
+        "peerbit-examples-music-preview",
+    ],
+    [
+        "chat",
+        "peerbit-examples-chat",
+        "chat.apps.peerbit.org",
+        "peerbit-examples-chat-preview",
+    ],
+    [
+        "ml",
+        "peerbit-examples-ml",
+        "ml.apps.peerbit.org",
+        "peerbit-examples-ml-preview",
+    ],
+    [
+        "text",
+        "peerbit-examples-text",
+        "text.apps.peerbit.org",
+        "peerbit-examples-text-preview",
+    ],
+    [
+        "files",
+        "peerbit-examples-files",
+        "files.apps.peerbit.org",
+        "peerbit-examples-files-preview",
+    ],
+    [
+        "chess",
+        "peerbit-examples-chess",
+        "chess.apps.peerbit.org",
+        "peerbit-examples-chess-preview",
+    ],
+]);
+
+const expectedVersionMessage = ({
+    siteId,
+    expectedCommit,
+    artifactManifestDigest,
+}) =>
+    artifactBoundVersionMessage({
+        siteId,
+        expectedCommit,
+        artifactManifestDigest,
+    });
+
+export const createProvisioningVersionTag = ({
+    siteId,
+    expectedCommit,
+    invocationNonce,
+}) => {
+    if (!/^[a-z][a-z0-9-]*$/.test(siteId || "")) {
+        throw new Error("Provisioning site identity is missing or malformed");
+    }
+    if (!FULL_GIT_COMMIT.test(expectedCommit || "")) {
+        throw new Error("Provisioning requires a full Git commit hash");
+    }
+    if (!INVOCATION_NONCE.test(invocationNonce || "")) {
+        throw new Error(
+            `${siteId}: provisioning invocation nonce is missing or malformed`
+        );
+    }
+    const tag = `peerbit_bootstrap_${siteId}_${expectedCommit
+        .toLowerCase()
+        .slice(0, 12)}_${invocationNonce}`;
+    if (!VERSION_TAG.test(tag)) {
+        throw new Error(`${siteId}: provisioning version tag is malformed`);
+    }
+    return tag;
+};
+
+const validateProvisioningEntries = (entries) => {
+    if (!Array.isArray(entries)) {
+        throw new Error("Production provisioning policy is missing");
+    }
+    const actual = entries.map(({ site, policy }) => [
+        site?.id,
+        policy?.productionWorker,
+        Array.isArray(policy?.productionHostnames) &&
+        policy.productionHostnames.length === 1
+            ? policy.productionHostnames[0]
+            : undefined,
+        policy?.previewWorker,
+    ]);
+    if (
+        JSON.stringify(actual) !== JSON.stringify(REVIEWED_PROVISIONING_TARGETS)
+    ) {
+        throw new Error(
+            "Production provisioning targets no longer exactly match the reviewed seven-application allowlist"
+        );
+    }
+    if (
+        entries.some(
+            ({ site, policy }) =>
+                policy.kind !== "app" ||
+                policy.id !== site.id ||
+                site.worker !== policy.productionWorker ||
+                !Array.isArray(site.domains) ||
+                site.domains.length !== 1 ||
+                site.domains[0] !== policy.productionHostnames[0]
+        )
+    ) {
+        throw new Error(
+            "Production provisioning requires seven exact app policy entries"
+        );
+    }
+    const productionWorkers = new Set(
+        entries.map(({ policy }) => policy.productionWorker)
+    );
+    const previewWorkers = entries.map(({ policy }) => policy.previewWorker);
+    if (
+        new Set(previewWorkers).size !== entries.length ||
+        previewWorkers.some(
+            (workerName) =>
+                !WORKER_NAME.test(workerName || "") ||
+                !workerName.startsWith(CLOUDFLARE_WORKER_NAMESPACE_PREFIX) ||
+                productionWorkers.has(workerName)
+        )
+    ) {
+        throw new Error(
+            "Production provisioning requires seven unique reviewed preview Worker identities"
+        );
+    }
+    return entries;
+};
+
+const managedAppHostname = (hostname) =>
+    hostname === APP_PRODUCTION_SUFFIX.slice(1) ||
+    hostname.endsWith(APP_PRODUCTION_SUFFIX);
+
+const routeTargetsManagedAppHostname = (pattern) => {
+    const authority = pattern
+        .trim()
+        .toLowerCase()
+        .replace(/^[a-z]+:\/\//, "")
+        .split("/", 1)[0]
+        .replace(/:\d+$/, "")
+        .replace(/\.$/, "")
+        .replace(/^\*+/, "");
+    return managedAppHostname(authority);
+};
+
+const validateProvisioningAttachmentInventory = ({
+    entries,
+    scripts,
+    domains,
+}) => {
+    const expectedByHostname = new Map();
+    const expectedProductionWorkers = new Set();
+    const expectedPreviewWorkers = new Set();
+    for (const { policy } of entries) {
+        expectedProductionWorkers.add(policy.productionWorker);
+        expectedPreviewWorkers.add(policy.previewWorker);
+        expectedByHostname.set(
+            policy.productionHostnames[0],
+            policy.productionWorker
+        );
+    }
+    const policyWorkers = new Set([
+        ...expectedProductionWorkers,
+        ...expectedPreviewWorkers,
+    ]);
+
+    for (const [workerName, metadata] of scripts) {
+        const inManagedNamespace = workerName.startsWith(
+            CLOUDFLARE_WORKER_NAMESPACE_PREFIX
+        );
+        if (inManagedNamespace && !policyWorkers.has(workerName)) {
+            if (workerName === RETIRED_LEGACY_WORKER) {
+                throw new Error(
+                    `${RETIRED_LEGACY_WORKER} still exists; provisioning is blocked until the separate retired-Worker cleanup plan is reviewed and executed`
+                );
+            }
+            throw new Error(
+                `Cloudflare has an unreviewed Worker identity ${workerName} inside the managed namespace`
+            );
+        }
+        const managedRoutes = metadata.routes.filter(({ pattern }) =>
+            routeTargetsManagedAppHostname(pattern)
+        );
+        if (
+            metadata.routes.length > 0 &&
+            (inManagedNamespace ||
+                policyWorkers.has(workerName) ||
+                managedRoutes.length > 0)
+        ) {
+            throw new Error(
+                `${workerName} has unreviewed traditional Worker route attachments`
+            );
+        }
+        if (
+            (metadata.tailConsumers?.length ?? 0) > 0 ||
+            metadata.logpush === true
+        ) {
+            throw new Error(
+                `${workerName} has unreviewed Tail Worker consumers or Logpush enabled`
+            );
+        }
+        if (
+            !Array.isArray(metadata.tailConsumers ?? []) ||
+            typeof (metadata.logpush ?? false) !== "boolean"
+        ) {
+            throw new Error(
+                `${workerName} has invalid or ambiguous non-versioned attachment metadata`
+            );
+        }
+    }
+
+    for (const domain of domains) {
+        const expectedWorker = expectedByHostname.get(domain.hostname);
+        const managedHostname = managedAppHostname(domain.hostname);
+        const policyWorker = policyWorkers.has(domain.service);
+        const managedWorker = domain.service.startsWith(
+            CLOUDFLARE_WORKER_NAMESPACE_PREFIX
+        );
+        if (
+            (managedHostname || policyWorker || managedWorker) &&
+            (expectedWorker == null ||
+                domain.service !== expectedWorker ||
+                domain.environment !== "production")
+        ) {
+            throw new Error(
+                `Cloudflare custom domain ${domain.hostname} is outside the exact provisioning policy`
+            );
+        }
+        if (expectedWorker && !scripts.has(expectedWorker)) {
+            throw new Error(
+                `${domain.hostname} is attached to a production Worker that is absent from the Worker inventory`
+            );
+        }
+    }
+
+    for (const { site, policy } of entries) {
+        const attached = domains.filter(
+            ({ service }) => service === policy.productionWorker
+        );
+        if (
+            attached.length > 1 ||
+            attached.some(
+                ({ hostname, environment }) =>
+                    hostname !== policy.productionHostnames[0] ||
+                    environment !== "production"
+            )
+        ) {
+            throw new Error(
+                `${site.id}: production Worker has custom domains outside its one reviewed hostname`
+            );
+        }
+    }
+};
+
+const validateSubdomainState = (workerName, state) => {
+    const keys =
+        state && typeof state === "object" && !Array.isArray(state)
+            ? Object.keys(state).sort()
+            : [];
+    if (
+        keys.length !== 2 ||
+        keys[0] !== "enabled" ||
+        keys[1] !== "previewsEnabled" ||
+        typeof state.enabled !== "boolean" ||
+        typeof state.previewsEnabled !== "boolean"
+    ) {
+        throw new Error(
+            `${workerName}: Worker subdomain state is invalid or ambiguous`
+        );
+    }
+    return state;
+};
+
+const canonicalize = (value) => {
+    if (Array.isArray(value)) return value.map(canonicalize);
+    if (value && typeof value === "object") {
+        return Object.fromEntries(
+            Object.keys(value)
+                .sort()
+                .map((key) => [key, canonicalize(value[key])])
+        );
+    }
+    return value;
+};
+
+const sha256Canonical = (value) =>
+    createHash("sha256")
+        .update(JSON.stringify(canonicalize(value)))
+        .digest("hex");
+
+const sameCanonicalValue = (left, right) =>
+    JSON.stringify(canonicalize(left)) === JSON.stringify(canonicalize(right));
+
+const isPlainObject = (value) => {
+    if (value == null || typeof value !== "object" || Array.isArray(value)) {
+        return false;
+    }
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+};
+
+const assertExactObjectKeys = (value, allowedKeys, label) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error(`${label} is missing or malformed`);
+    }
+    const extra = Object.keys(value).filter((key) => !allowedKeys.has(key));
+    if (extra.length > 0) {
+        throw new Error(
+            `${label} contains unreviewed fields ${extra.sort().join(", ")}`
+        );
+    }
+};
+
+const normalizeVersionLimits = ({ runtime, renderedConfig, siteId }) => {
+    const hasLimits = Object.hasOwn(runtime, "limits");
+    const expectsLimits = Object.hasOwn(renderedConfig, "limits");
+    if (expectsLimits) {
+        if (
+            !isPlainObject(renderedConfig.limits) ||
+            !hasLimits ||
+            !isPlainObject(runtime.limits) ||
+            !sameCanonicalValue(runtime.limits, renderedConfig.limits)
+        ) {
+            throw new Error(
+                `${siteId}: exact Worker version limits do not match the reviewed config`
+            );
+        }
+        return runtime.limits;
+    }
+    // Wrangler 4.110 and Cloudflare can serialize the default no-limits state
+    // either by omitting the field or as an exact empty object. Normalize only
+    // those two representations; any actual limit remains an unreviewed policy.
+    if (
+        hasLimits &&
+        (!isPlainObject(runtime.limits) ||
+            Reflect.ownKeys(runtime.limits).length !== 0)
+    ) {
+        throw new Error(
+            `${siteId}: exact Worker version limits do not match the reviewed config`
+        );
+    }
+    return {};
+};
+
+const validateVersionResources = ({
+    version,
+    renderedConfig,
+    siteId,
+    artifactManifestDigest,
+}) => {
+    const resources = version?.resources;
+    const script = resources?.script;
+    const runtime = resources?.script_runtime;
+    const bindings = resources?.bindings;
+    if (
+        !resources ||
+        typeof resources !== "object" ||
+        Array.isArray(resources) ||
+        !script ||
+        typeof script !== "object" ||
+        Array.isArray(script) ||
+        typeof script.etag !== "string" ||
+        script.etag.length === 0 ||
+        script.etag.length > 512 ||
+        !runtime ||
+        typeof runtime !== "object" ||
+        Array.isArray(runtime) ||
+        !Array.isArray(bindings)
+    ) {
+        throw new Error(
+            `${siteId}: exact Worker version resource evidence is missing or malformed`
+        );
+    }
+    assertExactObjectKeys(
+        resources,
+        new Set(["bindings", "script", "script_runtime"]),
+        `${siteId}: exact Worker version resources`
+    );
+    assertExactObjectKeys(
+        script,
+        new Set([
+            "etag",
+            "handlers",
+            "last_deployed_from",
+            "named_handlers",
+            "placement",
+            "placement_mode",
+        ]),
+        `${siteId}: exact Worker version script resource`
+    );
+    assertExactObjectKeys(
+        runtime,
+        new Set([
+            "compatibility_date",
+            "compatibility_flags",
+            "limits",
+            "migration_tag",
+            "usage_model",
+        ]),
+        `${siteId}: exact Worker version runtime resource`
+    );
+    const handlers = script.handlers ?? [];
+    const namedHandlers = script.named_handlers ?? [];
+    if (
+        !Array.isArray(handlers) ||
+        new Set(handlers).size !== handlers.length ||
+        handlers.some((handler) => handler !== "fetch") ||
+        !handlers.includes("fetch") ||
+        !Array.isArray(namedHandlers) ||
+        namedHandlers.length !== 0
+    ) {
+        throw new Error(
+            `${siteId}: exact Worker version event handlers do not match the reviewed config`
+        );
+    }
+
+    if (
+        renderedConfig.compatibility_date != null &&
+        runtime.compatibility_date !== renderedConfig.compatibility_date
+    ) {
+        throw new Error(
+            `${siteId}: exact Worker version has the wrong compatibility date`
+        );
+    }
+    const expectedFlags = [
+        ...(renderedConfig.compatibility_flags ?? []),
+    ].sort();
+    if (!Array.isArray(runtime.compatibility_flags ?? [])) {
+        throw new Error(
+            `${siteId}: exact Worker version has malformed compatibility flags`
+        );
+    }
+    const actualFlags = [...(runtime.compatibility_flags ?? [])].sort();
+    if (JSON.stringify(actualFlags) !== JSON.stringify(expectedFlags)) {
+        throw new Error(
+            `${siteId}: exact Worker version has the wrong compatibility flags`
+        );
+    }
+
+    const normalizedLimits = normalizeVersionLimits({
+        runtime,
+        renderedConfig,
+        siteId,
+    });
+    if (
+        Object.hasOwn(renderedConfig, "migrations") ||
+        Object.hasOwn(runtime, "migration_tag")
+    ) {
+        throw new Error(
+            `${siteId}: Durable Object migrations are outside the reviewed static-app runtime contract`
+        );
+    }
+    const actualPlacement =
+        script.placement ??
+        (script.placement_mode == null
+            ? undefined
+            : { mode: script.placement_mode });
+    if (
+        (script.placement != null && script.placement_mode != null) ||
+        !sameCanonicalValue(actualPlacement, renderedConfig.placement)
+    ) {
+        throw new Error(
+            `${siteId}: exact Worker version placement does not match the reviewed config`
+        );
+    }
+    const expectedUsageModel = renderedConfig.usage_model;
+    if (
+        expectedUsageModel == null
+            ? runtime.usage_model != null && runtime.usage_model !== "standard"
+            : runtime.usage_model !== expectedUsageModel
+    ) {
+        throw new Error(
+            `${siteId}: exact Worker version usage model does not match the reviewed config`
+        );
+    }
+
+    const expectsCache = Object.hasOwn(renderedConfig, "cache");
+    const hasCache = Object.hasOwn(version, "cache_options");
+    if (
+        expectsCache !== hasCache ||
+        (hasCache &&
+            !sameCanonicalValue(version.cache_options, renderedConfig.cache))
+    ) {
+        throw new Error(
+            `${siteId}: exact Worker version cache options do not match the reviewed config`
+        );
+    }
+    if (hasCache) {
+        assertExactObjectKeys(
+            version.cache_options,
+            new Set(["enabled", "cross_version_cache"]),
+            `${siteId}: exact Worker version cache options`
+        );
+        if (
+            typeof version.cache_options.enabled !== "boolean" ||
+            (version.cache_options.cross_version_cache != null &&
+                typeof version.cache_options.cross_version_cache !== "boolean")
+        ) {
+            throw new Error(
+                `${siteId}: exact Worker version cache options are malformed`
+            );
+        }
+    }
+
+    const expectedVars = new Map(
+        Object.entries(renderedConfig.vars ?? {}).map(([name, value]) => [
+            name,
+            String(value),
+        ])
+    );
+    expectedVars.set(
+        CLOUDFLARE_ARTIFACT_DIGEST_BINDING,
+        artifactManifestDigest
+    );
+    const seenBindings = new Set();
+    const observedVars = new Map();
+    const observedAssets = [];
+    const expectedAssetsBinding = renderedConfig.assets?.binding;
+    // The seven reviewed configs declare only plain-text vars and, for
+    // Worker-first asset sites, the exact assets binding. Imported JS/Wasm
+    // modules are script resources, not Wrangler binding declarations.
+    const safeEmbeddedTypes = new Set(["assets", "plain_text"]);
+    for (const binding of bindings) {
+        if (
+            !binding ||
+            typeof binding !== "object" ||
+            Array.isArray(binding) ||
+            typeof binding.name !== "string" ||
+            binding.name.length === 0 ||
+            typeof binding.type !== "string" ||
+            binding.type.length === 0 ||
+            seenBindings.has(binding.name) ||
+            !safeEmbeddedTypes.has(binding.type)
+        ) {
+            throw new Error(
+                `${siteId}: exact Worker version contains an unreviewed service, queue, secret, storage, or duplicate binding`
+            );
+        }
+        seenBindings.add(binding.name);
+        if (binding.type === "assets") {
+            observedAssets.push(binding.name);
+        }
+        if (binding.type === "plain_text") {
+            if (typeof binding.text !== "string") {
+                throw new Error(
+                    `${siteId}: exact Worker version plain-text binding is malformed`
+                );
+            }
+            observedVars.set(binding.name, binding.text);
+        }
+    }
+    if (
+        JSON.stringify(observedAssets.sort()) !==
+        JSON.stringify(
+            expectedAssetsBinding == null ? [] : [expectedAssetsBinding]
+        )
+    ) {
+        throw new Error(
+            `${siteId}: exact Worker version assets binding does not match the reviewed config`
+        );
+    }
+    if (
+        JSON.stringify([...observedVars].sort()) !==
+        JSON.stringify([...expectedVars].sort())
+    ) {
+        throw new Error(
+            `${siteId}: exact Worker version plain-text bindings do not match the reviewed config`
+        );
+    }
+    return sha256Canonical({
+        resources: {
+            ...resources,
+            script_runtime: {
+                ...runtime,
+                limits: normalizedLimits,
+            },
+        },
+        cacheOptions: hasCache ? version.cache_options : null,
+        // This receipt binds the reviewed assets behavior and byte inventory;
+        // exhaustive live verification proves that contract after activation.
+        artifactManifestDigest,
+    });
+};
+
+const validateProvisioningVersion = ({
+    version,
+    versionId,
+    versionTag,
+    siteId,
+    expectedCommit,
+    renderedConfig,
+    artifactManifestDigest,
+}) => {
+    if (
+        !version ||
+        typeof version !== "object" ||
+        Array.isArray(version) ||
+        version.id !== versionId ||
+        version.annotations?.["workers/tag"] !== versionTag ||
+        version.annotations?.["workers/message"] !==
+            expectedVersionMessage({
+                siteId,
+                expectedCommit,
+                artifactManifestDigest,
+            })
+    ) {
+        throw new Error(
+            `${siteId}: Worker version does not carry the exact provisioning release identity`
+        );
+    }
+    return {
+        version,
+        fingerprint: validateVersionResources({
+            version,
+            renderedConfig,
+            siteId,
+            artifactManifestDigest,
+        }),
+    };
+};
+
+const readCurrentVersion = ({ deployments, siteId }) => {
+    if (!Array.isArray(deployments)) {
+        throw new Error(`${siteId}: Worker deployment inventory is malformed`);
+    }
+    if (deployments.length === 0) return undefined;
+    if (
+        !deployments[0] ||
+        typeof deployments[0] !== "object" ||
+        Array.isArray(deployments[0])
+    ) {
+        throw new Error(`${siteId}: active Worker deployment is malformed`);
+    }
+    return readSingleVersionDeployment(deployments[0], siteId);
+};
+
+const readActiveServiceAttachmentInventory = async ({
+    entries,
+    scripts,
+    operations,
+}) => {
+    const policyWorkers = new Set(
+        entries.flatMap(({ policy }) => [
+            policy.productionWorker,
+            policy.previewWorker,
+        ])
+    );
+    const inventory = [];
+    for (const workerName of [...scripts.keys()].sort()) {
+        const activeVersionId = readCurrentVersion({
+            deployments: await operations.getWorkerDeployments(workerName),
+            siteId: workerName,
+        });
+        if (!activeVersionId) {
+            inventory.push({ workerName, activeVersionId: null, services: [] });
+            continue;
+        }
+        const version = await operations.getWorkerVersion(
+            workerName,
+            activeVersionId
+        );
+        const bindings = version?.resources?.bindings;
+        if (!Array.isArray(bindings)) {
+            throw new Error(
+                `${workerName}: active version binding inventory is missing or ambiguous`
+            );
+        }
+        const handlers = version.resources?.script?.handlers ?? [];
+        const namedHandlers = version.resources?.script?.named_handlers ?? [];
+        if (
+            policyWorkers.has(workerName) &&
+            (!Array.isArray(handlers) ||
+                handlers.some((handler) => handler !== "fetch") ||
+                !Array.isArray(namedHandlers) ||
+                namedHandlers.length > 0)
+        ) {
+            throw new Error(
+                `${workerName}: managed active version has an unreviewed queue, scheduled, email, tail, or other event handler`
+            );
+        }
+        const services = [];
+        for (const binding of bindings) {
+            if (!binding || typeof binding !== "object") {
+                throw new Error(
+                    `${workerName}: active version binding inventory is malformed`
+                );
+            }
+            if (
+                policyWorkers.has(workerName) &&
+                ["queue", "service", "service_binding"].includes(binding.type)
+            ) {
+                throw new Error(
+                    `${workerName}: managed Worker has an unreviewed queue or service binding`
+                );
+            }
+            if (["service", "service_binding"].includes(binding.type)) {
+                const service = binding.service ?? binding.service_name;
+                if (!WORKER_NAME.test(service || "")) {
+                    throw new Error(
+                        `${workerName}: active service binding target is malformed`
+                    );
+                }
+                services.push(service);
+                if (policyWorkers.has(service)) {
+                    throw new Error(
+                        `${workerName}: active service binding is an unreviewed inbound attachment to ${service}`
+                    );
+                }
+            }
+        }
+        inventory.push({
+            workerName,
+            activeVersionId,
+            services: services.sort(),
+        });
+    }
+    return inventory;
+};
+
+const validateQueueConsumerInventory = ({ entries, inventory }) => {
+    const policyWorkers = new Set(
+        entries.flatMap(({ policy }) => [
+            policy.productionWorker,
+            policy.previewWorker,
+        ])
+    );
+    const queueIds = new Set();
+    const queueNames = new Set();
+    if (!Array.isArray(inventory)) {
+        throw new Error("Cloudflare Queue consumer inventory is missing");
+    }
+    const normalizedQueues = [];
+    for (const queue of inventory) {
+        if (
+            !queue ||
+            typeof queue !== "object" ||
+            Array.isArray(queue) ||
+            typeof queue.queueId !== "string" ||
+            queue.queueId.length === 0 ||
+            queueIds.has(queue.queueId) ||
+            typeof queue.queueName !== "string" ||
+            queue.queueName.length === 0 ||
+            queueNames.has(queue.queueName) ||
+            !Array.isArray(queue.consumers)
+        ) {
+            throw new Error(
+                "Cloudflare Queue consumer inventory is invalid or ambiguous"
+            );
+        }
+        queueIds.add(queue.queueId);
+        queueNames.add(queue.queueName);
+        const consumerIds = new Set();
+        const normalizedConsumers = [];
+        for (const consumer of queue.consumers) {
+            if (
+                !consumer ||
+                typeof consumer !== "object" ||
+                typeof consumer.consumerId !== "string" ||
+                consumer.consumerId.length === 0 ||
+                consumerIds.has(consumer.consumerId) ||
+                !["worker", "http_pull"].includes(consumer.type) ||
+                consumer.queueName !== queue.queueName ||
+                (consumer.type === "worker" &&
+                    !WORKER_NAME.test(consumer.scriptName || "")) ||
+                (consumer.type === "http_pull" &&
+                    consumer.scriptName !== null) ||
+                typeof consumer.deadLetterQueue !== "string" ||
+                !consumer.settings ||
+                typeof consumer.settings !== "object" ||
+                Array.isArray(consumer.settings)
+            ) {
+                throw new Error(
+                    "Cloudflare Queue consumer inventory is invalid or ambiguous"
+                );
+            }
+            consumerIds.add(consumer.consumerId);
+            if (
+                consumer.type === "worker" &&
+                policyWorkers.has(consumer.scriptName)
+            ) {
+                throw new Error(
+                    `${consumer.scriptName}: unreviewed Cloudflare Queue consumer attachment on ${queue.queueName}`
+                );
+            }
+            normalizedConsumers.push({
+                consumerId: consumer.consumerId,
+                type: consumer.type,
+                scriptName: consumer.scriptName,
+                queueName: queue.queueName,
+                deadLetterQueue: consumer.deadLetterQueue,
+                settings: canonicalize(consumer.settings),
+            });
+        }
+        normalizedQueues.push({
+            queueId: queue.queueId,
+            queueName: queue.queueName,
+            consumers: normalizedConsumers.sort((left, right) =>
+                left.consumerId.localeCompare(right.consumerId)
+            ),
+        });
+    }
+    return normalizedQueues.sort((left, right) =>
+        left.queueId.localeCompare(right.queueId)
+    );
+};
+
+export const inspectProductionProvisioning = async ({
+    entries,
+    configs,
+    artifacts,
+    expectedCommit,
+    operations,
+    invocationNonce,
+    invocationCandidates = new Map(),
+}) => {
+    validateProvisioningEntries(entries);
+    if (!FULL_GIT_COMMIT.test(expectedCommit || "")) {
+        throw new Error("Provisioning requires a full Git commit hash");
+    }
+    if (!(configs instanceof Map) || configs.size !== entries.length) {
+        throw new Error(
+            "Provisioning requires every rendered production config"
+        );
+    }
+    if (!(artifacts instanceof Map) || artifacts.size !== entries.length) {
+        throw new Error(
+            "Provisioning requires every pre-credential artifact manifest"
+        );
+    }
+    if (invocationNonce != null && !INVOCATION_NONCE.test(invocationNonce)) {
+        throw new Error("Provisioning invocation nonce is malformed");
+    }
+    if (!(invocationCandidates instanceof Map)) {
+        throw new Error(
+            "Provisioning invocation candidate ledger is malformed"
+        );
+    }
+    const configPlans = entries.map(({ site, policy }) => {
+        const artifact = artifacts.get(site.id);
+        if (
+            !artifact ||
+            artifact.siteId !== site.id ||
+            artifact.workerName !== policy.productionWorker ||
+            artifact.commit !== expectedCommit.toLowerCase() ||
+            !STATE_DIGEST.test(artifact.digest || "")
+        ) {
+            throw new Error(
+                `${site.id}: pre-credential artifact manifest is missing or malformed`
+            );
+        }
+        const plan = {
+            site,
+            policy,
+            artifact,
+            artifactManifestDigest: artifact.digest,
+            ...productionWorkerConfig({ site, policy, configs }),
+        };
+        validateRenderedCloudflareConfig({
+            config: plan.renderedConfig,
+            policy,
+            mode: "production",
+        });
+        if (typeof plan.file !== "string" || plan.file.length === 0) {
+            throw new Error(`${site.id}: rendered config path is missing`);
+        }
+        return plan;
+    });
+    const scripts = await readWorkerScriptMap(operations);
+    const domains = await readWorkerDomainInventory(operations);
+    validateProvisioningAttachmentInventory({ entries, scripts, domains });
+    const activeServiceAttachments = await readActiveServiceAttachmentInventory(
+        {
+            entries,
+            scripts,
+            operations,
+        }
+    );
+    const queueConsumerInventory = validateQueueConsumerInventory({
+        entries,
+        inventory: await operations.listQueueConsumerInventory(),
+    });
+
+    const previewPlans = [];
+    for (const { site, policy } of entries) {
+        const metadata = scripts.get(policy.previewWorker);
+        if (!metadata) {
+            previewPlans.push({
+                site,
+                policy,
+                workerName: policy.previewWorker,
+                workerExists: false,
+                workerTag: undefined,
+                subdomainState: undefined,
+                schedules: [],
+                actions: [],
+            });
+            continue;
+        }
+        if (typeof metadata.tag !== "string" || metadata.tag.length === 0) {
+            throw new Error(
+                `${policy.previewWorker}: existing preview Worker has no immutable identity tag`
+            );
+        }
+        const subdomainState = validateSubdomainState(
+            policy.previewWorker,
+            await operations.getWorkerSubdomain(policy.previewWorker)
+        );
+        const schedules = await operations.listWorkerSchedules(
+            policy.previewWorker
+        );
+        if (!Array.isArray(schedules) || schedules.length > 0) {
+            throw new Error(
+                `${policy.previewWorker}: Cron Trigger schedules must be empty`
+            );
+        }
+        previewPlans.push({
+            site,
+            policy,
+            workerName: policy.previewWorker,
+            workerExists: true,
+            workerTag: metadata.tag,
+            subdomainState,
+            schedules,
+            actions:
+                subdomainState.enabled || subdomainState.previewsEnabled
+                    ? ["disable-public-subdomains"]
+                    : [],
+        });
+    }
+
+    const plans = [];
+    for (const configPlan of configPlans) {
+        const { site, policy, workerName } = configPlan;
+        const hostname = policy.productionHostnames[0];
+        const domain = domains.find(
+            ({ hostname: value }) => value === hostname
+        );
+        const metadata = scripts.get(workerName);
+        const versionTag = invocationNonce
+            ? createProvisioningVersionTag({
+                  siteId: site.id,
+                  expectedCommit,
+                  invocationNonce,
+              })
+            : undefined;
+        const invocationCandidate = invocationCandidates.get(site.id);
+        if (!metadata) {
+            if (invocationCandidate) {
+                throw new Error(
+                    `${site.id}: same-invocation upload evidence names a Worker absent from inventory`
+                );
+            }
+            plans.push({
+                ...configPlan,
+                hostname,
+                versionTag,
+                workerExists: false,
+                workerTag: undefined,
+                subdomainState: undefined,
+                schedules: [],
+                deployableVersionIds: [],
+                quarantinedVersionIds: [],
+                activeVersionId: undefined,
+                versionId: undefined,
+                versionFingerprint: undefined,
+                active: false,
+                domainAttached: false,
+                actions: [
+                    "upload-fresh-route-free-version",
+                    "disable-uploaded-public-subdomains",
+                    "activate-exact-version-100-percent",
+                    "attach-reviewed-custom-domain",
+                    "verify-live-release",
+                ],
+            });
+            continue;
+        }
+        if (typeof metadata.tag !== "string" || metadata.tag.length === 0) {
+            throw new Error(
+                `${site.id}: existing production Worker has no immutable identity tag`
+            );
+        }
+        const subdomainState = validateSubdomainState(
+            workerName,
+            await operations.getWorkerSubdomain(workerName)
+        );
+        const deployments = await operations.getWorkerDeployments(workerName);
+        const activeVersionId = readCurrentVersion({
+            deployments,
+            siteId: site.id,
+        });
+        const deployableVersionIds =
+            await operations.listDeployableWorkerVersions(workerName);
+        if (
+            !Array.isArray(deployableVersionIds) ||
+            new Set(deployableVersionIds).size !==
+                deployableVersionIds.length ||
+            deployableVersionIds.some(
+                (versionId) => !VERSION_ID.test(versionId || "")
+            ) ||
+            (activeVersionId && !deployableVersionIds.includes(activeVersionId))
+        ) {
+            throw new Error(
+                `${site.id}: deployable Worker version inventory is invalid or incomplete`
+            );
+        }
+        if (domain && !activeVersionId) {
+            throw new Error(
+                `${site.id}: reviewed custom domain is attached before an exact active baseline exists`
+            );
+        }
+        const schedules = await operations.listWorkerSchedules(workerName);
+        if (!Array.isArray(schedules) || schedules.length > 0) {
+            throw new Error(
+                `${workerName}: Cron Trigger schedules must be empty`
+            );
+        }
+        let versionId;
+        let versionFingerprint;
+        if (invocationCandidate) {
+            if (
+                invocationCandidate.workerName !== workerName ||
+                invocationCandidate.workerTag !== metadata.tag ||
+                invocationCandidate.versionTag !== versionTag ||
+                invocationCandidate.artifactManifestDigest !==
+                    configPlan.artifactManifestDigest ||
+                !VERSION_ID.test(invocationCandidate.versionId || "") ||
+                !deployableVersionIds.includes(invocationCandidate.versionId)
+            ) {
+                throw new Error(
+                    `${site.id}: same-invocation Wrangler upload evidence does not match the exact Worker inventory`
+                );
+            }
+            versionId = invocationCandidate.versionId;
+            const { fingerprint: runtimeFingerprint } =
+                validateProvisioningVersion({
+                    version: await operations.getWorkerVersion(
+                        workerName,
+                        versionId
+                    ),
+                    versionId,
+                    versionTag,
+                    siteId: site.id,
+                    expectedCommit,
+                    renderedConfig: configPlan.renderedConfig,
+                    artifactManifestDigest: configPlan.artifactManifestDigest,
+                });
+            const observedModule = await operations.getWorkerVersionModule(
+                workerName,
+                versionId
+            );
+            validateActiveWorkerModule({
+                artifact: configPlan.artifact,
+                observed: observedModule,
+            });
+            versionFingerprint = sha256Canonical({
+                runtimeFingerprint,
+                module: observedModule,
+            });
+            if (
+                invocationCandidate.versionFingerprint != null &&
+                invocationCandidate.versionFingerprint !== versionFingerprint
+            ) {
+                throw new Error(
+                    `${site.id}: exact uploaded Worker version resource fingerprint changed`
+                );
+            }
+        }
+        const actions = [];
+        if (subdomainState.enabled || subdomainState.previewsEnabled) {
+            actions.push("disable-existing-public-subdomains");
+        }
+        if (!invocationCandidate) {
+            actions.push(
+                "upload-fresh-route-free-version",
+                "disable-uploaded-public-subdomains"
+            );
+        }
+        if (activeVersionId !== versionId)
+            actions.push("activate-exact-version-100-percent");
+        if (!domain) actions.push("attach-reviewed-custom-domain");
+        actions.push("verify-live-release");
+        plans.push({
+            ...configPlan,
+            hostname,
+            versionTag,
+            workerExists: true,
+            workerTag: metadata.tag,
+            subdomainState,
+            schedules,
+            deployableVersionIds,
+            quarantinedVersionIds: deployableVersionIds.filter(
+                (candidateId) =>
+                    candidateId !== activeVersionId && candidateId !== versionId
+            ),
+            activeVersionId,
+            versionId,
+            versionFingerprint,
+            active: versionId != null && activeVersionId === versionId,
+            domainAttached: Boolean(domain),
+            actions,
+        });
+    }
+    return {
+        plans,
+        previewPlans,
+        scripts,
+        domains,
+        activeServiceAttachments,
+        queueConsumerInventory,
+    };
+};
+
+const nullable = (value) => value ?? null;
+
+export const productionProvisioningStateDigest = ({
+    inspection,
+    expectedCommit,
+    accountId,
+}) => {
+    if (!FULL_GIT_COMMIT.test(expectedCommit || "")) {
+        throw new Error("Provisioning state digest requires a full Git commit");
+    }
+    if (!CLOUDFLARE_ACCOUNT_ID.test(accountId || "")) {
+        throw new Error(
+            "Provisioning state digest requires an exact Cloudflare account ID"
+        );
+    }
+    const state = {
+        schema: 2,
+        expectedCommit: expectedCommit.toLowerCase(),
+        accountId: accountId.toLowerCase(),
+        scripts: [...inspection.scripts]
+            .map(([workerName, metadata]) => ({
+                workerName,
+                workerTag: nullable(metadata.tag),
+                routes: [...metadata.routes].sort((left, right) =>
+                    left.id.localeCompare(right.id)
+                ),
+                tailConsumers: metadata.tailConsumers ?? [],
+                logpush: metadata.logpush ?? false,
+            }))
+            .sort((left, right) =>
+                left.workerName.localeCompare(right.workerName)
+            ),
+        domains: [...inspection.domains].sort((left, right) =>
+            left.id.localeCompare(right.id)
+        ),
+        activeServiceAttachments: inspection.activeServiceAttachments,
+        queueConsumerInventory: inspection.queueConsumerInventory,
+        production: inspection.plans.map((plan) => ({
+            site: plan.site.id,
+            workerName: plan.workerName,
+            workerExists: plan.workerExists,
+            workerTag: nullable(plan.workerTag),
+            subdomainState: nullable(plan.subdomainState),
+            schedules: plan.schedules,
+            activeVersionId: nullable(plan.activeVersionId),
+            deployableVersionIds: [...plan.deployableVersionIds].sort(),
+            domainAttached: plan.domainAttached,
+            hostname: plan.hostname,
+            artifactManifestDigest: plan.artifactManifestDigest,
+        })),
+        preview: inspection.previewPlans.map((plan) => ({
+            site: plan.site.id,
+            workerName: plan.workerName,
+            workerExists: plan.workerExists,
+            workerTag: nullable(plan.workerTag),
+            subdomainState: nullable(plan.subdomainState),
+            schedules: plan.schedules,
+        })),
+    };
+    return sha256Canonical(state);
+};
+
+const planSummary = (plans, previewPlans) => {
+    const previewBySite = new Map(
+        previewPlans.map((plan) => [plan.site.id, plan])
+    );
+    return plans.map(
+        ({
+            site,
+            workerName,
+            workerTag,
+            hostname,
+            actions,
+            activeVersionId,
+            deployableVersionIds,
+            quarantinedVersionIds,
+            domainAttached,
+            artifactManifestDigest,
+        }) => {
+            const preview = previewBySite.get(site.id);
+            if (!preview) {
+                throw new Error(
+                    `Missing preview provisioning plan for ${site.id}`
+                );
+            }
+            return {
+                site: site.id,
+                worker: workerName,
+                workerTag: workerTag ?? null,
+                hostname,
+                actions,
+                activeVersionId: activeVersionId ?? null,
+                deployableVersionIds,
+                quarantinedVersionIds,
+                domainAttached,
+                artifactManifestDigest,
+                previewWorker: preview.workerName,
+                previewExists: preview.workerExists,
+                previewActions: preview.actions,
+            };
+        }
+    );
+};
+
+const diagnostic = (error, maxLength = MAX_DIAGNOSTIC_LENGTH) =>
+    redactCloudflareCredentials(error, process.env).slice(0, maxLength);
+
+const manualRecoveryError = ({ site, workerName, operation, error }) =>
+    new Error(
+        `${site.id}: ${operation} could not be proved by exact Cloudflare GET postconditions (${diagnostic(
+            error
+        )}); do not retry mutations blindly. Inspect ${workerName}'s versions, active deployment, routes, custom domain, and public subdomain state before rerunning the read-only plan`
+    );
+
+const failedUploadRecoveryError = ({
+    site,
+    workerName,
+    uploadError,
+    proofError,
+    exactCleanupError,
+    cleanupFenceError,
+}) => {
+    const details = [
+        uploadError
+            ? `upload response: ${diagnostic(uploadError, 750)}`
+            : undefined,
+        `post-upload proof: ${diagnostic(proofError, 750)}`,
+        exactCleanupError
+            ? `exact-name public-URL failure cleanup was not proved: ${diagnostic(
+                  exactCleanupError,
+                  750
+              )}`
+            : "exact-name public-URL failure cleanup was proved false/false by GET",
+        cleanupFenceError
+            ? `post-cleanup invocation fence was not proved: ${diagnostic(
+                  cleanupFenceError,
+                  750
+              )}`
+            : "post-cleanup invocation fence was proved",
+    ].filter(Boolean);
+    return new Error(
+        `${site.id}: route-free version upload could not be proved safely (${details.join(
+            "; "
+        )}); do not retry mutations blindly. Inspect ${workerName}'s versions, active deployment, routes, custom domain, and public subdomain state before rerunning the read-only plan`
+    );
+};
+
+const disableAndConfirm = async ({ plan, operations, log, force }) => {
+    if (
+        !force &&
+        plan.subdomainState &&
+        !plan.subdomainState.enabled &&
+        !plan.subdomainState.previewsEnabled
+    ) {
+        return;
+    }
+    let mutationError;
+    try {
+        await operations.disableWorkerSubdomain(plan.workerName);
+    } catch (error) {
+        mutationError = error;
+    }
+    let state;
+    try {
+        state = validateSubdomainState(
+            plan.workerName,
+            await operations.getWorkerSubdomain(plan.workerName)
+        );
+    } catch (error) {
+        throw manualRecoveryError({
+            site: plan.site,
+            workerName: plan.workerName,
+            operation: "public-subdomain disable",
+            error: mutationError ?? error,
+        });
+    }
+    if (state.enabled || state.previewsEnabled) {
+        throw manualRecoveryError({
+            site: plan.site,
+            workerName: plan.workerName,
+            operation: "public-subdomain disable",
+            error:
+                mutationError ?? new Error("disabled state was not observed"),
+        });
+    }
+    if (mutationError) {
+        log(
+            `${plan.site.id}: ambiguous public-subdomain response was resolved by an exact disabled-state GET`
+        );
+    }
+};
+
+const inspect = (context) => inspectProductionProvisioning(context);
+
+const planFor = (inspection, siteId) => {
+    const plan = inspection.plans.find(({ site }) => site.id === siteId);
+    if (!plan) throw new Error(`Missing provisioning plan for ${siteId}`);
+    return plan;
+};
+
+const previewPlanFor = (inspection, siteId) => {
+    const plan = inspection.previewPlans.find(({ site }) => site.id === siteId);
+    if (!plan)
+        throw new Error(`Missing preview provisioning plan for ${siteId}`);
+    return plan;
+};
+
+const assertSamePreviewInventory = (before, after, phase) => {
+    for (const beforePlan of before.previewPlans) {
+        const afterPlan = previewPlanFor(after, beforePlan.site.id);
+        if (
+            afterPlan.workerExists !== beforePlan.workerExists ||
+            afterPlan.workerTag !== beforePlan.workerTag
+        ) {
+            throw new Error(
+                `${beforePlan.workerName}: preview Worker identity changed ${phase}`
+            );
+        }
+    }
+};
+
+const assertSameQueueConsumerInventory = (before, after, phase) => {
+    if (
+        JSON.stringify(after.queueConsumerInventory) !==
+        JSON.stringify(before.queueConsumerInventory)
+    ) {
+        throw new Error(
+            `Cloudflare Queue consumer attachment inventory changed ${phase}`
+        );
+    }
+};
+
+const productionLedgerState = (plan) => ({
+    siteId: plan.site.id,
+    workerName: plan.workerName,
+    workerExists: plan.workerExists,
+    workerTag: plan.workerTag,
+    activeVersionId: plan.activeVersionId,
+    deployableVersionIds: [...plan.deployableVersionIds],
+    versionId: plan.versionId,
+    versionFingerprint: plan.versionFingerprint,
+    artifactManifestDigest: plan.artifactManifestDigest,
+    active: plan.active,
+    domainAttached: plan.domainAttached,
+});
+
+const createProductionLedger = (inspection) =>
+    new Map(
+        inspection.plans.map((plan) => [
+            plan.site.id,
+            productionLedgerState(plan),
+        ])
+    );
+
+const productionLedgerFor = (ledger, siteId) => {
+    const state = ledger.get(siteId);
+    if (!state) {
+        throw new Error(`Missing invocation production ledger for ${siteId}`);
+    }
+    return state;
+};
+
+const assertProductionLedger = (
+    ledger,
+    inspection,
+    { skipSiteId, phase } = {}
+) => {
+    if (
+        !(ledger instanceof Map) ||
+        ledger.size !== inspection.plans.length ||
+        new Set(inspection.plans.map(({ site }) => site.id)).size !==
+            inspection.plans.length
+    ) {
+        throw new Error("Invocation production ledger is incomplete");
+    }
+    for (const plan of inspection.plans) {
+        if (plan.site.id === skipSiteId) continue;
+        const expected = productionLedgerFor(ledger, plan.site.id);
+        const actual = productionLedgerState(plan);
+        for (const field of [
+            "workerName",
+            "workerExists",
+            "workerTag",
+            "activeVersionId",
+            "deployableVersionIds",
+            "versionId",
+            "versionFingerprint",
+            "artifactManifestDigest",
+            "active",
+            "domainAttached",
+        ]) {
+            if (
+                JSON.stringify(actual[field]) !==
+                JSON.stringify(expected[field])
+            ) {
+                throw new Error(
+                    `${plan.site.id}: invocation production ledger changed ${field}${phase ? ` ${phase}` : ""}`
+                );
+            }
+        }
+    }
+};
+
+const disabledPublicState = (state) =>
+    state && !state.enabled && !state.previewsEnabled;
+
+const assertAllManagedPublicUrlsDisabled = (
+    inspection,
+    phase,
+    { allowProductionWorker } = {}
+) => {
+    for (const plan of inspection.previewPlans) {
+        if (plan.workerExists && !disabledPublicState(plan.subdomainState)) {
+            throw new Error(
+                `${plan.workerName}: existing preview Worker must have workers.dev and Preview URLs disabled ${phase}`
+            );
+        }
+    }
+    for (const plan of inspection.plans) {
+        if (
+            plan.workerExists &&
+            plan.workerName !== allowProductionWorker &&
+            !disabledPublicState(plan.subdomainState)
+        ) {
+            throw new Error(
+                `${plan.workerName}: existing production Worker must have workers.dev and Preview URLs disabled ${phase}`
+            );
+        }
+    }
+};
+
+const validateUploadEvidence = ({ plan, evidence }) => {
+    if (
+        !evidence ||
+        evidence.workerName !== plan.workerName ||
+        evidence.workerTag !== plan.workerTag ||
+        evidence.versionId !== plan.versionId ||
+        evidence.artifactManifestDigest !== plan.artifactManifestDigest
+    ) {
+        throw new Error(
+            `${plan.site.id}: Wrangler upload evidence does not match the exact GET-confirmed Worker identity and version`
+        );
+    }
+};
+
+const confirmActiveWorkerModule = async ({
+    site,
+    policy,
+    versionId,
+    artifact,
+    operations,
+}) => {
+    try {
+        const observed = await operations.getWorkerVersionModule(
+            policy.productionWorker,
+            versionId
+        );
+        validateActiveWorkerModule({
+            artifact,
+            observed,
+        });
+        return observed;
+    } catch (error) {
+        throw manualRecoveryError({
+            site,
+            workerName: policy.productionWorker,
+            operation: "exact active Worker version module-set proof",
+            error,
+        });
+    }
+};
+
+const finalVerify = async ({
+    entries,
+    configs,
+    artifacts,
+    expectedCommit,
+    operations,
+    invocationCandidates,
+}) => {
+    const attachmentPlans = entries.map(({ site, policy }) => ({
+        site,
+        policy,
+        ...productionWorkerConfig({ site, policy, configs }),
+    }));
+    const initialScripts = await readAndValidateProductionAttachments({
+        plans: attachmentPlans,
+        operations,
+    });
+    const identities = new Map();
+    const versions = new Map();
+    for (const { site, policy } of entries) {
+        const metadata = initialScripts.get(policy.productionWorker);
+        if (typeof metadata?.tag !== "string" || metadata.tag.length === 0) {
+            throw new Error(`${site.id}: final Worker identity is missing`);
+        }
+        identities.set(site.id, metadata.tag);
+        const deployments = await operations.getWorkerDeployments(
+            policy.productionWorker
+        );
+        const versionId = readCurrentVersion({ deployments, siteId: site.id });
+        if (!versionId) {
+            throw new Error(`${site.id}: final active deployment is missing`);
+        }
+        const candidate = invocationCandidates.get(site.id);
+        if (!candidate || candidate.versionId !== versionId) {
+            throw new Error(
+                `${site.id}: final active version was not created and proved by this apply invocation`
+            );
+        }
+        const { renderedConfig } = productionWorkerConfig({
+            site,
+            policy,
+            configs,
+        });
+        const { fingerprint: runtimeFingerprint } = validateProvisioningVersion(
+            {
+                version: await operations.getWorkerVersion(
+                    policy.productionWorker,
+                    versionId
+                ),
+                versionId,
+                versionTag: candidate.versionTag,
+                siteId: site.id,
+                expectedCommit,
+                renderedConfig,
+                artifactManifestDigest: candidate.artifactManifestDigest,
+            }
+        );
+        const observedModule = await confirmActiveWorkerModule({
+            site,
+            policy,
+            versionId,
+            artifact: artifacts.get(site.id),
+            operations,
+        });
+        const fingerprint = sha256Canonical({
+            runtimeFingerprint,
+            module: observedModule,
+        });
+        if (fingerprint !== candidate.versionFingerprint) {
+            throw new Error(
+                `${site.id}: final Worker version resource fingerprint changed`
+            );
+        }
+        versions.set(site.id, versionId);
+    }
+
+    for (const { site, policy } of entries) {
+        try {
+            await operations.verify({
+                site,
+                policy,
+                expectedCommit,
+                artifact: artifacts.get(site.id),
+            });
+        } catch (error) {
+            throw manualRecoveryError({
+                site,
+                workerName: policy.productionWorker,
+                operation:
+                    "exhaustive live artifact verification after activation",
+                error,
+            });
+        }
+    }
+
+    const finalScripts = await readAndValidateProductionAttachments({
+        plans: attachmentPlans,
+        operations,
+    });
+    for (const { site, policy } of entries) {
+        if (
+            finalScripts.get(policy.productionWorker)?.tag !==
+            identities.get(site.id)
+        ) {
+            throw new Error(
+                `${site.id}: immutable Worker identity changed during live verification`
+            );
+        }
+        const deployments = await operations.getWorkerDeployments(
+            policy.productionWorker
+        );
+        const versionId = readCurrentVersion({ deployments, siteId: site.id });
+        if (versionId !== versions.get(site.id)) {
+            throw new Error(
+                `${site.id}: exact active version changed during live verification`
+            );
+        }
+        const candidate = invocationCandidates.get(site.id);
+        const { renderedConfig } = productionWorkerConfig({
+            site,
+            policy,
+            configs,
+        });
+        const { fingerprint: runtimeFingerprint } = validateProvisioningVersion(
+            {
+                version: await operations.getWorkerVersion(
+                    policy.productionWorker,
+                    versionId
+                ),
+                versionId,
+                versionTag: candidate.versionTag,
+                siteId: site.id,
+                expectedCommit,
+                renderedConfig,
+                artifactManifestDigest: candidate.artifactManifestDigest,
+            }
+        );
+        const observedModule = await confirmActiveWorkerModule({
+            site,
+            policy,
+            versionId,
+            artifact: artifacts.get(site.id),
+            operations,
+        });
+        if (
+            sha256Canonical({
+                runtimeFingerprint,
+                module: observedModule,
+            }) !== candidate.versionFingerprint
+        ) {
+            throw new Error(
+                `${site.id}: exact active runtime or module changed during live verification`
+            );
+        }
+    }
+};
+
+export const provisionProductionEntries = async ({
+    entries,
+    configs,
+    artifacts,
+    expectedCommit,
+    accountId,
+    mode,
+    plannedStateDigest,
+    operations,
+    log = console.log,
+}) => {
+    if (mode !== "plan" && mode !== "apply") {
+        throw new Error("Provisioning mode must be plan or apply");
+    }
+    if (!CLOUDFLARE_ACCOUNT_ID.test(accountId || "")) {
+        throw new Error(
+            "Provisioning requires the exact Cloudflare account identity"
+        );
+    }
+    const invocationNonce =
+        mode === "apply" ? randomBytes(16).toString("hex") : undefined;
+    const invocationCandidates = new Map();
+    const context = {
+        entries,
+        configs,
+        artifacts,
+        expectedCommit,
+        operations,
+        invocationNonce,
+        invocationCandidates,
+    };
+    const initial = await inspect(context);
+    const observedStateDigest = productionProvisioningStateDigest({
+        inspection: initial,
+        expectedCommit,
+        accountId,
+    });
+    if (mode === "apply" && plannedStateDigest == null) {
+        throw new Error(
+            "Provisioning apply requires the exact state digest emitted by a reviewed plan"
+        );
+    }
+    if (plannedStateDigest != null) {
+        if (!STATE_DIGEST.test(plannedStateDigest)) {
+            throw new Error(
+                "Provisioning apply state receipt must be a lowercase SHA-256 digest"
+            );
+        }
+        if (plannedStateDigest !== observedStateDigest) {
+            throw new Error(
+                `Cloudflare provisioning state changed after review (planned ${plannedStateDigest}, observed ${observedStateDigest}); run and review a new plan`
+            );
+        }
+    }
+    const summary = planSummary(initial.plans, initial.previewPlans);
+    log(
+        `${mode === "plan" ? "Read-only" : "Confirmed"} Cloudflare production provisioning plan for ${expectedCommit} with PLAN_STATE_SHA256=${observedStateDigest}: ${JSON.stringify(
+            summary
+        )}`
+    );
+    if (mode === "plan") {
+        log("Read-only plan complete; no Cloudflare mutations were dispatched");
+        Object.defineProperty(summary, "stateDigest", {
+            value: observedStateDigest,
+            enumerable: false,
+        });
+        return summary;
+    }
+
+    const productionLedger = createProductionLedger(initial);
+    const assertPinnedInspection = (
+        inspection,
+        {
+            phase,
+            skipProductionSiteId,
+            requirePublicFence = false,
+            allowProductionWorker,
+        } = {}
+    ) => {
+        assertProductionLedger(productionLedger, inspection, {
+            skipSiteId: skipProductionSiteId,
+            phase,
+        });
+        assertSamePreviewInventory(initial, inspection, phase);
+        assertSameQueueConsumerInventory(initial, inspection, phase);
+        if (requirePublicFence) {
+            assertAllManagedPublicUrlsDisabled(inspection, phase, {
+                allowProductionWorker,
+            });
+        }
+        return inspection;
+    };
+    const readPinnedInspection = async (options) =>
+        assertPinnedInspection(await inspect(context), options);
+    const readFencedInspection = (phase) =>
+        readPinnedInspection({ phase, requirePublicFence: true });
+
+    const stopAfterFailedUploadProof = async ({
+        before,
+        uploadError,
+        proofError,
+    }) => {
+        let exactCleanupError;
+        try {
+            // Even when the upload's Worker identity cannot be learned, the
+            // exact reviewed Worker name is independently pinned. Disabling
+            // its two public URL surfaces is privacy-reducing and must happen
+            // before this failed invocation exits.
+            await disableAndConfirm({
+                plan: before,
+                operations,
+                log,
+                force: true,
+            });
+        } catch (error) {
+            exactCleanupError = error;
+        }
+
+        let cleanupFenceError;
+        try {
+            // Do not learn the failed upload's identity or version. Every
+            // other production ledger entry and every preview identity stays
+            // pinned, while the complete public-URL fence includes the
+            // current exact Worker if it appeared.
+            assertPinnedInspection(await inspect(context), {
+                phase: "after failed route-free upload cleanup",
+                skipProductionSiteId: before.site.id,
+                requirePublicFence: true,
+            });
+        } catch (error) {
+            cleanupFenceError = error;
+        }
+
+        throw failedUploadRecoveryError({
+            site: before.site,
+            workerName: before.workerName,
+            uploadError,
+            proofError,
+            exactCleanupError,
+            cleanupFenceError,
+        });
+    };
+
+    const disableDuringPreflight = async ({ plan, selectAfter }) => {
+        await disableAndConfirm({
+            plan,
+            operations,
+            log,
+            force: false,
+        });
+        try {
+            const inspection = await readPinnedInspection({
+                phase: "after a public-URL preflight mutation",
+            });
+            const after = selectAfter(inspection);
+            if (
+                !after.workerExists ||
+                !disabledPublicState(after.subdomainState)
+            ) {
+                throw new Error(
+                    `${plan.workerName}: exact disabled public-URL state was not retained`
+                );
+            }
+        } catch (error) {
+            throw manualRecoveryError({
+                site: plan.site,
+                workerName: plan.workerName,
+                operation: "public-URL preflight",
+                error,
+            });
+        }
+    };
+
+    // Inventory and immutable production state were pinned by the initial
+    // inspection. Disable every existing preview and production public URL
+    // before any upload, activation, or domain attachment. Missing Workers are
+    // never created by this phase.
+    for (const { site } of entries) {
+        const inspection = await readPinnedInspection({
+            phase: "before a preview public-URL preflight mutation",
+        });
+        const preview = previewPlanFor(inspection, site.id);
+        if (
+            !preview.workerExists ||
+            disabledPublicState(preview.subdomainState)
+        ) {
+            continue;
+        }
+        await disableDuringPreflight({
+            plan: preview,
+            selectAfter: (after) => previewPlanFor(after, site.id),
+        });
+    }
+    for (const { site } of entries) {
+        const inspection = await readPinnedInspection({
+            phase: "before a production public-URL preflight mutation",
+        });
+        const production = planFor(inspection, site.id);
+        if (
+            !production.workerExists ||
+            disabledPublicState(production.subdomainState)
+        ) {
+            continue;
+        }
+        await disableDuringPreflight({
+            plan: production,
+            selectAfter: (after) => planFor(after, site.id),
+        });
+    }
+    await readFencedInspection(
+        "before the first production deployment mutation"
+    );
+
+    for (const { site } of entries) {
+        const before = planFor(
+            await readFencedInspection("before a route-free version upload"),
+            site.id
+        );
+        if (!before.active && !before.versionId) {
+            const pinnedBefore = productionLedgerFor(productionLedger, site.id);
+            let uploadEvidence;
+            let uploadError;
+            try {
+                uploadEvidence = await operations.upload({
+                    configFile: before.file,
+                    renderedConfig: before.renderedConfig,
+                    site: before.site,
+                    policy: before.policy,
+                    expectedCommit,
+                    versionTag: before.versionTag,
+                    artifact: before.artifact,
+                });
+            } catch (error) {
+                uploadError = error;
+                uploadEvidence = error?.deploymentEvidence;
+            }
+            let afterUpload;
+            let uploadProofError;
+            try {
+                if (
+                    !uploadEvidence ||
+                    uploadEvidence.workerName !== before.workerName ||
+                    typeof uploadEvidence.workerTag !== "string" ||
+                    uploadEvidence.workerTag.length === 0 ||
+                    !VERSION_ID.test(uploadEvidence.versionId || "") ||
+                    uploadEvidence.artifactManifestDigest !==
+                        before.artifactManifestDigest ||
+                    (before.workerExists &&
+                        uploadEvidence.workerTag !== before.workerTag)
+                ) {
+                    throw new Error(
+                        "same-invocation structured Wrangler upload evidence is missing or malformed"
+                    );
+                }
+                invocationCandidates.set(site.id, {
+                    ...uploadEvidence,
+                    versionTag: before.versionTag,
+                });
+                const afterInspection = assertPinnedInspection(
+                    await inspect(context),
+                    {
+                        phase: "after a route-free version upload",
+                        skipProductionSiteId: site.id,
+                        requirePublicFence: true,
+                        // Wrangler can transiently expose only the Worker it
+                        // just uploaded. It is disabled immediately below.
+                        allowProductionWorker: before.workerName,
+                    }
+                );
+                afterUpload = planFor(afterInspection, site.id);
+                const expectedVersionIds = [
+                    ...pinnedBefore.deployableVersionIds,
+                    afterUpload.versionId,
+                ].sort();
+                if (
+                    !afterUpload.workerExists ||
+                    !afterUpload.versionId ||
+                    afterUpload.active ||
+                    afterUpload.activeVersionId !==
+                        pinnedBefore.activeVersionId ||
+                    pinnedBefore.deployableVersionIds.includes(
+                        afterUpload.versionId
+                    ) ||
+                    JSON.stringify(
+                        [...afterUpload.deployableVersionIds].sort()
+                    ) !== JSON.stringify(expectedVersionIds) ||
+                    afterUpload.domainAttached !==
+                        pinnedBefore.domainAttached ||
+                    (pinnedBefore.workerExists &&
+                        afterUpload.workerTag !== pinnedBefore.workerTag) ||
+                    (!pinnedBefore.workerExists &&
+                        (typeof afterUpload.workerTag !== "string" ||
+                            afterUpload.workerTag.length === 0))
+                ) {
+                    throw new Error(
+                        "exact inactive uploaded Worker/version transition was not observed"
+                    );
+                }
+                validateUploadEvidence({
+                    plan: afterUpload,
+                    evidence: uploadEvidence,
+                });
+                invocationCandidates.get(site.id).versionFingerprint =
+                    afterUpload.versionFingerprint;
+                Object.assign(
+                    productionLedgerFor(productionLedger, site.id),
+                    productionLedgerState(afterUpload)
+                );
+                assertProductionLedger(productionLedger, afterInspection, {
+                    phase: "after learning the exact Wrangler-owned upload",
+                });
+            } catch (error) {
+                uploadProofError = error;
+            }
+            if (uploadProofError) {
+                invocationCandidates.delete(site.id);
+                await stopAfterFailedUploadProof({
+                    before,
+                    uploadError,
+                    proofError: uploadProofError,
+                });
+            }
+            if (uploadError) {
+                log(
+                    `${site.id}: ambiguous upload response was resolved by matching Wrangler evidence and exact Worker/version/tag GETs`
+                );
+            }
+            // This is the only allowed public-URL transient: the current
+            // freshly uploaded Worker. No other mutation can occur before its
+            // immediate disable and the restored invocation-wide fence.
+            await disableAndConfirm({
+                plan: afterUpload,
+                operations,
+                log,
+                force: true,
+            });
+            try {
+                await readFencedInspection(
+                    "after the freshly uploaded Worker public-URL disable"
+                );
+            } catch (error) {
+                throw manualRecoveryError({
+                    site: before.site,
+                    workerName: before.workerName,
+                    operation: "post-upload public-URL disable",
+                    error,
+                });
+            }
+        }
+
+        const ready = planFor(
+            await readFencedInspection("before an exact 100% activation"),
+            site.id
+        );
+        if (!ready.versionId) {
+            throw new Error(
+                `${site.id}: exact provisioning version is missing`
+            );
+        }
+        if (!ready.active) {
+            const pinnedBefore = productionLedgerFor(productionLedger, site.id);
+            let activation;
+            let activationError;
+            try {
+                activation = await operations.activate({
+                    workerName: ready.workerName,
+                    versionId: ready.versionId,
+                    message: `peerbit-examples ${site.id} initial 100% production baseline ${expectedCommit}`,
+                });
+            } catch (error) {
+                activationError = error;
+            }
+            if (activation) {
+                const activatedVersion = readSingleVersionDeployment(
+                    activation,
+                    site.id
+                );
+                if (activatedVersion !== ready.versionId) {
+                    activationError = new Error(
+                        `activation selected ${activatedVersion}, expected ${ready.versionId}`
+                    );
+                }
+            }
+            let afterActivation;
+            try {
+                const afterInspection = assertPinnedInspection(
+                    await inspect(context),
+                    {
+                        phase: "after an exact 100% activation",
+                        skipProductionSiteId: site.id,
+                        requirePublicFence: true,
+                    }
+                );
+                afterActivation = planFor(afterInspection, site.id);
+                if (
+                    !afterActivation.workerExists ||
+                    afterActivation.workerTag !== pinnedBefore.workerTag ||
+                    afterActivation.versionId !== pinnedBefore.versionId ||
+                    !afterActivation.active ||
+                    afterActivation.domainAttached !==
+                        pinnedBefore.domainAttached
+                ) {
+                    throw new Error("exact active version was not observed");
+                }
+                pinnedBefore.activeVersionId = pinnedBefore.versionId;
+                pinnedBefore.active = true;
+                assertProductionLedger(productionLedger, afterInspection, {
+                    phase: "after recording the exact owned activation",
+                });
+            } catch (error) {
+                throw manualRecoveryError({
+                    site: ready.site,
+                    workerName: ready.workerName,
+                    operation: "exact 100% activation",
+                    error,
+                });
+            }
+            if (activationError) {
+                log(
+                    `${site.id}: ambiguous activation response was resolved by an exact 100% active-version GET`
+                );
+            }
+            await confirmActiveWorkerModule({
+                site: ready.site,
+                policy: ready.policy,
+                versionId: ready.versionId,
+                artifact: ready.artifact,
+                operations,
+            });
+            await readFencedInspection(
+                "after the exact active Worker version module-set proof"
+            );
+        }
+    }
+
+    for (const { site } of entries) {
+        const before = planFor(
+            await readFencedInspection("before a custom-domain attachment"),
+            site.id
+        );
+        if (!before.active) {
+            throw new Error(
+                `${site.id}: custom domain cannot be attached before an exact active baseline exists`
+            );
+        }
+        if (before.domainAttached) continue;
+        const pinnedBefore = productionLedgerFor(productionLedger, site.id);
+        let attachment;
+        let attachmentError;
+        try {
+            attachment = await operations.attachDomain({
+                workerName: before.workerName,
+                hostname: before.hostname,
+            });
+        } catch (error) {
+            attachmentError = error;
+        }
+        if (
+            attachment &&
+            (attachment.hostname !== before.hostname ||
+                attachment.service !== before.workerName ||
+                attachment.environment !== "production")
+        ) {
+            attachmentError = new Error(
+                "custom-domain mutation returned the wrong attachment"
+            );
+        }
+        try {
+            const afterInspection = assertPinnedInspection(
+                await inspect(context),
+                {
+                    phase: "after a custom-domain attachment",
+                    skipProductionSiteId: site.id,
+                    requirePublicFence: true,
+                }
+            );
+            const after = planFor(afterInspection, site.id);
+            if (
+                !after.workerExists ||
+                after.workerTag !== pinnedBefore.workerTag ||
+                after.versionId !== pinnedBefore.versionId ||
+                after.active !== pinnedBefore.active ||
+                !after.domainAttached
+            ) {
+                throw new Error("exact custom domain was not observed");
+            }
+            pinnedBefore.domainAttached = true;
+            assertProductionLedger(productionLedger, afterInspection, {
+                phase: "after recording the exact owned custom domain",
+            });
+        } catch (error) {
+            throw manualRecoveryError({
+                site: before.site,
+                workerName: before.workerName,
+                operation: "reviewed custom-domain attachment",
+                error,
+            });
+        }
+        if (attachmentError) {
+            log(
+                `${site.id}: ambiguous domain response was resolved by a stable exact custom-domain inventory GET`
+            );
+        }
+    }
+
+    await readFencedInspection("before final live verification");
+    await finalVerify({
+        entries,
+        configs,
+        artifacts,
+        expectedCommit,
+        operations,
+        invocationCandidates,
+    });
+    const finalInspection = await readFencedInspection(
+        "after final live verification"
+    );
+    log(
+        `Provisioned and verified ${entries.length} exact Cloudflare production Workers at 100% for ${expectedCommit}`
+    );
+    return planSummary(finalInspection.plans, finalInspection.previewPlans);
+};
+
+export const parseProductionProvisioningArgs = (argv) => {
+    const allowed = new Set([
+        "mode",
+        "commit",
+        "planned-commit",
+        "planned-state-digest",
+        "confirm",
+    ]);
+    if (argv.length !== 10) {
+        throw new Error(
+            "Usage: provision-cloudflare-production.mjs --mode plan|apply --commit SHA --planned-commit SHA --planned-state-digest SHA256_OR_PLAN_SENTINEL --confirm STATE_BOUND_PHRASE"
+        );
+    }
+    const args = new Map();
+    for (let index = 0; index < argv.length; index += 2) {
+        const key = argv[index];
+        const value = argv[index + 1];
+        if (!key?.startsWith("--") || value == null) {
+            throw new Error("Production provisioning arguments are malformed");
+        }
+        const name = key.slice(2);
+        if (!allowed.has(name) || args.has(name)) {
+            throw new Error(
+                `Unsupported or duplicate provisioning argument ${key}`
+            );
+        }
+        args.set(name, value);
+    }
+    const mode = args.get("mode");
+    const expectedCommit = args.get("commit");
+    const plannedCommit = args.get("planned-commit");
+    const plannedStateDigest = args.get("planned-state-digest");
+    const confirmation = args.get("confirm");
+    if (mode !== "plan" && mode !== "apply") {
+        throw new Error("Provisioning mode must be plan or apply");
+    }
+    if (!FULL_GIT_COMMIT.test(expectedCommit || "")) {
+        throw new Error("Provisioning requires a full Git commit hash");
+    }
+    if (!FULL_GIT_COMMIT.test(plannedCommit || "")) {
+        throw new Error(
+            "Provisioning requires an explicit full planned commit receipt"
+        );
+    }
+    const normalizedExpectedCommit = expectedCommit.toLowerCase();
+    const normalizedPlannedCommit = plannedCommit.toLowerCase();
+    if (normalizedPlannedCommit !== normalizedExpectedCommit) {
+        throw new Error(
+            "The explicit planned commit receipt must equal the checked-out commit"
+        );
+    }
+    if (
+        !STATE_DIGEST.test(plannedStateDigest || "") ||
+        (mode === "plan" &&
+            plannedStateDigest !== PROVISIONING_PLAN_STATE_SENTINEL) ||
+        (mode === "apply" &&
+            plannedStateDigest === PROVISIONING_PLAN_STATE_SENTINEL)
+    ) {
+        throw new Error(
+            mode === "plan"
+                ? `Plan requires the state-digest sentinel ${PROVISIONING_PLAN_STATE_SENTINEL}`
+                : "Apply requires the nonzero SHA-256 state digest emitted by the reviewed plan"
+        );
+    }
+    const requiredConfirmation = productionProvisioningConfirmation({
+        mode,
+        plannedCommit: normalizedPlannedCommit,
+        plannedStateDigest,
+    });
+    if (confirmation !== requiredConfirmation) {
+        throw new Error(
+            `${mode} requires the exact SHA-bound confirmation phrase ${requiredConfirmation}`
+        );
+    }
+    return {
+        mode,
+        expectedCommit: normalizedExpectedCommit,
+        plannedCommit: normalizedPlannedCommit,
+        plannedStateDigest,
+    };
+};
+
+const runVerifier = ({ site, expectedCommit, artifact }) => {
+    const verifier = path.join(repoRoot, "scripts/verify-cloudflare-sites.mjs");
+    const result = spawnSync(
+        process.execPath,
+        [
+            verifier,
+            "--mode",
+            "production",
+            "--site",
+            site.id,
+            "--commit",
+            expectedCommit,
+            "--artifact-manifest-digest",
+            artifact.digest,
+        ],
+        {
+            cwd: repoRoot,
+            env: withoutCloudflareDeploymentCredentials(process.env),
+            stdio: "inherit",
+        }
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+        throw new Error(
+            `${site.id}: production runtime verifier exited ${result.status}`
+        );
+    }
+};
+
+const runProductionBrowserSmoke = ({ site, runtimeSmokeEnvironment }) => {
+    const smokeNames = new Map([
+        ["files", "file-share boots and connects to an authoritative relay"],
+        ["stream", "streaming preview serves exact MP4 byte ranges"],
+    ]);
+    const smokeName = smokeNames.get(site.id);
+    if (!smokeName) return;
+    const result = spawnSync(
+        "pnpm",
+        [
+            "--dir",
+            "packages/file-share/frontend",
+            "exec",
+            "playwright",
+            "test",
+            "-c",
+            "playwright.config.ts",
+            "tests/cloudflare-preview.e2e.spec.ts",
+            "--project=chromium",
+            "--workers=1",
+            "--retries=1",
+            "--grep",
+            smokeName,
+        ],
+        {
+            cwd: repoRoot,
+            env: {
+                ...withoutCloudflareDeploymentCredentials(process.env),
+                PW_CLOUDFLARE_SMOKE: "1",
+                ...runtimeSmokeEnvironment,
+            },
+            stdio: "inherit",
+        }
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+        throw new Error(
+            `${site.id}: production browser smoke exited ${result.status}`
+        );
+    }
+};
+
+export const main = async (argv = process.argv.slice(2)) => {
+    const { mode, expectedCommit, plannedStateDigest } =
+        parseProductionProvisioningArgs(argv);
+    const { entries } = loadCloudflareDeploymentData();
+    validateProvisioningEntries(entries);
+    const configs = validateRenderedCloudflareConfigSet({
+        directory: path.join(repoRoot, ".wrangler-config"),
+        entries,
+        mode: "production",
+    });
+    const artifacts = loadCloudflareArtifactManifestSet({
+        entries,
+        configs,
+        expectedCommit,
+    });
+    const workersApi = createCloudflareWorkersApi({
+        accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
+        apiToken: process.env.CLOUDFLARE_API_TOKEN,
+    });
+    const wrangler = path.join(
+        repoRoot,
+        "tools/wrangler/node_modules/.bin/wrangler"
+    );
+    const runtimeSmokeEnvironment = productionSmokeEnvironment(entries);
+    const operations = {
+        listWorkerScripts: workersApi.listWorkerScripts,
+        listWorkerDomains: workersApi.listWorkerDomains,
+        getWorkerSubdomain: workersApi.getWorkerSubdomain,
+        listWorkerSchedules: workersApi.listWorkerSchedules,
+        listQueueConsumerInventory: workersApi.listQueueConsumerInventory,
+        getWorkerDeployments: workersApi.getWorkerDeployments,
+        listDeployableWorkerVersions: workersApi.listDeployableWorkerVersions,
+        getWorkerVersion: workersApi.getWorkerVersion,
+        getWorkerVersionModule: workersApi.getWorkerVersionModule,
+        disableWorkerSubdomain: workersApi.disableWorkerSubdomain,
+        attachDomain: workersApi.attachWorkerDomain,
+        activate: workersApi.createDeployment,
+        upload: ({
+            configFile,
+            renderedConfig,
+            site,
+            policy,
+            expectedCommit: commit,
+            versionTag,
+            artifact,
+        }) =>
+            runWranglerVersionUpload({
+                wrangler,
+                configFile,
+                renderedConfig,
+                site,
+                expectedCommit: commit,
+                workerName: policy.productionWorker,
+                versionTag,
+                artifact,
+            }),
+        verify: (input) => {
+            runVerifier(input);
+            runProductionBrowserSmoke({
+                site: input.site,
+                runtimeSmokeEnvironment,
+            });
+        },
+    };
+    await provisionProductionEntries({
+        entries,
+        configs,
+        artifacts,
+        expectedCommit,
+        accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
+        mode,
+        ...(mode === "apply" ? { plannedStateDigest } : {}),
+        operations,
+    });
+};
+
+if (
+    process.argv[1] &&
+    path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+    main().catch((error) => {
+        console.error(diagnostic(error));
+        process.exitCode = 1;
+    });
+}

--- a/scripts/render-cloudflare-configs.mjs
+++ b/scripts/render-cloudflare-configs.mjs
@@ -143,6 +143,10 @@ const baseConfig = (entry) => ({
     compatibility_date: manifest.compatibilityDate,
     workers_dev: false,
     preview_urls: false,
+    // Keep dry-run output and the eventual exact-version multipart upload to
+    // one reviewed ES module. Wrangler otherwise emits a linked source map to
+    // --outdir by default even when source-map upload is not requested.
+    upload_source_maps: false,
     ...(mode === "production"
         ? {
               routes: entry.domains.map((domain) => ({

--- a/scripts/validate-wrangler-toolchain.mjs
+++ b/scripts/validate-wrangler-toolchain.mjs
@@ -1,0 +1,62 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    ".."
+);
+const toolRoot = path.join(repoRoot, "tools/wrangler");
+const readJson = (file) => JSON.parse(readFileSync(file, "utf8"));
+const packageJson = readJson(path.join(toolRoot, "package.json"));
+const packageLock = readJson(path.join(toolRoot, "package-lock.json"));
+const installedEsbuild = readJson(
+    path.join(toolRoot, "node_modules/esbuild/package.json")
+);
+const expectedWrangler = packageJson.devDependencies?.wrangler;
+const lockedWrangler = packageLock.packages?.["node_modules/wrangler"]?.version;
+const lockedEsbuild = packageLock.packages?.["node_modules/esbuild"]?.version;
+
+if (
+    expectedWrangler !== "4.110.0" ||
+    lockedWrangler !== expectedWrangler ||
+    typeof lockedEsbuild !== "string" ||
+    installedEsbuild.version !== lockedEsbuild
+) {
+    throw new Error(
+        "Locked Wrangler/esbuild package versions are inconsistent"
+    );
+}
+
+const exactVersion = (command, args, expected, label) => {
+    const result = spawnSync(command, args, {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: process.env,
+    });
+    if (result.error) throw result.error;
+    const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`.trim();
+    if (result.status !== 0 || !output.split(/\s+/).includes(expected)) {
+        throw new Error(
+            `${label} executable does not match its locked package version ${expected}`
+        );
+    }
+};
+
+exactVersion(
+    path.join(toolRoot, "node_modules/.bin/esbuild"),
+    ["--version"],
+    lockedEsbuild,
+    "esbuild"
+);
+exactVersion(
+    path.join(toolRoot, "node_modules/.bin/wrangler"),
+    ["--version"],
+    expectedWrangler,
+    "Wrangler"
+);
+
+console.log(
+    `Validated Wrangler ${expectedWrangler} with matching esbuild ${lockedEsbuild}`
+);

--- a/scripts/verify-cloudflare-sites.mjs
+++ b/scripts/verify-cloudflare-sites.mjs
@@ -1,6 +1,14 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+    loadCloudflareDeploymentData,
+    validateRenderedCloudflareConfigSet,
+} from "./cloudflare-deployment-policy.mjs";
+import {
+    loadCloudflareArtifactManifest,
+    verifyLiveCloudflareArtifact,
+} from "./cloudflare-artifact-manifest.mjs";
 
 const repoRoot = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
@@ -16,7 +24,7 @@ for (let index = 2; index < process.argv.length; index += 2) {
     const value = process.argv[index + 1];
     if (!key?.startsWith("--") || value == null) {
         throw new Error(
-            "Usage: verify-cloudflare-sites.mjs --mode production [--commit SHA] [--target apps|all] [--site ID]"
+            "Usage: verify-cloudflare-sites.mjs --mode production [--commit SHA] [--target apps|all] [--site ID] [--artifact-manifest-digest SHA256]"
         );
     }
     args.set(key.slice(2), value);
@@ -28,6 +36,13 @@ if (mode !== "production") {
 const expectedCommit = args.get("commit");
 if (expectedCommit && !/^[0-9a-f]{40}$/i.test(expectedCommit)) {
     throw new Error("--commit must be a full Git commit hash");
+}
+const expectedArtifactDigest = args.get("artifact-manifest-digest");
+if (
+    expectedArtifactDigest != null &&
+    !/^[0-9a-f]{64}$/.test(expectedArtifactDigest)
+) {
+    throw new Error("--artifact-manifest-digest must be a SHA-256 digest");
 }
 const target = args.get("target") || "all";
 if (!["apps", "all"].includes(target)) {
@@ -86,6 +101,33 @@ const originsFor = (entry) =>
 const selectedStaticSites = requestedSite
     ? manifest.staticSites.filter((site) => site.id === requestedSite)
     : manifest.staticSites;
+let expectedArtifact;
+if (expectedArtifactDigest) {
+    if (!requestedSite || !expectedCommit) {
+        throw new Error(
+            "Artifact verification requires one --site and an exact --commit"
+        );
+    }
+    const { entries } = loadCloudflareDeploymentData();
+    const entry = entries.find(({ site }) => site.id === requestedSite);
+    const configs = validateRenderedCloudflareConfigSet({
+        directory: path.join(repoRoot, ".wrangler-config"),
+        entries,
+        mode: "production",
+    });
+    const rendered = configs.get(requestedSite);
+    expectedArtifact = loadCloudflareArtifactManifest({
+        ...entry,
+        configFile: rendered.file,
+        renderedConfig: rendered.config,
+        expectedCommit,
+    });
+    if (expectedArtifact.digest !== expectedArtifactDigest) {
+        throw new Error(
+            `${requestedSite}: artifact receipt does not match the reviewed manifest`
+        );
+    }
+}
 for (const site of selectedStaticSites) {
     for (const origin of originsFor(site)) {
         await verifyEventually(origin, async () => {
@@ -166,6 +208,14 @@ for (const site of selectedStaticSites) {
             const hiddenHeaders = await request(`${origin}/_headers`);
             if (hiddenHeaders.status !== 404)
                 throw new Error(`${origin}: _headers is publicly served`);
+
+            if (expectedArtifact) {
+                await verifyLiveCloudflareArtifact({
+                    origin,
+                    artifact: expectedArtifact,
+                    request,
+                });
+            }
 
             for (const mediaPath of site.workerFirst || []) {
                 const fixture = readFileSync(


### PR DESCRIPTION
## Summary

- add a SHA-bound plan/apply workflow for the seven supported apps.peerbit.org Workers
- pin Worker identities, versions, domains, and preview identities across the entire invocation
- enforce false/false public-subdomain fencing before and after every mutation
- make ambiguous or failed uploads perform mandatory exact-name cleanup before surfacing recovery diagnostics
- document the protected Cloudflare production environment and operator workflow

## Safety

The provisioner has no executable Worker DELETE path. It refuses legacy/shadow Workers, cross-site identity replacement, unreviewed commits, public preview URLs, domain drift, and missing or mismatched Wrangler evidence. A failed upload cannot proceed to activation or domain attachment.

## Validation

- 178/178 Cloudflare tests
- all seven asset bundles and Wrangler 4.110.0 dry runs
- bootstrap validation
- Prettier and git diff check
- three independent adversarial exploit replays fail safely