### PR TITLE
fix(cloudflare): reconcile authoritative route inventory

### DIFF
--- a/.github/workflows/cloudflare-production-provision.yml
+++ b/.github/workflows/cloudflare-production-provision.yml
@@ -252,9 +252,15 @@ jobs:
                   install --with-deps chromium
 
             - name: Plan or provision exact production baseline
+              # The protected token must cover Zone Read and Workers Routes
+              # Read across every account zone, in addition to the narrowly
+              # documented account-level Workers and Queue permissions.
+              # The protected zone fingerprint must be derived independently;
+              # never derive it with this possibly permission-filtered token.
               env:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PRODUCTION_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+                  CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256: ${{ vars.CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 }}
                   PROVISION_MODE: ${{ inputs.mode }}
                   PROVISION_CONFIRM: ${{ inputs.confirm }}
                   PROVISION_PLANNED_COMMIT: ${{ inputs.planned_commit }}

--- a/.github/workflows/cloudflare-production.yml
+++ b/.github/workflows/cloudflare-production.yml
@@ -128,9 +128,15 @@ jobs:
                   install --with-deps chromium
 
             - name: Deploy, verify, and roll back each selected target
+              # The protected token needs Workers Scripts Read plus Zone Read
+              # and Workers Routes Read across every account zone so routine
+              # attachment fences can use authoritative per-zone route truth.
+              # The protected zone fingerprint must be derived independently;
+              # never derive it with this possibly permission-filtered token.
               env:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PRODUCTION_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+                  CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256: ${{ vars.CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 }}
                   DEPLOY_TARGET: ${{ inputs.target }}
                   DEPLOY_COMMIT: ${{ github.sha }}
                   PW_CLOUDFLARE_SMOKE: "1"

--- a/README.md
+++ b/README.md
@@ -126,26 +126,47 @@ done
 Production configs are rendered with `--mode production`. First-party demo
 Workers are restricted to `*.apps.peerbit.org` and must exactly match the
 deployment policy. Before any upload or promotion, production reads the
-account's Worker route inventory and every page of its custom-domain inventory
-with `Workers Scripts Read`. It accepts the custom-domain inventory only after
-two independently read, canonical complete snapshots match. The account-wide
-check requires every reviewed production Worker, including Workers outside a
-targeted release, to have no traditional routes and exactly its reviewed custom
-domain. It also reads each production Worker's live `workers.dev` and version
+account's complete zone inventory and each zone's authoritative Worker routes,
+plus every page of its custom-domain inventory. The protected token therefore
+needs `Workers Scripts Read`, `Zone Read`, and `Workers Routes Read` across every
+zone in the account. Zone enumeration explicitly includes `full`, `partial`,
+`secondary`, and `internal` zones and accepts the route inventory only after two
+independently read, canonical complete snapshots match. Cloudflare's optional
+inline script-route field is used only as a consistency check when present;
+missing inline routes defer to the authoritative per-zone result. Custom-domain
+zone IDs and names must exist in that same account snapshot. The account-wide
+zone list is permission-filtered, so a successful paginated response is not by
+itself proof that the token can see every zone. The protected environment must
+also define `CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256`, derived independently
+from a full dashboard/admin inventory. Its input is the UTF-8 JSON encoding of
+every expected `{zoneId,zoneName}` object, with exactly those keys, lowercase
+values, no extra whitespace or newline, sorted first by `zoneId` and then by
+`zoneName` using ascending code-point order. Missing, malformed, or mismatched
+fingerprints stop both routine deploys and provisioning before mutation; the
+running transaction rechecks the fingerprint at every attachment fence. Do not
+derive or update this protected value from the deployment token's own `/zones`
+response.
+
+The account-wide check requires every reviewed production Worker, including
+Workers outside a targeted release, to have no traditional routes and exactly
+its reviewed custom domain. It also reads each production Worker's live
+`workers.dev` and version
 Preview URL state, plus that state for every existing allowlisted preview
 Worker, and requires both flags to be disabled. It rejects retired Worker
 identities, unreviewed ownership under `*.apps.peerbit.org`, and traditional
 routes involving the managed namespace; unrelated account Workers and domains
-remain outside this policy. The full read-only policy fence runs immediately
-before and after every inactive upload. Wrangler output is captured rather than
-echoed, and an unexpected `workers.dev` URL fails closed without exposing the
-account subdomain. Production deploys capture every selected app's current 100%
-version, release identity, and immutable Worker identity. They then upload every
-new version without activating it, verify its per-invocation version tag, and
-revalidate every baseline before promoting traffic. Exact versions are promoted
-through Cloudflare's deployments API; that endpoint cannot alter routes or
-custom domains. After every runtime check, all activated apps receive a final
-exact version, version-tag, Worker-tag, public-subdomain, and attachment recheck.
+remain outside this policy. The complete authoritative zone/route snapshot is
+pinned for the transaction, and the full read-only policy fence runs immediately
+before and after every inactive upload and activation. Wrangler output is
+captured rather than echoed, and an unexpected `workers.dev` URL fails closed
+without exposing the account subdomain. Production deploys capture every
+selected app's current 100% version, release identity, and immutable Worker
+identity. They then upload every new version without activating it, verify its
+per-invocation version tag, and revalidate every baseline before promoting
+traffic. Exact versions are promoted through Cloudflare's deployments API; that
+endpoint cannot alter routes or custom domains. After every runtime check, all
+activated apps receive a final exact version, version-tag, Worker-tag,
+public-subdomain, and attachment recheck.
 If a later promotion or verification fails, earlier versions from the invocation
 are unwound in reverse order only while each exact version, version tag, Worker
 identity, and public attachment still match. After the rollback verifier, the

--- a/cloudflare/deployment-safety.test.mjs
+++ b/cloudflare/deployment-safety.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
@@ -11,6 +12,7 @@ import {
     validateRenderedCloudflareConfig,
 } from "../scripts/cloudflare-deployment-policy.mjs";
 import {
+    accountZoneInventorySha256,
     createRouteFreeWranglerConfig,
     deployProductionEntries as deployProductionEntriesWithPolicy,
     parseWranglerVersionUploadOutput,
@@ -36,12 +38,17 @@ const OLD_COMMIT = "b".repeat(40);
 const OLD_VERSION = "11111111-1111-4111-8111-111111111111";
 const NEW_VERSION = "22222222-2222-4222-8222-222222222222";
 const ZONE_ID = "e".repeat(32);
+const EXAMPLE_ZONE_ID = "f".repeat(32);
+const EXPECTED_ZONE_INVENTORY_SHA256 = accountZoneInventorySha256([
+    { zoneId: ZONE_ID, zoneName: "peerbit.org" },
+]);
 const WORKER_TAGS = new Map([
     ["files", "files-tag-11111111"],
     ["stream", "stream-tag-22222222"],
 ]);
 const CLOUDFLARE_CREDENTIALS = {
     CLOUDFLARE_ACCOUNT_ID: "account-id-secret",
+    CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256: "f".repeat(64),
     CLOUDFLARE_API_TOKEN: "api-token-secret",
     CLOUDFLARE_API_KEY: "api-key-secret",
     CLOUDFLARE_EMAIL: "email-secret",
@@ -78,6 +85,15 @@ const rawWorkerDomain = (id, overrides = {}) => ({
     zone_name: "example.com",
     ...overrides,
 });
+const routineZoneRouteInventory = (routes = []) => [
+    {
+        zoneId: ZONE_ID,
+        zoneName: "peerbit.org",
+        status: "active",
+        type: "full",
+        routes: clone(routes),
+    },
+];
 
 test("production Workers and hostnames are an exact reviewed allowlist", () => {
     const { manifest, policy, entries } = loadCloudflareDeploymentData();
@@ -1113,7 +1129,7 @@ test("custom-domain pagination and API ambiguity fail closed", async () => {
     }
 });
 
-test("attachment inventory source contract is account-scoped and read-only", () => {
+test("attachment inventory source contract uses account-scoped domains and authoritative read-only zone routes", () => {
     const source = readFileSync(
         path.join(repoRoot, "scripts/cloudflare-workers-api.mjs"),
         "utf8"
@@ -1140,8 +1156,34 @@ test("attachment inventory source contract is account-scoped and read-only", () 
     assert.ok(subdomainStart >= 0 && subdomainEnd > subdomainStart);
     assert.match(subdomainInventory, /\/subdomain/);
     assert.doesNotMatch(subdomainInventory, /method\s*:|body\s*:/);
-    assert.match(source, /for \(const route of script\.routes\)/);
-    assert.doesNotMatch(source, /\/zones\/\$\{[^}]+\}\/workers\/routes/);
+    const zoneRoutesStart = source.indexOf("listZoneRouteInventory: async");
+    const zoneRoutesEnd = source.indexOf(
+        "listWorkerDomains: async",
+        zoneRoutesStart
+    );
+    const zoneRoutes = source.slice(zoneRoutesStart, zoneRoutesEnd);
+    assert.ok(zoneRoutesStart >= 0 && zoneRoutesEnd > zoneRoutesStart);
+    assert.match(zoneRoutes, /"account\.id": accountId/);
+    assert.match(zoneRoutes, /per_page: String\(ZONE_PAGE_SIZE\)/);
+    assert.match(
+        zoneRoutes,
+        /\$\{zonesUrl\}\/\$\{zone\.zoneId\}\/workers\/routes/
+    );
+    assert.match(zoneRoutes, /REQUIRED_ZONE_ROUTE_SNAPSHOTS/);
+    assert.doesNotMatch(zoneRoutes, /method\s*:|body\s*:/);
+    assert.match(source, /script\.routes == null \? null : \[\]/);
+    const deploymentSource = readFileSync(
+        path.join(repoRoot, "scripts/deploy-cloudflare-production.mjs"),
+        "utf8"
+    );
+    assert.match(
+        deploymentSource,
+        /listZoneRouteInventory: workersApi\.listZoneRouteInventory/
+    );
+    assert.match(
+        deploymentSource,
+        /readAndValidateZoneRouteInventory\(\{\s*scripts,\s*operations,\s*expectedZoneInventorySha256,\s*\}\)/
+    );
 });
 
 test("Cloudflare Workers API reads versions and changes traffic only through deployments", async () => {
@@ -1511,6 +1553,48 @@ test("production CLI accepts only target and immutable commit", () => {
     );
 });
 
+test("account zone identity fingerprint uses exact canonical sorted identities", () => {
+    const canonical = JSON.stringify([
+        { zoneId: ZONE_ID, zoneName: "peerbit.org" },
+        { zoneId: EXAMPLE_ZONE_ID, zoneName: "example.com" },
+    ]);
+    const expected = createHash("sha256")
+        .update(canonical, "utf8")
+        .digest("hex");
+    assert.equal(
+        accountZoneInventorySha256([
+            {
+                zoneId: EXAMPLE_ZONE_ID,
+                zoneName: "example.com",
+                status: "pending",
+                type: "internal",
+                routes: [{ ignored: true }],
+            },
+            {
+                zoneId: ZONE_ID,
+                zoneName: "peerbit.org",
+                status: "active",
+                type: "full",
+                routes: [],
+            },
+        ]),
+        expected
+    );
+    assert.notEqual(
+        accountZoneInventorySha256([
+            { zoneId: ZONE_ID, zoneName: "peerbit.org" },
+        ]),
+        expected
+    );
+    assert.throws(
+        () =>
+            accountZoneInventorySha256([
+                { zoneId: 1, zoneName: "peerbit.org" },
+            ]),
+        /invalid or ambiguous/
+    );
+});
+
 const fixtureEntries = (ids) =>
     ids.map((id) => ({
         site: { id },
@@ -1525,7 +1609,12 @@ const fixtureEntries = (ids) =>
 const deployProductionEntries = (options) =>
     deployProductionEntriesWithPolicy({
         deploymentEntries: options.selectedEntries,
+        expectedZoneInventorySha256: EXPECTED_ZONE_INVENTORY_SHA256,
         ...options,
+        operations: {
+            listZoneRouteInventory: () => routineZoneRouteInventory(),
+            ...options.operations,
+        },
     });
 const fixtureConfigs = (ids) =>
     new Map(
@@ -1580,6 +1669,7 @@ const createRolloutHarness = (ids) => {
                 ])
             ),
         listWorkerDomains: () => ids.map((id) => workerDomain(id)),
+        listZoneRouteInventory: () => routineZoneRouteInventory(),
         getWorkerSubdomain: (workerName) =>
             structuredClone(subdomains.get(workerName)),
         status: ({ site }) => deployment(current.get(site.id)),
@@ -1631,6 +1721,7 @@ test("account-wide attachment validation requires an explicit non-empty full pol
                 selectedEntries: fixtureEntries(["files"]),
                 configs: fixtureConfigs(["files"]),
                 expectedCommit: COMMIT,
+                expectedZoneInventorySha256: EXPECTED_ZONE_INVENTORY_SHA256,
                 log: () => {},
                 operations: {
                     listWorkerScripts: () => {
@@ -1659,6 +1750,7 @@ test("an empty selected entry set fails before account reads or mutations", asyn
             deploymentEntries: fixtureEntries(["files"]),
             configs: fixtureConfigs(["files"]),
             expectedCommit: COMMIT,
+            expectedZoneInventorySha256: EXPECTED_ZONE_INVENTORY_SHA256,
             log: () => {},
             operations: {
                 listWorkerScripts: () => {
@@ -1672,6 +1764,123 @@ test("an empty selected entry set fails before account reads or mutations", asyn
         /non-empty selected entry set/
     );
     assert.equal(listed, false);
+});
+
+test("routine deploy requires the independently reviewed zone fingerprint", async (t) => {
+    for (const fixture of [
+        { name: "missing", value: undefined },
+        { name: "non-string", value: { toString: () => "a".repeat(64) } },
+        { name: "uppercase", value: "A".repeat(64) },
+        { name: "short", value: "a".repeat(63) },
+    ]) {
+        await t.test(fixture.name, async () => {
+            const harness = createRolloutHarness(["files"]);
+            await assert.rejects(
+                deployProductionEntries({
+                    selectedEntries: fixtureEntries(["files"]),
+                    configs: fixtureConfigs(["files"]),
+                    expectedCommit: COMMIT,
+                    expectedZoneInventorySha256: fixture.value,
+                    log: () => {},
+                    operations: harness.operations,
+                }),
+                /CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 must be an exact lowercase SHA-256 digest/
+            );
+            assert.deepEqual(harness.events, []);
+        });
+    }
+});
+
+test("permission-filtered 200 zone inventory cannot authorize routine deploy", async () => {
+    const harness = createRolloutHarness(["files"]);
+    harness.operations.listWorkerScripts = () =>
+        new Map([
+            [
+                "peerbit-examples-files",
+                { tag: WORKER_TAGS.get("files"), routes: null },
+            ],
+        ]);
+    const accountId = "c".repeat(32);
+    const requests = [];
+    const api = createCloudflareWorkersApi({
+        accountId,
+        apiToken: "permission-filtered-token",
+        request: async (url, init) => {
+            requests.push({ url, init });
+            const parsed = new URL(url);
+            if (parsed.pathname.endsWith("/zones")) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: [
+                            {
+                                id: ZONE_ID,
+                                name: "peerbit.org",
+                                account: { id: accountId },
+                                status: "active",
+                                type: "full",
+                            },
+                        ],
+                        result_info: {
+                            count: 1,
+                            page: 1,
+                            per_page: 50,
+                            total_count: 1,
+                            total_pages: 1,
+                        },
+                    }),
+                    { status: 200 }
+                );
+            }
+            assert.match(parsed.pathname, /\/workers\/routes$/);
+            return new Response(JSON.stringify({ success: true, result: [] }), {
+                status: 200,
+            });
+        },
+    });
+    harness.operations.listZoneRouteInventory = api.listZoneRouteInventory;
+    const independentlyReviewed = accountZoneInventorySha256([
+        { zoneId: ZONE_ID, zoneName: "peerbit.org" },
+        { zoneId: EXAMPLE_ZONE_ID, zoneName: "hidden.example" },
+    ]);
+    let failure;
+    try {
+        await deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            expectedZoneInventorySha256: independentlyReviewed,
+            log: () => {},
+            operations: harness.operations,
+        });
+    } catch (error) {
+        failure = error;
+    }
+    assert.ok(failure instanceof Error);
+    assert.match(
+        failure.message,
+        /does not match the independently reviewed fingerprint/
+    );
+    assert.doesNotMatch(failure.message, new RegExp(independentlyReviewed));
+    assert.equal(requests.length, 4);
+    assert.ok(requests.every(({ init }) => init.method === "GET"));
+    assert.deepEqual(harness.events, []);
+});
+
+test("routine deploy rejects a well-formed but wrong zone fingerprint", async () => {
+    const harness = createRolloutHarness(["files"]);
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            expectedZoneInventorySha256: "0".repeat(64),
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /does not match the independently reviewed fingerprint/
+    );
+    assert.deepEqual(harness.events, []);
 });
 
 test("a missing production Worker fails closed before every mutation", async () => {
@@ -1825,22 +2034,23 @@ test("noncanonical custom-domain hostnames fail closed before upload", async () 
 
 test("traditional Worker routes fail exact attachment validation", async () => {
     const harness = createRolloutHarness(["files"]);
+    const route = {
+        id: "route-legacy",
+        pattern: "peerbit.org/legacy/*",
+        script: "peerbit-examples-files",
+    };
     harness.operations.listWorkerScripts = () =>
         new Map([
             [
                 "peerbit-examples-files",
                 {
                     tag: WORKER_TAGS.get("files"),
-                    routes: [
-                        {
-                            id: "route-legacy",
-                            pattern: "peerbit.org/legacy/*",
-                            script: "peerbit-examples-files",
-                        },
-                    ],
+                    routes: [route],
                 },
             ],
         ]);
+    harness.operations.listZoneRouteInventory = () =>
+        routineZoneRouteInventory([route]);
     await assert.rejects(
         deployProductionEntries({
             selectedEntries: fixtureEntries(["files"]),
@@ -1850,6 +2060,213 @@ test("traditional Worker routes fail exact attachment validation", async () => {
             operations: harness.operations,
         }),
         /unreviewed Worker route attachments/
+    );
+    assert.deepEqual(harness.events, []);
+});
+
+test("routine deploy accepts missing inline routes only through authoritative reconciliation", async () => {
+    const harness = createRolloutHarness(["files"]);
+    harness.operations.listWorkerScripts = () =>
+        new Map([
+            [
+                "peerbit-examples-files",
+                { tag: WORKER_TAGS.get("files"), routes: null },
+            ],
+        ]);
+
+    await deployProductionEntries({
+        selectedEntries: fixtureEntries(["files"]),
+        configs: fixtureConfigs(["files"]),
+        expectedCommit: COMMIT,
+        log: () => {},
+        operations: harness.operations,
+    });
+    assert.equal(harness.current.get("files"), NEW_VERSION);
+});
+
+test("routine deploy rejects hidden authoritative routes and inline disagreement", async (t) => {
+    await t.test("hidden authoritative managed route", async () => {
+        const harness = createRolloutHarness(["files"]);
+        const route = {
+            id: "hidden-route",
+            pattern: "unrelated.example.com/*",
+            script: "peerbit-examples-files",
+        };
+        harness.operations.listWorkerScripts = () =>
+            new Map([
+                [
+                    "peerbit-examples-files",
+                    { tag: WORKER_TAGS.get("files"), routes: null },
+                ],
+            ]);
+        harness.operations.listZoneRouteInventory = () =>
+            routineZoneRouteInventory([route]);
+
+        await assert.rejects(
+            deployProductionEntries({
+                selectedEntries: fixtureEntries(["files"]),
+                configs: fixtureConfigs(["files"]),
+                expectedCommit: COMMIT,
+                log: () => {},
+                operations: harness.operations,
+            }),
+            /files: peerbit-examples-files has unreviewed Worker route attachments/
+        );
+        assert.deepEqual(harness.events, []);
+    });
+
+    await t.test(
+        "inline route absent from authoritative inventory",
+        async () => {
+            const harness = createRolloutHarness(["files"]);
+            harness.operations.listWorkerScripts = () =>
+                new Map([
+                    [
+                        "peerbit-examples-files",
+                        {
+                            tag: WORKER_TAGS.get("files"),
+                            routes: [
+                                {
+                                    id: "inline-only-route",
+                                    pattern: "unrelated.example.com/*",
+                                    script: "peerbit-examples-files",
+                                },
+                            ],
+                        },
+                    ],
+                ]);
+
+            await assert.rejects(
+                deployProductionEntries({
+                    selectedEntries: fixtureEntries(["files"]),
+                    configs: fixtureConfigs(["files"]),
+                    expectedCommit: COMMIT,
+                    log: () => {},
+                    operations: harness.operations,
+                }),
+                /inline Worker routes do not exactly match the authoritative per-zone route inventory/
+            );
+            assert.deepEqual(harness.events, []);
+        }
+    );
+});
+
+test("routine deploy fails closed when authoritative zone-route scope is unavailable", async () => {
+    const harness = createRolloutHarness(["files"]);
+    harness.operations.listZoneRouteInventory = () => {
+        throw new Error(
+            "HTTP 403: token requires Zone Read and Workers Routes Read"
+        );
+    };
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /403.*Zone Read and Workers Routes Read/
+    );
+    assert.deepEqual(harness.events, []);
+});
+
+test("routine deploy pins the complete authoritative route inventory across upload fences", async () => {
+    const harness = createRolloutHarness(["files"]);
+    harness.operations.listWorkerScripts = () =>
+        new Map([
+            [
+                "peerbit-examples-files",
+                { tag: WORKER_TAGS.get("files"), routes: null },
+            ],
+        ]);
+    let reads = 0;
+    harness.operations.listZoneRouteInventory = () => {
+        reads += 1;
+        return routineZoneRouteInventory(
+            reads >= 4
+                ? [
+                      {
+                          id: "external-route-drift",
+                          pattern: "unrelated.example.com/*",
+                          script: null,
+                      },
+                  ]
+                : []
+        );
+    };
+
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /authoritative account zone or Worker route inventory changed/
+    );
+    assert.equal(harness.events.includes("upload:files"), true);
+    assert.equal(
+        harness.events.some((event) => event.startsWith("activate:")),
+        false
+    );
+});
+
+test("routine deploy rechecks the independent zone identity fingerprint after upload", async () => {
+    const harness = createRolloutHarness(["files"]);
+    const fullInventory = [
+        ...routineZoneRouteInventory(),
+        {
+            zoneId: EXAMPLE_ZONE_ID,
+            zoneName: "hidden.example",
+            status: "active",
+            type: "internal",
+            routes: [],
+        },
+    ];
+    let reads = 0;
+    harness.operations.listZoneRouteInventory = () => {
+        reads += 1;
+        return clone(reads >= 4 ? fullInventory.slice(0, 1) : fullInventory);
+    };
+
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            expectedZoneInventorySha256:
+                accountZoneInventorySha256(fullInventory),
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /does not match the independently reviewed fingerprint/
+    );
+    assert.equal(harness.events.includes("upload:files"), true);
+    assert.equal(
+        harness.events.some((event) => event.startsWith("activate:")),
+        false
+    );
+});
+
+test("routine deploy rejects custom domains outside authoritative account zones", async () => {
+    const harness = createRolloutHarness(["files"]);
+    harness.operations.listWorkerDomains = () => [
+        workerDomain("files", {
+            zoneId: EXAMPLE_ZONE_ID,
+            zoneName: "example.com",
+        }),
+    ];
+    await assert.rejects(
+        deployProductionEntries({
+            selectedEntries: fixtureEntries(["files"]),
+            configs: fixtureConfigs(["files"]),
+            expectedCommit: COMMIT,
+            log: () => {},
+            operations: harness.operations,
+        }),
+        /references a zone outside the authoritative account inventory/
     );
     assert.deepEqual(harness.events, []);
 });
@@ -1920,16 +2337,19 @@ test("a targeted deploy rejects unmanaged ownership of retired app hostnames", a
 
 test("a targeted deploy rejects routes on non-selected policy Workers", async () => {
     const harness = createRolloutHarness(["files", "stream"]);
+    const route = {
+        id: "stream-route",
+        pattern: "unrelated.example.com/*",
+        script: "peerbit-examples-stream",
+    };
     const listWorkerScripts = harness.operations.listWorkerScripts;
     harness.operations.listWorkerScripts = () => {
         const scripts = listWorkerScripts();
-        scripts.get("peerbit-examples-stream").routes.push({
-            id: "stream-route",
-            pattern: "unrelated.example.com/*",
-            script: "peerbit-examples-stream",
-        });
+        scripts.get("peerbit-examples-stream").routes.push(route);
         return scripts;
     };
+    harness.operations.listZoneRouteInventory = () =>
+        routineZoneRouteInventory([route]);
 
     await assert.rejects(
         deployProductionEntries({
@@ -1947,6 +2367,11 @@ test("a targeted deploy rejects routes on non-selected policy Workers", async ()
 
 test("routes targeting the managed app suffix are rejected on unrelated Workers", async () => {
     const harness = createRolloutHarness(["files", "stream"]);
+    const route = {
+        id: "managed-suffix-route",
+        pattern: "retired.apps.peerbit.org./*",
+        script: "unrelated-account-worker",
+    };
     const listWorkerScripts = harness.operations.listWorkerScripts;
     harness.operations.listWorkerScripts = () =>
         new Map([
@@ -1955,16 +2380,12 @@ test("routes targeting the managed app suffix are rejected on unrelated Workers"
                 "unrelated-account-worker",
                 {
                     tag: "unrelated-worker-tag",
-                    routes: [
-                        {
-                            id: "managed-suffix-route",
-                            pattern: "retired.apps.peerbit.org./*",
-                            script: "unrelated-account-worker",
-                        },
-                    ],
+                    routes: [route],
                 },
             ],
         ]);
+    harness.operations.listZoneRouteInventory = () =>
+        routineZoneRouteInventory([route]);
 
     await assert.rejects(
         deployProductionEntries({
@@ -1982,6 +2403,11 @@ test("routes targeting the managed app suffix are rejected on unrelated Workers"
 
 test("unrelated account Workers, routes, and domains remain outside deployment policy", async () => {
     const harness = createRolloutHarness(["files", "stream"]);
+    const route = {
+        id: "unrelated-route",
+        pattern: "unrelated.example.com/*",
+        script: "unrelated-account-worker",
+    };
     const listWorkerScripts = harness.operations.listWorkerScripts;
     harness.operations.listWorkerScripts = () =>
         new Map([
@@ -1990,22 +2416,27 @@ test("unrelated account Workers, routes, and domains remain outside deployment p
                 "unrelated-account-worker",
                 {
                     tag: "unrelated-worker-tag",
-                    routes: [
-                        {
-                            id: "unrelated-route",
-                            pattern: "unrelated.example.com/*",
-                            script: "unrelated-account-worker",
-                        },
-                    ],
+                    routes: [route],
                 },
             ],
         ]);
+    harness.operations.listZoneRouteInventory = () => [
+        ...routineZoneRouteInventory([route]),
+        {
+            zoneId: EXAMPLE_ZONE_ID,
+            zoneName: "example.com",
+            status: "active",
+            type: "full",
+            routes: [],
+        },
+    ];
     harness.operations.listWorkerDomains = () => [
         workerDomain("files"),
         workerDomain("stream"),
         workerDomain("unrelated", {
             hostname: "unrelated.example.com",
             service: "unrelated-account-worker",
+            zoneId: EXAMPLE_ZONE_ID,
             zoneName: "example.com",
         }),
     ];
@@ -2015,6 +2446,10 @@ test("unrelated account Workers, routes, and domains remain outside deployment p
         deploymentEntries: fixtureEntries(["files", "stream"]),
         configs: fixtureConfigs(["files", "stream"]),
         expectedCommit: COMMIT,
+        expectedZoneInventorySha256: accountZoneInventorySha256([
+            { zoneId: ZONE_ID, zoneName: "peerbit.org" },
+            { zoneId: EXAMPLE_ZONE_ID, zoneName: "example.com" },
+        ]),
         log: () => {},
         operations: harness.operations,
     });
@@ -2841,21 +3276,28 @@ test("rollback success requires full policy and active-version confirmation afte
         },
         {
             name: "traditional-route drift",
-            pattern: /unreviewed Worker route attachments/,
+            pattern:
+                /authoritative account zone or Worker route inventory changed/,
             configure: (harness) => {
                 let drifted = false;
                 const listWorkerScripts = harness.operations.listWorkerScripts;
                 harness.operations.listWorkerScripts = () => {
                     const scripts = listWorkerScripts();
-                    if (drifted) {
-                        scripts.get("peerbit-examples-files").routes.push({
-                            id: "rollback-route-drift",
-                            pattern: "files.apps.peerbit.org/*",
-                            script: "peerbit-examples-files",
-                        });
-                    }
+                    scripts.get("peerbit-examples-files").routes = null;
                     return scripts;
                 };
+                harness.operations.listZoneRouteInventory = () =>
+                    routineZoneRouteInventory(
+                        drifted
+                            ? [
+                                  {
+                                      id: "rollback-route-drift",
+                                      pattern: "files.apps.peerbit.org/*",
+                                      script: "peerbit-examples-files",
+                                  },
+                              ]
+                            : []
+                    );
                 return () => {
                     drifted = true;
                 };

--- a/cloudflare/production-provisioning.md
+++ b/cloudflare/production-provisioning.md
@@ -18,6 +18,8 @@ These are the relevant official references:
 - [Versions and deployments](https://developers.cloudflare.com/workers/versions-and-deployments/)
 - [`wrangler versions upload`](https://developers.cloudflare.com/workers/wrangler/commands/workers/#versions-upload)
 - [Worker scripts API](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/)
+- [Zones list API](https://developers.cloudflare.com/api/resources/zones/methods/list/)
+- [Authoritative Worker routes API](https://developers.cloudflare.com/api/resources/workers/subresources/routes/methods/list/)
 - [Worker subdomain API](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/subdomain/)
 - [Worker deployments API](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/deployments/)
 - [Worker versions API](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/versions/)
@@ -38,8 +40,21 @@ These are the relevant official references:
    the narrowly required Workers Scripts read/write access, including version,
    deployment, subdomain, domain, Cron Trigger schedule, and active script
    content reads, plus **Queue Read** for the separate account-wide Queue
-   consumer inventory. Its existing `CLOUDFLARE_ACCOUNT_ID` variable must
-   identify the reviewed account.
+   consumer inventory. It must also have **Zone Read** and **Workers Routes
+   Read** for **every zone in the account**, not merely `peerbit.org`: the
+   safety fence enumerates the complete account and reads each zone's
+   authoritative traditional-Worker routes. Its existing
+   `CLOUDFLARE_ACCOUNT_ID` variable must identify the reviewed account.
+   The protected environment must also define the exact lowercase 64-hex
+   `CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256` variable. Establish it from an
+   independently verified full dashboard/admin zone inventory, never from the
+   deployment token's permission-filtered `/zones` response. Canonical input is
+   UTF-8 JSON with no trailing newline: an array of exactly
+   `{"zoneId":"<lowercase-id>","zoneName":"<lowercase-name>"}` identities,
+   sorted first by `zoneId` and then by `zoneName` using ascending code-point
+   order. Hash that byte sequence with SHA-256. If the full inventory has not
+   yet been independently established, leave production workflows blocked
+   until this variable is reviewed and set.
 3. Confirm that the `peerbit.org` zone is active in that account. Cloudflare
    cannot attach a Custom Domain over a conflicting CNAME, so resolve any such
    conflict manually before applying.
@@ -67,11 +82,27 @@ For example, for planned commit
 
 The protected environment supplies credentials only to the final read-only
 step. The plan reads the complete Worker and stable custom-domain inventories,
-the live public-subdomain state, deployments, every deployable version ID,
-immutable Worker tags, routes, Tail consumers, Logpush state, Cron schedules,
-active service-binding targets, and every Queue plus its separate consumer
-attachments. The Queue list is paginated and every complete account snapshot
-must be observed twice without change. The digest also binds the exact
+then strictly paginates every zone belonging to the exact account and reads
+the authoritative traditional-Worker routes from every zone. Two complete
+zone-plus-route snapshots must match exactly. The zone query explicitly asks
+for `full`, `partial`, `secondary`, and `internal` zones because Cloudflare's
+default omits internal zones. The Worker-list API's optional
+inline `routes` field is never treated as proof of an empty route set; when it
+is present it must exactly match the authoritative per-zone result. The plan
+hashes the observed canonical zone identities and requires the independently
+configured protected fingerprint to match. This closes the case where every
+API response is HTTP 200 but the token silently sees only a subset of the
+account's zones. Missing, malformed, or mismatched fingerprints fail before
+mutation and are never printed. The expected fingerprint is bound into the
+plan state digest, reviewed receipt, and apply-time invocation ledger; every
+inspection fence recomputes and rechecks it. Zone status, type, and complete
+route inventories remain separately bound as dynamic state in that digest.
+The plan also reads the live public-subdomain state, deployments, every
+deployable version ID, immutable Worker tags, Tail consumers, Logpush state,
+Cron schedules, active service-binding targets, and every Queue plus its
+separate consumer attachments. The Queue list is paginated and every complete
+account snapshot must be observed twice without change. The digest also binds
+the exact
 Cloudflare account ID so an account-variable change cannot reuse a receipt. It
 prints the full planned commit, reviewed
 Worker names, public custom domains, proposed actions, and a canonical
@@ -100,13 +131,16 @@ has no action and is never created. Any unknown `peerbit-examples-*` Worker,
 traditional route, wrong domain owner, split deployment, Tail consumer,
 Logpush attachment, Cron Trigger, queue/service attachment on a managed Worker,
 inbound service binding, Queue consumer attachment targeting any managed
-production or preview Worker, or malformed response blocks the run. Old
+production or preview Worker, a route that references an unknown Worker, any
+inaccessible/incomplete/unstable account zone or route inventory, or malformed
+response blocks the run. Old
 inactive versions are listed as quarantined state: their annotations are never
 accepted as proof that this invocation uploaded them. The inspection records
 every production Worker's existence, immutable Worker tag, active and
 deployable version IDs, subdomain flags, schedules, domain state,
-artifact-manifest digest, and the canonical account Queue-consumer inventory in
-the signed plan receipt and apply-time invocation ledger.
+artifact-manifest digest, the complete canonical account zone-and-route
+inventory, and the canonical account Queue-consumer inventory in the signed
+plan receipt and apply-time invocation ledger.
 
 ## Confirmed apply
 
@@ -131,7 +165,7 @@ apply confirmation to both. The provisioning CLI independently repeats those
 checks and recomputes the canonical account-state digest before dispatching any
 mutation. Any Worker tag, active/deployable version, route, domain, public flag,
 schedule, Tail/Logpush setting, or exposed service-binding drift forces a new
-reviewed plan. Artifact-manifest or Queue-consumer drift does the same. A
+reviewed plan. Artifact-manifest, zone/route, or Queue-consumer drift does the same. A
 mismatch exits nonzero; it is not treated as a skipped deploy.
 
 The workflow rebuilds all seven frontends and assets from the checked-out
@@ -151,10 +185,11 @@ commit, tests the sources, dry-runs every locked Wrangler bundle, and then:
    responses continue only if that exact GET postcondition is observed.
 3. Rechecks the complete ledger, exact preview identities, zero Cron schedules,
    zero Tail/Logpush attachments, active service-binding inventory, the exact
-   account-wide Queue-consumer inventory, and global false/false public-URL
-   fence before every upload, activation, and domain attachment and after every
-   mutation. A change to an earlier or unrelated site or Queue stops the
-   invocation; it is never accepted as a new baseline.
+   account-wide Queue-consumer inventory, complete authoritative account
+   zone-and-route inventory, and global false/false public-URL fence before
+   every upload, activation, and domain attachment and after every mutation.
+   An added/deleted zone, route drift, or a change to an earlier or unrelated
+   site or Queue stops the invocation; it is never accepted as a new baseline.
 4. Revalidates every artifact manifest immediately before upload, uploads its
    exact prebuilt module with bundling disabled, and uploads one new route-free
    version for every site on every apply. Its tag
@@ -186,7 +221,8 @@ commit, tests the sources, dry-runs every locked Wrangler bundle, and then:
    policy, verifies the exact served artifact manifest and exhaustively hashes
    every public live asset (including `release.json`) against it, runs the same
    file-share relay and media-range browser smokes, then
-   rereads exact Worker identity, version resource fingerprint, domain, route,
+   rereads exact Worker identity, version resource fingerprint, domain,
+   authoritative account zones/routes,
    schedule, Tail/Logpush, service-binding, Queue-consumer, active-module, and
    subdomain state, including every existing allowlisted preview Worker.
 

--- a/cloudflare/production-provisioning.test.mjs
+++ b/cloudflare/production-provisioning.test.mjs
@@ -19,11 +19,16 @@ import {
     CLOUDFLARE_ARTIFACT_DIGEST_BINDING,
     artifactBoundVersionMessage,
 } from "../scripts/cloudflare-artifact-manifest.mjs";
+import { accountZoneInventorySha256 } from "../scripts/deploy-cloudflare-production.mjs";
 
 const COMMIT = "a".repeat(40);
 const OTHER_COMMIT = "b".repeat(40);
 const ACCOUNT_ID = "c".repeat(32);
 const ZONE_ID = "d".repeat(32);
+const HIDDEN_ZONE_ID = "e".repeat(32);
+const EXPECTED_ZONE_INVENTORY_SHA256 = accountZoneInventorySha256([
+    { zoneId: ZONE_ID, zoneName: "peerbit.org" },
+]);
 const API_TOKEN = "cloudflare-test-token";
 const LEGACY_NONCE = "1".repeat(32);
 const PLAN_DIGEST = "2".repeat(64);
@@ -85,6 +90,7 @@ const provisionProductionEntriesWithReceipt = (input) =>
     runProvisionProductionEntriesWithReceipt({
         accountId: ACCOUNT_ID,
         artifacts,
+        expectedZoneInventorySha256: EXPECTED_ZONE_INVENTORY_SHA256,
         ...input,
     });
 
@@ -147,6 +153,15 @@ const createHarness = () => {
     const deployments = new Map();
     const versions = new Map();
     const queueConsumerInventory = [];
+    const zoneRouteInventory = [
+        {
+            zoneId: ZONE_ID,
+            zoneName: "peerbit.org",
+            status: "active",
+            type: "full",
+            routes: [],
+        },
+    ];
     const calls = [];
     let uploadGeneration = 0;
 
@@ -258,6 +273,10 @@ const createHarness = () => {
             return new Map(
                 [...scripts].map(([name, metadata]) => [name, clone(metadata)])
             );
+        },
+        listZoneRouteInventory: async () => {
+            calls.push(["list-zone-routes"]);
+            return clone(zoneRouteInventory);
         },
         listWorkerDomains: async () => {
             calls.push(["list-domains"]);
@@ -386,6 +405,7 @@ const createHarness = () => {
         deployments,
         versions,
         queueConsumerInventory,
+        zoneRouteInventory,
         calls,
         operations,
         addWorker,
@@ -591,6 +611,437 @@ test("read-only plan proposes all seven exact targets without mutations", async 
     assert.match(logs.at(-1), /no Cloudflare mutations were dispatched/);
 });
 
+test("provisioning requires the independently reviewed zone fingerprint", async (t) => {
+    for (const fixture of [
+        { name: "missing", value: undefined },
+        { name: "non-string", value: { toString: () => "a".repeat(64) } },
+        { name: "uppercase", value: "A".repeat(64) },
+        { name: "short", value: "a".repeat(63) },
+    ]) {
+        await t.test(fixture.name, async () => {
+            const harness = createHarness();
+            await assert.rejects(
+                provisionProductionEntriesWithReceipt({
+                    entries,
+                    configs,
+                    expectedCommit: COMMIT,
+                    expectedZoneInventorySha256: fixture.value,
+                    mode: "plan",
+                    operations: harness.operations,
+                    log: () => {},
+                }),
+                /CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 must be an exact lowercase SHA-256 digest/
+            );
+            assert.deepEqual(mutationCalls(harness.calls), []);
+        });
+    }
+});
+
+test("permission-filtered 200 zone inventory cannot authorize provisioning", async () => {
+    const harness = createHarness();
+    const requests = [];
+    const api = createCloudflareWorkersApi({
+        accountId: ACCOUNT_ID,
+        apiToken: API_TOKEN,
+        request: async (url, init) => {
+            requests.push({ url, init });
+            const parsed = new URL(url);
+            if (parsed.pathname.endsWith("/zones")) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: [
+                            {
+                                id: ZONE_ID,
+                                name: "peerbit.org",
+                                account: { id: ACCOUNT_ID },
+                                status: "active",
+                                type: "full",
+                            },
+                        ],
+                        result_info: {
+                            count: 1,
+                            page: 1,
+                            per_page: 50,
+                            total_count: 1,
+                            total_pages: 1,
+                        },
+                    }),
+                    { status: 200 }
+                );
+            }
+            assert.match(parsed.pathname, /\/workers\/routes$/);
+            return new Response(JSON.stringify({ success: true, result: [] }), {
+                status: 200,
+            });
+        },
+    });
+    harness.operations.listZoneRouteInventory = api.listZoneRouteInventory;
+    const independentlyReviewed = accountZoneInventorySha256([
+        { zoneId: ZONE_ID, zoneName: "peerbit.org" },
+        { zoneId: HIDDEN_ZONE_ID, zoneName: "hidden.example" },
+    ]);
+    let failure;
+    try {
+        await provisionProductionEntriesWithReceipt({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            expectedZoneInventorySha256: independentlyReviewed,
+            mode: "plan",
+            operations: harness.operations,
+            log: () => {},
+        });
+    } catch (error) {
+        failure = error;
+    }
+    assert.ok(failure instanceof Error);
+    assert.match(
+        failure.message,
+        /does not match the independently reviewed fingerprint/
+    );
+    assert.doesNotMatch(failure.message, new RegExp(independentlyReviewed));
+    assert.equal(requests.length, 4);
+    assert.ok(requests.every(({ init }) => init.method === "GET"));
+    assert.deepEqual(mutationCalls(harness.calls), []);
+});
+
+test("provisioning rejects a well-formed but wrong zone fingerprint", async () => {
+    const harness = createHarness();
+    await assert.rejects(
+        provisionProductionEntriesWithReceipt({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            expectedZoneInventorySha256: "0".repeat(64),
+            mode: "plan",
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /does not match the independently reviewed fingerprint/
+    );
+    assert.deepEqual(mutationCalls(harness.calls), []);
+});
+
+test("missing inline routes defer to exact authoritative per-zone truth", async () => {
+    const harness = createHarness();
+    const target = entries[0];
+    harness.addWorker({ entry: target });
+    harness.scripts.get(target.policy.productionWorker).routes = null;
+    harness.zoneRouteInventory[0].routes.push({
+        id: "scriptless-route",
+        pattern: "unrelated.example.com/*",
+        script: null,
+    });
+
+    const plan = await provisionProductionEntries({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "plan",
+        operations: harness.operations,
+        log: () => {},
+    });
+    assert.equal(plan.length, entries.length);
+    assert.deepEqual(mutationCalls(harness.calls), []);
+});
+
+test("authoritative hidden routes and inline disagreements fail closed", async (t) => {
+    await t.test("hidden route on managed Worker", async () => {
+        const harness = createHarness();
+        const target = entries[0];
+        harness.addWorker({ entry: target });
+        harness.scripts.get(target.policy.productionWorker).routes = null;
+        harness.zoneRouteInventory[0].routes.push({
+            id: "hidden-managed-route",
+            pattern: "unrelated.example.com/*",
+            script: target.policy.productionWorker,
+        });
+        await assert.rejects(
+            provisionProductionEntries({
+                entries,
+                configs,
+                expectedCommit: COMMIT,
+                mode: "plan",
+                operations: harness.operations,
+                log: () => {},
+            }),
+            /unreviewed traditional Worker route attachment/
+        );
+        assert.deepEqual(mutationCalls(harness.calls), []);
+    });
+
+    await t.test("inline route does not exist authoritatively", async () => {
+        const harness = createHarness();
+        harness.scripts.set("unrelated-worker", {
+            tag: "unrelated-tag",
+            routes: [
+                {
+                    id: "inline-only-route",
+                    pattern: "unrelated.example.com/*",
+                    script: "unrelated-worker",
+                },
+            ],
+            tailConsumers: [],
+            logpush: false,
+        });
+        await assert.rejects(
+            provisionProductionEntries({
+                entries,
+                configs,
+                expectedCommit: COMMIT,
+                mode: "plan",
+                operations: harness.operations,
+                log: () => {},
+            }),
+            /do not exactly match the authoritative per-zone route inventory/
+        );
+        assert.deepEqual(mutationCalls(harness.calls), []);
+    });
+
+    await t.test(
+        "authoritative route references an unknown script",
+        async () => {
+            const harness = createHarness();
+            harness.zoneRouteInventory[0].routes.push({
+                id: "unknown-script-route",
+                pattern: "unrelated.example.com/*",
+                script: "unknown-worker",
+            });
+            await assert.rejects(
+                provisionProductionEntries({
+                    entries,
+                    configs,
+                    expectedCommit: COMMIT,
+                    mode: "plan",
+                    operations: harness.operations,
+                    log: () => {},
+                }),
+                /references unknown script unknown-worker/
+            );
+            assert.deepEqual(mutationCalls(harness.calls), []);
+        }
+    );
+});
+
+test("reviewed fingerprint and state digest bind every authoritative zone and route field", async (t) => {
+    for (const [name, mutate, pattern] of [
+        [
+            "zone ID",
+            (inventory) => (inventory[0].zoneId = "e".repeat(32)),
+            /independently reviewed fingerprint/,
+        ],
+        [
+            "zone name",
+            (inventory) => (inventory[0].zoneName = "changed.org"),
+            /independently reviewed fingerprint/,
+        ],
+        [
+            "zone status",
+            (inventory) => (inventory[0].status = "pending"),
+            /state changed after review/,
+        ],
+        [
+            "zone type",
+            (inventory) => (inventory[0].type = "partial"),
+            /state changed after review/,
+        ],
+        [
+            "route ID",
+            (inventory) => (inventory[0].routes[0].id = "changed-route"),
+            /state changed after review/,
+        ],
+        [
+            "route pattern",
+            (inventory) =>
+                (inventory[0].routes[0].pattern = "changed.example.com/*"),
+            /state changed after review/,
+        ],
+        [
+            "route script",
+            (inventory) => (inventory[0].routes[0].script = "external-worker"),
+            /state changed after review/,
+        ],
+        [
+            "route removal",
+            (inventory) => inventory[0].routes.splice(0),
+            /state changed after review/,
+        ],
+        [
+            "zone addition",
+            (inventory) =>
+                inventory.push({
+                    zoneId: "e".repeat(32),
+                    zoneName: "peerchecker.com",
+                    status: "active",
+                    type: "full",
+                    routes: [],
+                }),
+            /independently reviewed fingerprint/,
+        ],
+    ]) {
+        await t.test(name, async () => {
+            const harness = createHarness();
+            harness.scripts.set("external-worker", {
+                tag: "external-tag",
+                routes: null,
+                tailConsumers: [],
+                logpush: false,
+            });
+            harness.zoneRouteInventory[0].routes.push({
+                id: "scriptless-route",
+                pattern: "unrelated.example.com/*",
+                script: null,
+            });
+            const reviewed = await provisionProductionEntriesWithReceipt({
+                entries,
+                configs,
+                expectedCommit: COMMIT,
+                mode: "plan",
+                operations: harness.operations,
+                log: () => {},
+            });
+            mutate(harness.zoneRouteInventory);
+            await assert.rejects(
+                provisionProductionEntriesWithReceipt({
+                    entries,
+                    configs,
+                    expectedCommit: COMMIT,
+                    mode: "apply",
+                    plannedStateDigest: reviewed.stateDigest,
+                    operations: harness.operations,
+                    log: () => {},
+                }),
+                pattern
+            );
+            assert.deepEqual(mutationCalls(harness.calls), []);
+        });
+    }
+});
+
+test("authoritative route drift after upload trips the invocation fence", async () => {
+    const harness = createHarness();
+    const reviewed = await provisionProductionEntriesWithReceipt({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "plan",
+        operations: harness.operations,
+        log: () => {},
+    });
+    const upload = harness.operations.upload;
+    harness.operations.upload = async (input) => {
+        const evidence = await upload(input);
+        harness.zoneRouteInventory[0].routes.push({
+            id: "concurrent-scriptless-route",
+            pattern: "concurrent.example.com/*",
+            script: null,
+        });
+        return evidence;
+    };
+    await assert.rejects(
+        provisionProductionEntriesWithReceipt({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            mode: "apply",
+            plannedStateDigest: reviewed.stateDigest,
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /authoritative account zone or Worker route inventory changed|post-upload proof/
+    );
+    assert.equal(
+        harness.calls.some(([name]) => name === "activate"),
+        false
+    );
+});
+
+test("independent zone identity fingerprint is rechecked after upload", async () => {
+    const harness = createHarness();
+    harness.zoneRouteInventory.push({
+        zoneId: HIDDEN_ZONE_ID,
+        zoneName: "hidden.example",
+        status: "active",
+        type: "internal",
+        routes: [],
+    });
+    const expectedZoneInventorySha256 = accountZoneInventorySha256(
+        harness.zoneRouteInventory
+    );
+    const reviewed = await provisionProductionEntriesWithReceipt({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        expectedZoneInventorySha256,
+        mode: "plan",
+        operations: harness.operations,
+        log: () => {},
+    });
+    const upload = harness.operations.upload;
+    harness.operations.upload = async (input) => {
+        const evidence = await upload(input);
+        harness.zoneRouteInventory.splice(1, 1);
+        return evidence;
+    };
+    await assert.rejects(
+        provisionProductionEntriesWithReceipt({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            expectedZoneInventorySha256,
+            mode: "apply",
+            plannedStateDigest: reviewed.stateDigest,
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /does not match the independently reviewed fingerprint|post-upload proof/
+    );
+    assert.equal(
+        harness.calls.some(([name]) => name === "upload"),
+        true
+    );
+    assert.equal(
+        harness.calls.some(([name]) => name === "activate"),
+        false
+    );
+});
+
+test("reviewed provisioning receipt cannot be reused with a swapped zone fingerprint", async () => {
+    const harness = createHarness();
+    const reviewed = await provisionProductionEntriesWithReceipt({
+        entries,
+        configs,
+        expectedCommit: COMMIT,
+        mode: "plan",
+        operations: harness.operations,
+        log: () => {},
+    });
+    harness.zoneRouteInventory.push({
+        zoneId: HIDDEN_ZONE_ID,
+        zoneName: "hidden.example",
+        status: "active",
+        type: "internal",
+        routes: [],
+    });
+    await assert.rejects(
+        provisionProductionEntriesWithReceipt({
+            entries,
+            configs,
+            expectedCommit: COMMIT,
+            expectedZoneInventorySha256: accountZoneInventorySha256(
+                harness.zoneRouteInventory
+            ),
+            mode: "apply",
+            plannedStateDigest: reviewed.stateDigest,
+            operations: harness.operations,
+            log: () => {},
+        }),
+        /state changed after review/
+    );
+    assert.deepEqual(mutationCalls(harness.calls), []);
+});
+
 test("preview planning derives exact policy identities and handles every public flag combination", async () => {
     const harness = createHarness();
     const states = [
@@ -788,6 +1239,7 @@ test("preview identities are independently pinned before every account read", as
                     configs,
                     artifacts,
                     expectedCommit: COMMIT,
+                    expectedZoneInventorySha256: EXPECTED_ZONE_INVENTORY_SHA256,
                     operations: harness.operations,
                 }),
                 /reviewed seven-application allowlist/
@@ -1811,6 +2263,11 @@ test("unexpected namespace, route, domain, and release state fail before preview
                     pattern: "preview.peerbit.org/*",
                     script: preview,
                 });
+                harness.zoneRouteInventory[0].routes.push({
+                    id: "preview-route",
+                    pattern: "preview.peerbit.org/*",
+                    script: preview,
+                });
             },
         ],
         [
@@ -1825,6 +2282,11 @@ test("unexpected namespace, route, domain, and release state fail before preview
                             script: "unrelated-worker",
                         },
                     ],
+                });
+                harness.zoneRouteInventory[0].routes.push({
+                    id: "route-1",
+                    pattern: "files.apps.peerbit.org/*",
+                    script: "unrelated-worker",
                 });
             },
         ],
@@ -2737,6 +3199,426 @@ test("Cloudflare provisioning adapters use exact documented endpoints and bodies
     ]);
 });
 
+test("Worker list preserves absent and null inline routes as non-authoritative", async () => {
+    const api = createCloudflareWorkersApi({
+        accountId: ACCOUNT_ID,
+        apiToken: API_TOKEN,
+        request: async () =>
+            new Response(
+                JSON.stringify({
+                    success: true,
+                    result: [
+                        { id: "worker-with-omitted-routes", tag: "tag-a" },
+                        {
+                            id: "worker-with-null-routes",
+                            tag: "tag-b",
+                            routes: null,
+                        },
+                        {
+                            id: "worker-with-implicit-route-script",
+                            tag: "tag-c",
+                            routes: [
+                                {
+                                    id: "implicit-inline-route",
+                                    pattern: "example.com/*",
+                                },
+                                {
+                                    id: "null-inline-route",
+                                    pattern: "example.com/null/*",
+                                    script: null,
+                                },
+                            ],
+                        },
+                    ],
+                })
+            ),
+    });
+    assert.deepEqual(
+        [...(await api.listWorkerScripts())],
+        [
+            [
+                "worker-with-omitted-routes",
+                {
+                    tag: "tag-a",
+                    routes: null,
+                    tailConsumers: [],
+                    logpush: false,
+                },
+            ],
+            [
+                "worker-with-null-routes",
+                {
+                    tag: "tag-b",
+                    routes: null,
+                    tailConsumers: [],
+                    logpush: false,
+                },
+            ],
+            [
+                "worker-with-implicit-route-script",
+                {
+                    tag: "tag-c",
+                    routes: [
+                        {
+                            id: "implicit-inline-route",
+                            pattern: "example.com/*",
+                            script: "worker-with-implicit-route-script",
+                        },
+                        {
+                            id: "null-inline-route",
+                            pattern: "example.com/null/*",
+                            script: "worker-with-implicit-route-script",
+                        },
+                    ],
+                    tailConsumers: [],
+                    logpush: false,
+                },
+            ],
+        ]
+    );
+
+    const malformed = createCloudflareWorkersApi({
+        accountId: ACCOUNT_ID,
+        apiToken: API_TOKEN,
+        request: async () =>
+            new Response(
+                JSON.stringify({
+                    success: true,
+                    result: [{ id: "worker", routes: {} }],
+                })
+            ),
+    });
+    await assert.rejects(
+        malformed.listWorkerScripts(),
+        CloudflareWorkersApiError
+    );
+
+    const substituted = createCloudflareWorkersApi({
+        accountId: ACCOUNT_ID,
+        apiToken: API_TOKEN,
+        request: async () =>
+            new Response(
+                JSON.stringify({
+                    success: true,
+                    result: [
+                        {
+                            id: "parent-worker",
+                            routes: [
+                                {
+                                    id: "substituted-route",
+                                    pattern: "example.com/*",
+                                    script: "different-worker",
+                                },
+                            ],
+                        },
+                    ],
+                })
+            ),
+    });
+    await assert.rejects(
+        substituted.listWorkerScripts(),
+        CloudflareWorkersApiError
+    );
+});
+
+test("authoritative zone routes paginate the exact account and require two complete stable snapshots", async () => {
+    const OTHER_ZONE_ID = "e".repeat(32);
+    const requests = [];
+    const zone = ({ id, name, status = "active", type = "full" }) => ({
+        id,
+        name,
+        status,
+        type,
+        account: { id: ACCOUNT_ID, name: "redacted-test-account" },
+    });
+    const api = createCloudflareWorkersApi({
+        accountId: ACCOUNT_ID,
+        apiToken: API_TOKEN,
+        request: async (url, init) => {
+            requests.push([url, init.method, init.headers.Authorization]);
+            const parsed = new URL(url);
+            if (parsed.pathname === "/client/v4/zones") {
+                assert.equal(parsed.searchParams.get("account.id"), ACCOUNT_ID);
+                assert.equal(parsed.searchParams.get("per_page"), "50");
+                assert.equal(
+                    parsed.searchParams.get("type"),
+                    "full,partial,secondary,internal"
+                );
+                const page = Number(parsed.searchParams.get("page"));
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result:
+                            page === 1
+                                ? [zone({ id: ZONE_ID, name: "peerbit.org" })]
+                                : [
+                                      zone({
+                                          id: OTHER_ZONE_ID,
+                                          name: "peerchecker.com",
+                                          status: "pending",
+                                          type: "partial",
+                                      }),
+                                  ],
+                        result_info: {
+                            count: 1,
+                            page,
+                            per_page: 1,
+                            total_count: 2,
+                            total_pages: 2,
+                        },
+                    })
+                );
+            }
+            if (parsed.pathname.endsWith(`/${ZONE_ID}/workers/routes`)) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: [
+                            {
+                                id: "scriptless-route",
+                                pattern: "peerbit.org/disabled/*",
+                            },
+                        ],
+                    })
+                );
+            }
+            if (parsed.pathname.endsWith(`/${OTHER_ZONE_ID}/workers/routes`)) {
+                return new Response(
+                    JSON.stringify({
+                        success: true,
+                        result: [
+                            {
+                                id: "external-route",
+                                pattern: "peerchecker.com/*",
+                                script: "external-worker",
+                            },
+                        ],
+                    })
+                );
+            }
+            return new Response("not found", { status: 404 });
+        },
+    });
+
+    assert.deepEqual(await api.listZoneRouteInventory(), [
+        {
+            zoneId: ZONE_ID,
+            zoneName: "peerbit.org",
+            status: "active",
+            type: "full",
+            routes: [
+                {
+                    id: "scriptless-route",
+                    pattern: "peerbit.org/disabled/*",
+                    script: null,
+                },
+            ],
+        },
+        {
+            zoneId: OTHER_ZONE_ID,
+            zoneName: "peerchecker.com",
+            status: "pending",
+            type: "partial",
+            routes: [
+                {
+                    id: "external-route",
+                    pattern: "peerchecker.com/*",
+                    script: "external-worker",
+                },
+            ],
+        },
+    ]);
+    assert.equal(requests.length, 8);
+    assert.ok(requests.every(([, method]) => method === "GET"));
+    assert.ok(
+        requests.every(
+            ([, , authorization]) => authorization === `Bearer ${API_TOKEN}`
+        )
+    );
+});
+
+test("authoritative zone-route inventory fails closed on scope, pagination, identity, and drift errors", async (t) => {
+    const zone = (
+        id = ZONE_ID,
+        name = "peerbit.org",
+        account = ACCOUNT_ID
+    ) => ({
+        id,
+        name,
+        status: "active",
+        type: "full",
+        account: { id: account, name: "test-account" },
+    });
+    const zonePage = (zones, overrides = {}) => ({
+        success: true,
+        result: zones,
+        result_info: {
+            count: zones.length,
+            page: 1,
+            per_page: 50,
+            total_count: zones.length,
+            total_pages: zones.length === 0 ? 0 : 1,
+            ...overrides,
+        },
+    });
+    const invoke = (request) =>
+        createCloudflareWorkersApi({
+            accountId: ACCOUNT_ID,
+            apiToken: API_TOKEN,
+            request,
+        }).listZoneRouteInventory();
+
+    await t.test("wrong account", async () => {
+        await assert.rejects(
+            invoke(
+                async () =>
+                    new Response(
+                        JSON.stringify(
+                            zonePage([
+                                zone(ZONE_ID, "peerbit.org", "f".repeat(32)),
+                            ])
+                        )
+                    )
+            ),
+            /wrong-account zone identity/
+        );
+    });
+
+    await t.test("Workers Routes token scope failure", async () => {
+        await assert.rejects(
+            invoke(
+                async (url) =>
+                    new Response(
+                        JSON.stringify(
+                            url.includes("/workers/routes")
+                                ? {
+                                      success: false,
+                                      errors: [
+                                          {
+                                              code: 10000,
+                                              message:
+                                                  "Workers Routes Read is required",
+                                          },
+                                      ],
+                                  }
+                                : zonePage([zone()])
+                        ),
+                        { status: url.includes("/workers/routes") ? 403 : 200 }
+                    )
+            ),
+            (error) =>
+                error instanceof CloudflareWorkersApiError &&
+                error.details.status === 403 &&
+                error.details.indeterminateMutation === false
+        );
+    });
+
+    await t.test("incomplete pagination", async () => {
+        await assert.rejects(
+            invoke(async (url) => {
+                const page = Number(new URL(url).searchParams.get("page"));
+                return new Response(
+                    JSON.stringify(
+                        page === 1
+                            ? zonePage([zone()], {
+                                  per_page: 1,
+                                  total_count: 2,
+                                  total_pages: 2,
+                              })
+                            : zonePage([], {
+                                  page: 2,
+                                  per_page: 1,
+                                  total_count: 2,
+                                  total_pages: 2,
+                              })
+                    )
+                );
+            }),
+            /incomplete account-zone inventory/
+        );
+    });
+
+    for (const direction of ["deleted", "added"]) {
+        await t.test(`${direction} zone between snapshots`, async () => {
+            let zoneReads = 0;
+            await assert.rejects(
+                invoke(async (url) => {
+                    if (url.includes("/workers/routes")) {
+                        return new Response(
+                            JSON.stringify({ success: true, result: [] })
+                        );
+                    }
+                    zoneReads += 1;
+                    const include =
+                        direction === "deleted"
+                            ? zoneReads === 1
+                            : zoneReads > 1;
+                    return new Response(
+                        JSON.stringify(zonePage(include ? [zone()] : []))
+                    );
+                }),
+                /changed between complete snapshots/
+            );
+        });
+    }
+
+    await t.test("route drift between snapshots", async () => {
+        let routeReads = 0;
+        await assert.rejects(
+            invoke(
+                async (url) =>
+                    new Response(
+                        JSON.stringify(
+                            url.includes("/workers/routes")
+                                ? {
+                                      success: true,
+                                      result: [
+                                          {
+                                              id: "route-a",
+                                              pattern: `peerbit.org/${++routeReads}`,
+                                              script: null,
+                                          },
+                                      ],
+                                  }
+                                : zonePage([zone()])
+                        )
+                    )
+            ),
+            /changed between complete snapshots/
+        );
+    });
+
+    await t.test("duplicate route pattern", async () => {
+        await assert.rejects(
+            invoke(
+                async (url) =>
+                    new Response(
+                        JSON.stringify(
+                            url.includes("/workers/routes")
+                                ? {
+                                      success: true,
+                                      result: [
+                                          {
+                                              id: "route-a",
+                                              pattern: "peerbit.org/*",
+                                              script: null,
+                                          },
+                                          {
+                                              id: "route-b",
+                                              pattern: "peerbit.org/*",
+                                              script: null,
+                                          },
+                                      ],
+                                  }
+                                : zonePage([zone()])
+                        )
+                    )
+            ),
+            /duplicate, or ambiguous authoritative Worker route/
+        );
+    });
+});
+
 test("Cron schedule inventory accepts only Cloudflare's exact documented envelope", async (t) => {
     const workerName = entries[0].policy.productionWorker;
     const invoke = async (result) => {
@@ -3360,8 +4242,20 @@ test("inspection exposes only exact policy-derived actions", async () => {
         configs,
         artifacts,
         expectedCommit: COMMIT,
+        expectedZoneInventorySha256: EXPECTED_ZONE_INVENTORY_SHA256,
         operations: harness.operations,
     });
+    assert.equal(
+        inspection.expectedZoneInventorySha256,
+        EXPECTED_ZONE_INVENTORY_SHA256
+    );
+    assert.ok(
+        inspection.plans.every(
+            (plan) =>
+                plan.expectedZoneInventorySha256 ===
+                EXPECTED_ZONE_INVENTORY_SHA256
+        )
+    );
     assert.deepEqual(
         inspection.plans.map(({ site, workerName, hostname }) => [
             site.id,

--- a/cloudflare/workflow-safety.test.mjs
+++ b/cloudflare/workflow-safety.test.mjs
@@ -44,6 +44,10 @@ test("credentialed production shell receives target and commit through env", () 
         /DEPLOY_TARGET: \$\{\{ inputs\.target \}\}/
     );
     assert.match(productionWorkflow, /DEPLOY_COMMIT: \$\{\{ github\.sha \}\}/);
+    assert.match(
+        productionWorkflow,
+        /CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256: \$\{\{ vars\.CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 \}\}/
+    );
     assert.match(productionWorkflow, /--target "\$DEPLOY_TARGET"/);
     assert.match(productionWorkflow, /--commit "\$DEPLOY_COMMIT"/);
     assert.doesNotMatch(
@@ -73,7 +77,7 @@ test("Cloudflare workflows carry no Supabase build configuration", () => {
 test("preview hosting is validation-only and has no Cloudflare credentials", () => {
     assert.doesNotMatch(
         previewWorkflow,
-        /CLOUDFLARE_API_TOKEN|CLOUDFLARE_ACCOUNT_ID|\$\{\{\s*secrets\./
+        /CLOUDFLARE_API_TOKEN|CLOUDFLARE_ACCOUNT_ID|CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256|\$\{\{\s*secrets\./
     );
     assert.doesNotMatch(
         previewWorkflow,
@@ -98,6 +102,11 @@ test("production deployment remains manually gated", () => {
         /inputs\.confirm == 'deploy-peerbit-production'/
     );
     assert.match(productionWorkflow, /environment: cloudflare-production/);
+    assert.match(productionWorkflow, /Zone Read/);
+    assert.match(
+        productionWorkflow,
+        /Workers Routes Read across every account zone/
+    );
     assert.doesNotMatch(productionWorkflow, /initialize_missing_workers/);
 });
 
@@ -168,6 +177,8 @@ test("one-time provisioning is protected, explicit, and serialized with routine 
         /inputs\.confirm == '(?:plan|provision)-peerbit-production'/
     );
     assert.match(provisioningWorkflow, /environment: cloudflare-production/);
+    assert.match(provisioningWorkflow, /Zone Read and Workers Routes/);
+    assert.match(provisioningWorkflow, /Read across every account zone/);
     assert.match(provisioningWorkflow, /group: cloudflare-examples-production/);
     assert.match(
         provisioningWorkflow,
@@ -176,6 +187,10 @@ test("one-time provisioning is protected, explicit, and serialized with routine 
     assert.match(
         provisioningWorkflow,
         /CLOUDFLARE_ACCOUNT_ID: \$\{\{ vars\.CLOUDFLARE_ACCOUNT_ID \}\}/
+    );
+    assert.match(
+        provisioningWorkflow,
+        /CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256: \$\{\{ vars\.CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 \}\}/
     );
     assert.match(provisioningWorkflow, /--mode "\$PROVISION_MODE"/);
     assert.match(provisioningWorkflow, /--commit "\$PROVISION_COMMIT"/);
@@ -392,7 +407,7 @@ test("one-time provisioning rebuilds exact bundles and never invokes Worker dele
             ),
             credentialedProvision
         ),
-        /CLOUDFLARE_API_TOKEN|CLOUDFLARE_ACCOUNT_ID/
+        /CLOUDFLARE_API_TOKEN|CLOUDFLARE_ACCOUNT_ID|CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256/
     );
 
     const source = readFileSync(
@@ -401,6 +416,40 @@ test("one-time provisioning rebuilds exact bundles and never invokes Worker dele
     );
     assert.doesNotMatch(source, /method:\s*["']DELETE["']/);
     assert.doesNotMatch(source, /wrangler["'],\s*\[[^\]]*["']delete["']/s);
+});
+
+test("protected zone fingerprint is omitted from every uncredentialed workflow phase", () => {
+    assert.equal(
+        (
+            productionWorkflow.match(
+                /CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256:/g
+            ) ?? []
+        ).length,
+        1
+    );
+    assert.equal(
+        (
+            provisioningWorkflow.match(
+                /CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256:/g
+            ) ?? []
+        ).length,
+        1
+    );
+    assert.equal(
+        (
+            previewWorkflow.match(
+                /CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256:/g
+            ) ?? []
+        ).length,
+        0
+    );
+    assert.doesNotMatch(
+        productionWorkflow.slice(
+            0,
+            productionWorkflow.indexOf("CLOUDFLARE_API_TOKEN:")
+        ),
+        /CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256/
+    );
 });
 
 test("every action in Cloudflare workflows is pinned to a full commit", () => {

--- a/scripts/cloudflare-workers-api.mjs
+++ b/scripts/cloudflare-workers-api.mjs
@@ -10,11 +10,17 @@ const CLOUDFLARE_API_BASE_URL = "https://api.cloudflare.com/client/v4";
 const CUSTOM_DOMAIN_PAGE_SIZE = 100;
 const MAX_CUSTOM_DOMAIN_PAGES = 1_000;
 const MAX_CUSTOM_DOMAIN_SNAPSHOT_ATTEMPTS = 3;
+const ZONE_PAGE_SIZE = 50;
+const MAX_ZONE_PAGES = 1_000;
+const REQUIRED_ZONE_ROUTE_SNAPSHOTS = 2;
+const MAX_ROUTES_PER_ZONE = 100_000;
 const QUEUE_PAGE_SIZE = 100;
 const MAX_QUEUE_PAGES = 1_000;
 const MAX_QUEUE_SNAPSHOT_ATTEMPTS = 3;
 const CLOUDFLARE_RESOURCE_ID = /^(?=.{1,32}$)[A-Za-z0-9_-]+$/;
 const QUEUE_NAME = /^(?=.{1,63}$)[A-Za-z0-9_-]+$/;
+const ZONE_STATUSES = new Set(["initializing", "pending", "active", "moved"]);
+const ZONE_TYPES = new Set(["full", "partial", "secondary", "internal"]);
 const MAX_DEPLOYABLE_WORKER_VERSIONS = 10_000;
 const WORKERS_DEV_REFERENCE =
     /(?<![a-z0-9-])(?:(?:[a-z][a-z0-9+.-]*:)?\/\/)?(?:[a-z0-9-]+\.)*workers\.dev(?:\.(?![a-z0-9-])|(?![a-z0-9.-]))(?::[0-9]+)?(?:[/?#][^\s<>"']*)?/gi;
@@ -177,6 +183,7 @@ export const createCloudflareWorkersApi = ({
     const scriptsUrl = `${CLOUDFLARE_API_BASE_URL}/accounts/${accountId}/workers/scripts`;
     const domainsUrl = `${CLOUDFLARE_API_BASE_URL}/accounts/${accountId}/workers/domains`;
     const queuesUrl = `${CLOUDFLARE_API_BASE_URL}/accounts/${accountId}/queues`;
+    const zonesUrl = `${CLOUDFLARE_API_BASE_URL}/zones`;
     const secrets = [apiToken, accountId];
     const call = async ({ operation, url, method = "GET", body }) => {
         let response;
@@ -308,7 +315,7 @@ export const createCloudflareWorkersApi = ({
                     (script.tag != null &&
                         (typeof script.tag !== "string" ||
                             script.tag.length === 0)) ||
-                    !Array.isArray(script.routes) ||
+                    (script.routes != null && !Array.isArray(script.routes)) ||
                     (script.tail_consumers != null &&
                         !Array.isArray(script.tail_consumers)) ||
                     (script.logpush != null &&
@@ -325,33 +332,39 @@ export const createCloudflareWorkersApi = ({
                 }
                 const routeIds = new Set();
                 const routePatterns = new Set();
-                const routes = [];
-                for (const route of script.routes) {
-                    if (
-                        typeof route?.id !== "string" ||
-                        route.id.length === 0 ||
-                        routeIds.has(route.id) ||
-                        typeof route.pattern !== "string" ||
-                        route.pattern.length === 0 ||
-                        routePatterns.has(route.pattern) ||
-                        route.script !== script.id
-                    ) {
-                        throw new CloudflareWorkersApiError({
-                            operation: "list account Worker scripts",
-                            status: 200,
-                            cause: new Error(
-                                "Cloudflare returned an invalid or ambiguous Worker route attachment"
-                            ),
-                            secrets,
+                const routes = script.routes == null ? null : [];
+                if (script.routes != null) {
+                    for (const route of script.routes) {
+                        const routeScript = route?.script ?? script.id;
+                        if (
+                            !CLOUDFLARE_RESOURCE_ID.test(route?.id || "") ||
+                            routeIds.has(route.id) ||
+                            typeof route.pattern !== "string" ||
+                            route.pattern.length === 0 ||
+                            route.pattern.trim() !== route.pattern ||
+                            routePatterns.has(route.pattern) ||
+                            routeScript !== script.id
+                        ) {
+                            throw new CloudflareWorkersApiError({
+                                operation: "list account Worker scripts",
+                                status: 200,
+                                cause: new Error(
+                                    "Cloudflare returned an invalid or ambiguous inline Worker route attachment"
+                                ),
+                                secrets,
+                            });
+                        }
+                        routeIds.add(route.id);
+                        routePatterns.add(route.pattern);
+                        routes.push({
+                            id: route.id,
+                            pattern: route.pattern,
+                            script: routeScript,
                         });
                     }
-                    routeIds.add(route.id);
-                    routePatterns.add(route.pattern);
-                    routes.push({
-                        id: route.id,
-                        pattern: route.pattern,
-                        script: route.script,
-                    });
+                    routes.sort((left, right) =>
+                        left.id.localeCompare(right.id)
+                    );
                 }
                 scripts.set(script.id, {
                     tag: script.tag,
@@ -361,6 +374,219 @@ export const createCloudflareWorkersApi = ({
                 });
             }
             return scripts;
+        },
+        listZoneRouteInventory: async () => {
+            const operation =
+                "list stable authoritative account zone and Worker route inventory";
+            const readZoneSnapshot = async () => {
+                const zones = [];
+                const zoneIds = new Set();
+                const zoneNames = new Set();
+                let expectedTotalCount;
+                let expectedTotalPages;
+                let expectedPerPage;
+
+                for (let page = 1; page <= MAX_ZONE_PAGES; page += 1) {
+                    const query = new URLSearchParams({
+                        "account.id": accountId,
+                        page: String(page),
+                        per_page: String(ZONE_PAGE_SIZE),
+                        type: [...ZONE_TYPES].join(","),
+                        order: "name",
+                        direction: "asc",
+                        match: "all",
+                    });
+                    const payload = await call({
+                        operation,
+                        url: `${zonesUrl}?${query}`,
+                    });
+                    const result = payload.result;
+                    const info = payload.result_info;
+                    const validInfo =
+                        Array.isArray(result) &&
+                        info &&
+                        typeof info === "object" &&
+                        Number.isSafeInteger(info.count) &&
+                        info.count >= 0 &&
+                        info.count === result.length &&
+                        Number.isSafeInteger(info.page) &&
+                        info.page === page &&
+                        Number.isSafeInteger(info.per_page) &&
+                        info.per_page > 0 &&
+                        info.per_page <= ZONE_PAGE_SIZE &&
+                        info.count <= info.per_page &&
+                        Number.isSafeInteger(info.total_count) &&
+                        info.total_count >= 0 &&
+                        Number.isSafeInteger(info.total_pages) &&
+                        info.total_pages >= 0 &&
+                        info.total_pages <= MAX_ZONE_PAGES &&
+                        (info.total_count === 0
+                            ? info.total_pages === 0 || info.total_pages === 1
+                            : info.total_pages ===
+                              Math.ceil(info.total_count / info.per_page)) &&
+                        page <= Math.max(info.total_pages, 1);
+                    if (!validInfo) {
+                        invalidResult({
+                            operation,
+                            message:
+                                "Cloudflare returned invalid or ambiguous account-zone pagination",
+                        });
+                    }
+
+                    expectedTotalCount ??= info.total_count;
+                    expectedTotalPages ??= info.total_pages;
+                    expectedPerPage ??= info.per_page;
+                    if (
+                        info.total_count !== expectedTotalCount ||
+                        info.total_pages !== expectedTotalPages ||
+                        info.per_page !== expectedPerPage
+                    ) {
+                        invalidResult({
+                            operation,
+                            message:
+                                "Cloudflare account-zone pagination changed while it was being read",
+                        });
+                    }
+
+                    for (const zone of result) {
+                        const zoneId =
+                            typeof zone?.id === "string"
+                                ? zone.id.toLowerCase()
+                                : undefined;
+                        const zoneName =
+                            typeof zone?.name === "string"
+                                ? zone.name.toLowerCase()
+                                : undefined;
+                        const zoneAccountId =
+                            typeof zone?.account?.id === "string"
+                                ? zone.account.id.toLowerCase()
+                                : undefined;
+                        const zoneType = zone?.type ?? null;
+                        if (
+                            !zoneId ||
+                            !CLOUDFLARE_ACCOUNT_ID.test(zoneId) ||
+                            zone.id !== zoneId ||
+                            zoneIds.has(zoneId) ||
+                            !zoneName ||
+                            !DNS_HOSTNAME.test(zoneName) ||
+                            zone.name !== zoneName ||
+                            zone.name.trim() !== zone.name ||
+                            zoneNames.has(zoneName) ||
+                            zoneAccountId !== accountId.toLowerCase() ||
+                            zone.account.id !== zoneAccountId ||
+                            !ZONE_STATUSES.has(zone.status) ||
+                            (zoneType !== null && !ZONE_TYPES.has(zoneType))
+                        ) {
+                            invalidResult({
+                                operation,
+                                message:
+                                    "Cloudflare returned an invalid, duplicate, or wrong-account zone identity",
+                            });
+                        }
+                        zoneIds.add(zoneId);
+                        zoneNames.add(zoneName);
+                        zones.push({
+                            zoneId,
+                            zoneName,
+                            status: zone.status,
+                            type: zoneType,
+                        });
+                    }
+                    if (page >= info.total_pages) break;
+                }
+
+                if (
+                    expectedTotalCount == null ||
+                    expectedTotalPages == null ||
+                    zones.length !== expectedTotalCount
+                ) {
+                    invalidResult({
+                        operation,
+                        message:
+                            "Cloudflare returned an incomplete account-zone inventory",
+                    });
+                }
+                return zones.sort((left, right) =>
+                    left.zoneId.localeCompare(right.zoneId)
+                );
+            };
+
+            const readFullSnapshot = async () => {
+                const zones = await readZoneSnapshot();
+                const routeIds = new Set();
+                const routePatterns = new Set();
+                for (const zone of zones) {
+                    const payload = await call({
+                        operation,
+                        url: `${zonesUrl}/${zone.zoneId}/workers/routes`,
+                    });
+                    if (
+                        !Array.isArray(payload.result) ||
+                        payload.result.length > MAX_ROUTES_PER_ZONE
+                    ) {
+                        invalidResult({
+                            operation,
+                            message:
+                                "Cloudflare returned an invalid authoritative Worker route list",
+                        });
+                    }
+                    const routes = [];
+                    for (const route of payload.result) {
+                        const script = route?.script ?? null;
+                        if (
+                            !CLOUDFLARE_RESOURCE_ID.test(route?.id || "") ||
+                            routeIds.has(route.id) ||
+                            typeof route.pattern !== "string" ||
+                            route.pattern.length === 0 ||
+                            route.pattern.trim() !== route.pattern ||
+                            routePatterns.has(route.pattern) ||
+                            (script !== null && !WORKER_NAME.test(script))
+                        ) {
+                            invalidResult({
+                                operation,
+                                message:
+                                    "Cloudflare returned an invalid, duplicate, or ambiguous authoritative Worker route",
+                            });
+                        }
+                        routeIds.add(route.id);
+                        routePatterns.add(route.pattern);
+                        routes.push({
+                            id: route.id,
+                            pattern: route.pattern,
+                            script,
+                        });
+                    }
+                    zone.routes = routes.sort((left, right) =>
+                        left.id.localeCompare(right.id)
+                    );
+                }
+                return zones;
+            };
+
+            let previousCanonicalSnapshot;
+            for (
+                let snapshotNumber = 1;
+                snapshotNumber <= REQUIRED_ZONE_ROUTE_SNAPSHOTS;
+                snapshotNumber += 1
+            ) {
+                const snapshot = await readFullSnapshot();
+                const canonicalSnapshot = JSON.stringify(snapshot);
+                if (
+                    snapshotNumber > 1 &&
+                    canonicalSnapshot !== previousCanonicalSnapshot
+                ) {
+                    invalidResult({
+                        operation,
+                        message:
+                            "Cloudflare authoritative zone or Worker route inventory changed between complete snapshots",
+                    });
+                }
+                previousCanonicalSnapshot = canonicalSnapshot;
+                if (snapshotNumber === REQUIRED_ZONE_ROUTE_SNAPSHOTS) {
+                    return snapshot;
+                }
+            }
+            throw new Error("unreachable zone-route snapshot state");
         },
         listWorkerDomains: async () => {
             const operation = "list account Worker custom domains";

--- a/scripts/deploy-cloudflare-production.mjs
+++ b/scripts/deploy-cloudflare-production.mjs
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import {
     APP_PRODUCTION_SUFFIX,
@@ -41,6 +41,14 @@ const MAX_DIAGNOSTIC_LENGTH = 2_000;
 const VERSION_TAG = /^[A-Za-z0-9_-]{1,100}$/;
 const DNS_HOSTNAME =
     /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const CLOUDFLARE_ACCOUNT_ID = /^[0-9a-f]{32}$/i;
+const CLOUDFLARE_RESOURCE_ID = /^(?=.{1,32}$)[A-Za-z0-9_-]+$/;
+const WORKER_NAME = /^(?=.{1,63}$)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+const ZONE_STATUSES = new Set(["initializing", "pending", "active", "moved"]);
+const ZONE_TYPES = new Set(["full", "partial", "secondary", "internal"]);
+const SHA256_DIGEST = /^[0-9a-f]{64}$/;
+const compareCanonicalStrings = (left, right) =>
+    left < right ? -1 : left > right ? 1 : 0;
 const INDETERMINATE_ACTIVATION_OBSERVATIONS = 12;
 const INDETERMINATE_ACTIVATION_DELAY_MS = 2_500;
 
@@ -213,7 +221,10 @@ export const createInvocationVersionTag = ({
     return tag;
 };
 
-export const readWorkerScriptMap = async (operations) => {
+export const readWorkerScriptMap = async (
+    operations,
+    { allowMissingInlineRoutes = false } = {}
+) => {
     const scripts = await operations.listWorkerScripts();
     if (
         !(scripts instanceof Map) ||
@@ -226,17 +237,19 @@ export const readWorkerScriptMap = async (operations) => {
                 (metadata.tag != null &&
                     (typeof metadata.tag !== "string" ||
                         metadata.tag.length === 0)) ||
-                !Array.isArray(metadata.routes) ||
-                metadata.routes.some(
-                    (route) =>
-                        !route ||
-                        typeof route !== "object" ||
-                        typeof route.id !== "string" ||
-                        route.id.length === 0 ||
-                        typeof route.pattern !== "string" ||
-                        route.pattern.length === 0 ||
-                        route.script !== scriptName
-                )
+                (!Array.isArray(metadata.routes) &&
+                    !(allowMissingInlineRoutes && metadata.routes === null)) ||
+                (Array.isArray(metadata.routes) &&
+                    metadata.routes.some(
+                        (route) =>
+                            !route ||
+                            typeof route !== "object" ||
+                            typeof route.id !== "string" ||
+                            route.id.length === 0 ||
+                            typeof route.pattern !== "string" ||
+                            route.pattern.length === 0 ||
+                            route.script !== scriptName
+                    ))
         )
     ) {
         throw new Error(
@@ -244,6 +257,180 @@ export const readWorkerScriptMap = async (operations) => {
         );
     }
     return scripts;
+};
+
+export const requireExpectedAccountZoneInventorySha256 = (value) => {
+    if (typeof value !== "string" || !SHA256_DIGEST.test(value)) {
+        throw new Error(
+            "CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 must be an exact lowercase SHA-256 digest"
+        );
+    }
+    return value;
+};
+
+export const accountZoneInventorySha256 = (inventory) => {
+    if (!Array.isArray(inventory)) {
+        throw new Error(
+            "Cloudflare account zone identity inventory must be an array"
+        );
+    }
+    const zoneIds = new Set();
+    const zoneNames = new Set();
+    const identities = inventory.map((zone) => {
+        if (
+            !zone ||
+            typeof zone !== "object" ||
+            Array.isArray(zone) ||
+            typeof zone.zoneId !== "string" ||
+            !CLOUDFLARE_ACCOUNT_ID.test(zone.zoneId || "") ||
+            zone.zoneId !== zone.zoneId.toLowerCase() ||
+            zoneIds.has(zone.zoneId) ||
+            typeof zone.zoneName !== "string" ||
+            zone.zoneName !== zone.zoneName.toLowerCase() ||
+            zone.zoneName.trim() !== zone.zoneName ||
+            !DNS_HOSTNAME.test(zone.zoneName) ||
+            zoneNames.has(zone.zoneName)
+        ) {
+            throw new Error(
+                "Cloudflare account zone identity inventory is invalid or ambiguous"
+            );
+        }
+        zoneIds.add(zone.zoneId);
+        zoneNames.add(zone.zoneName);
+        return { zoneId: zone.zoneId, zoneName: zone.zoneName };
+    });
+    identities.sort(
+        (left, right) =>
+            compareCanonicalStrings(left.zoneId, right.zoneId) ||
+            compareCanonicalStrings(left.zoneName, right.zoneName)
+    );
+    return createHash("sha256")
+        .update(JSON.stringify(identities), "utf8")
+        .digest("hex");
+};
+
+export const readAndValidateZoneRouteInventory = async ({
+    scripts,
+    operations,
+    expectedZoneInventorySha256,
+}) => {
+    const expectedFingerprint = requireExpectedAccountZoneInventorySha256(
+        expectedZoneInventorySha256
+    );
+    const inventory = await operations.listZoneRouteInventory();
+    if (!Array.isArray(inventory)) {
+        throw new Error(
+            "Cloudflare authoritative zone and Worker route inventory is missing"
+        );
+    }
+    const zoneIds = new Set();
+    const zoneNames = new Set();
+    const routeIds = new Set();
+    const routePatterns = new Set();
+    const authoritativeByScript = new Map();
+    const normalizedZones = [];
+    for (const zone of inventory) {
+        if (
+            !zone ||
+            typeof zone !== "object" ||
+            Array.isArray(zone) ||
+            !CLOUDFLARE_ACCOUNT_ID.test(zone.zoneId || "") ||
+            zone.zoneId !== zone.zoneId.toLowerCase() ||
+            zoneIds.has(zone.zoneId) ||
+            typeof zone.zoneName !== "string" ||
+            zone.zoneName !== zone.zoneName.toLowerCase() ||
+            zone.zoneName.trim() !== zone.zoneName ||
+            !DNS_HOSTNAME.test(zone.zoneName) ||
+            zoneNames.has(zone.zoneName) ||
+            !ZONE_STATUSES.has(zone.status) ||
+            (zone.type !== null && !ZONE_TYPES.has(zone.type)) ||
+            !Array.isArray(zone.routes)
+        ) {
+            throw new Error(
+                "Cloudflare authoritative zone inventory is invalid or ambiguous"
+            );
+        }
+        zoneIds.add(zone.zoneId);
+        zoneNames.add(zone.zoneName);
+        const routes = [];
+        for (const route of zone.routes) {
+            if (
+                !route ||
+                typeof route !== "object" ||
+                Array.isArray(route) ||
+                !CLOUDFLARE_RESOURCE_ID.test(route.id || "") ||
+                routeIds.has(route.id) ||
+                typeof route.pattern !== "string" ||
+                route.pattern.length === 0 ||
+                route.pattern.trim() !== route.pattern ||
+                routePatterns.has(route.pattern) ||
+                (route.script !== null && !WORKER_NAME.test(route.script || ""))
+            ) {
+                throw new Error(
+                    "Cloudflare authoritative Worker route inventory is invalid or ambiguous"
+                );
+            }
+            if (route.script !== null && !scripts.has(route.script)) {
+                throw new Error(
+                    `Cloudflare authoritative Worker route references unknown script ${route.script}`
+                );
+            }
+            routeIds.add(route.id);
+            routePatterns.add(route.pattern);
+            const normalized = {
+                id: route.id,
+                pattern: route.pattern,
+                script: route.script,
+            };
+            routes.push(normalized);
+            if (route.script !== null) {
+                const attached = authoritativeByScript.get(route.script) ?? [];
+                attached.push(normalized);
+                authoritativeByScript.set(route.script, attached);
+            }
+        }
+        normalizedZones.push({
+            zoneId: zone.zoneId,
+            zoneName: zone.zoneName,
+            status: zone.status,
+            type: zone.type,
+            routes: routes.sort((left, right) =>
+                left.id.localeCompare(right.id)
+            ),
+        });
+    }
+
+    for (const [workerName, metadata] of scripts) {
+        const inlineRoutes = metadata.routes;
+        if (inlineRoutes === null) continue;
+        if (!Array.isArray(inlineRoutes)) {
+            throw new Error(
+                `${workerName}: inline Worker route inventory is invalid`
+            );
+        }
+        const authoritative = [...(authoritativeByScript.get(workerName) ?? [])]
+            .map(({ id, pattern, script }) => ({ id, pattern, script }))
+            .sort((left, right) => left.id.localeCompare(right.id));
+        const inline = [...inlineRoutes]
+            .map(({ id, pattern, script }) => ({ id, pattern, script }))
+            .sort((left, right) => left.id.localeCompare(right.id));
+        if (JSON.stringify(inline) !== JSON.stringify(authoritative)) {
+            throw new Error(
+                `${workerName}: inline Worker routes do not exactly match the authoritative per-zone route inventory`
+            );
+        }
+    }
+    const normalizedInventory = normalizedZones.sort((left, right) =>
+        left.zoneId.localeCompare(right.zoneId)
+    );
+    if (
+        accountZoneInventorySha256(normalizedInventory) !== expectedFingerprint
+    ) {
+        throw new Error(
+            "Cloudflare account zone identity inventory does not match the independently reviewed fingerprint"
+        );
+    }
+    return normalizedInventory;
 };
 
 export const readWorkerDomainInventory = async (operations) => {
@@ -306,16 +493,23 @@ export const validateProductionAttachmentInventory = ({
     plans,
     scripts,
     domains,
+    zoneRouteInventory,
 }) => {
     const expectedByHostname = new Map();
     const policyWorkerNames = new Set();
+    const policySiteByWorker = new Map();
     for (const plan of plans) {
         policyWorkerNames.add(plan.workerName);
         policyWorkerNames.add(plan.policy.previewWorker);
+        policySiteByWorker.set(plan.workerName, plan.site.id);
+        policySiteByWorker.set(plan.policy.previewWorker, plan.site.id);
         for (const hostname of plan.policy.productionHostnames) {
             expectedByHostname.set(hostname, plan.workerName);
         }
     }
+    const zonesById = new Map(
+        zoneRouteInventory.map((zone) => [zone.zoneId, zone])
+    );
 
     for (const plan of plans) {
         const metadata = scripts.get(plan.workerName);
@@ -324,14 +518,6 @@ export const validateProductionAttachmentInventory = ({
                 `${plan.site.id}: production Worker ${plan.workerName} disappeared during attachment validation`
             );
         }
-        if (metadata.routes.length !== 0) {
-            throw new Error(
-                `${plan.site.id}: ${plan.workerName} has unreviewed Worker route attachments (${metadata.routes
-                    .map(({ pattern }) => pattern)
-                    .join(", ")})`
-            );
-        }
-
         const expectedHostnames = plan.policy.productionHostnames;
         if (
             !Array.isArray(expectedHostnames) ||
@@ -388,7 +574,7 @@ export const validateProductionAttachmentInventory = ({
         }
     }
 
-    for (const [workerName, metadata] of scripts) {
+    for (const [workerName] of scripts) {
         const policyOwned = policyWorkerNames.has(workerName);
         const inManagedNamespace = workerName.startsWith(
             CLOUDFLARE_WORKER_NAMESPACE_PREFIX
@@ -398,22 +584,38 @@ export const validateProductionAttachmentInventory = ({
                 `Cloudflare has an unreviewed or retired Worker identity ${workerName} inside the ${CLOUDFLARE_WORKER_NAMESPACE_PREFIX} namespace`
             );
         }
-        const managedRoutes = metadata.routes.filter(({ pattern }) =>
-            routeTargetsManagedAppHostname(pattern)
-        );
-        if (
-            metadata.routes.length > 0 &&
-            (policyOwned || inManagedNamespace || managedRoutes.length > 0)
-        ) {
-            throw new Error(
-                `${workerName} has unreviewed Worker route attachments (${metadata.routes
-                    .map(({ pattern }) => pattern)
-                    .join(", ")})`
-            );
+    }
+
+    for (const zone of zoneRouteInventory) {
+        for (const route of zone.routes) {
+            const policyOwned =
+                route.script !== null && policyWorkerNames.has(route.script);
+            const managedWorker =
+                route.script !== null &&
+                route.script.startsWith(CLOUDFLARE_WORKER_NAMESPACE_PREFIX);
+            if (
+                policyOwned ||
+                managedWorker ||
+                routeTargetsManagedAppHostname(route.pattern)
+            ) {
+                const policySite =
+                    route.script === null
+                        ? undefined
+                        : policySiteByWorker.get(route.script);
+                throw new Error(
+                    `${policySite ? `${policySite}: ` : ""}${route.script ?? "scriptless route"} has unreviewed Worker route attachments in ${zone.zoneName}`
+                );
+            }
         }
     }
 
     for (const domain of domains) {
+        const domainZone = zonesById.get(domain.zoneId);
+        if (!domainZone || domainZone.zoneName !== domain.zoneName) {
+            throw new Error(
+                `Cloudflare custom domain ${domain.hostname} references a zone outside the authoritative account inventory`
+            );
+        }
         const expectedWorker = expectedByHostname.get(domain.hostname);
         const managedHostname = managedAppHostname(domain.hostname);
         const policyOwnedWorker = policyWorkerNames.has(domain.service);
@@ -473,12 +675,37 @@ export const readAndValidateProductionAttachments = async ({
     plans,
     operations,
     scripts: providedScripts,
+    expectedZoneInventorySha256,
+    expectedZoneRouteInventory,
 }) => {
-    const scripts = providedScripts ?? (await readWorkerScriptMap(operations));
+    const scripts =
+        providedScripts ??
+        (await readWorkerScriptMap(operations, {
+            allowMissingInlineRoutes: true,
+        }));
+    const zoneRouteInventory = await readAndValidateZoneRouteInventory({
+        scripts,
+        operations,
+        expectedZoneInventorySha256,
+    });
+    if (
+        expectedZoneRouteInventory !== undefined &&
+        JSON.stringify(zoneRouteInventory) !==
+            JSON.stringify(expectedZoneRouteInventory)
+    ) {
+        throw new Error(
+            "Cloudflare authoritative account zone or Worker route inventory changed during production deployment"
+        );
+    }
     const domains = await readWorkerDomainInventory(operations);
-    validateProductionAttachmentInventory({ plans, scripts, domains });
+    validateProductionAttachmentInventory({
+        plans,
+        scripts,
+        domains,
+        zoneRouteInventory,
+    });
     await readAndValidateWorkerSubdomains({ plans, scripts, operations });
-    return scripts;
+    return { scripts, zoneRouteInventory };
 };
 
 export const productionWorkerConfig = ({ site, policy, configs }) => {
@@ -567,7 +794,9 @@ const revalidateRollbackBaseline = async ({
             `${site.id}: production app requires a full rollback release commit`
         );
     }
-    const scripts = await readWorkerScriptMap(operations);
+    const scripts = await readWorkerScriptMap(operations, {
+        allowMissingInlineRoutes: true,
+    });
     const currentTag = requireWorkerTag({
         site,
         workerName,
@@ -640,7 +869,9 @@ const readActiveVersion = async ({ plan, operations }) =>
     );
 
 const readCurrentWorkerTag = async ({ plan, operations }) => {
-    const scripts = await readWorkerScriptMap(operations);
+    const scripts = await readWorkerScriptMap(operations, {
+        allowMissingInlineRoutes: true,
+    });
     return requireWorkerTag({
         site: plan.site,
         workerName: plan.workerName,
@@ -652,12 +883,16 @@ const readFencedActiveVersionLast = async ({
     plan,
     inventoryPlans,
     operations,
+    expectedZoneInventorySha256,
+    expectedZoneRouteInventory,
     expectedWorkerTag,
     phase,
 }) => {
     await readAndValidateProductionAttachments({
         plans: inventoryPlans,
         operations,
+        expectedZoneInventorySha256,
+        expectedZoneRouteInventory,
     });
     const currentTag = await readCurrentWorkerTag({ plan, operations });
     if (currentTag !== expectedWorkerTag) {
@@ -734,6 +969,8 @@ const rollbackExactInvocation = async ({
     plan,
     inventoryPlans,
     operations,
+    expectedZoneInventorySha256,
+    expectedZoneRouteInventory,
     log,
 }) => {
     const { previousVersion, previousCommit, workerTag } = plan.baseline;
@@ -748,6 +985,8 @@ const rollbackExactInvocation = async ({
         plan,
         inventoryPlans,
         operations,
+        expectedZoneInventorySha256,
+        expectedZoneRouteInventory,
         expectedWorkerTag: workerTag,
         phase: "rollback authorization",
     });
@@ -770,6 +1009,8 @@ const rollbackExactInvocation = async ({
             plan,
             inventoryPlans,
             operations,
+            expectedZoneInventorySha256,
+            expectedZoneRouteInventory,
             expectedWorkerTag: workerTag,
             phase: "post-verifier baseline confirmation",
         });
@@ -810,6 +1051,8 @@ const rollbackExactInvocation = async ({
         plan,
         inventoryPlans,
         operations,
+        expectedZoneInventorySha256,
+        expectedZoneRouteInventory,
         expectedWorkerTag: workerTag,
         phase: "final rollback authorization",
     });
@@ -849,6 +1092,12 @@ const rollbackExactInvocation = async ({
             `rollback API selected ${rollbackVersion}, expected ${previousVersion}`
         );
     }
+    await readAndValidateProductionAttachments({
+        plans: inventoryPlans,
+        operations,
+        expectedZoneInventorySha256,
+        expectedZoneRouteInventory,
+    });
     const restoredVersion = await readActiveVersion({ plan, operations });
     if (restoredVersion !== previousVersion) {
         throw new Error(
@@ -869,6 +1118,8 @@ const rollbackExactInvocation = async ({
         plan,
         inventoryPlans,
         operations,
+        expectedZoneInventorySha256,
+        expectedZoneRouteInventory,
         expectedWorkerTag: workerTag,
         phase: "post-verifier rollback confirmation",
     });
@@ -887,6 +1138,7 @@ export const deployProductionEntries = async ({
     deploymentEntries,
     configs,
     expectedCommit,
+    expectedZoneInventorySha256,
     operations,
     log = console.log,
 }) => {
@@ -895,6 +1147,9 @@ export const deployProductionEntries = async ({
             "Production deployment requires a full Git commit hash"
         );
     }
+    const pinnedZoneInventorySha256 = requireExpectedAccountZoneInventorySha256(
+        expectedZoneInventorySha256
+    );
     if (!Array.isArray(selectedEntries) || selectedEntries.length === 0) {
         throw new Error(
             "Production deployment requires a non-empty selected entry set"
@@ -948,7 +1203,9 @@ export const deployProductionEntries = async ({
         }
         return plan;
     });
-    const scripts = await readWorkerScriptMap(operations);
+    const scripts = await readWorkerScriptMap(operations, {
+        allowMissingInlineRoutes: true,
+    });
     const missingPlans = attachmentPlans.filter(
         ({ workerName }) => !scripts.has(workerName)
     );
@@ -960,11 +1217,13 @@ export const deployProductionEntries = async ({
             `Production deploys require pre-provisioned Workers; missing ${missing}. Provision these exact Worker names and their reviewed custom domains from cloudflare/deployment-policy.json in Cloudflare once, then rerun. No deployment was attempted`
         );
     }
-    await readAndValidateProductionAttachments({
-        plans: attachmentPlans,
-        operations,
-        scripts,
-    });
+    const { zoneRouteInventory: expectedZoneRouteInventory } =
+        await readAndValidateProductionAttachments({
+            plans: attachmentPlans,
+            operations,
+            scripts,
+            expectedZoneInventorySha256: pinnedZoneInventorySha256,
+        });
 
     const baselines = new Map();
     for (const plan of plans) {
@@ -999,6 +1258,8 @@ export const deployProductionEntries = async ({
     await readAndValidateProductionAttachments({
         plans: attachmentPlans,
         operations,
+        expectedZoneInventorySha256: pinnedZoneInventorySha256,
+        expectedZoneRouteInventory,
     });
     for (const plan of plans) {
         await revalidateRollbackBaseline({
@@ -1018,6 +1279,8 @@ export const deployProductionEntries = async ({
             await readAndValidateProductionAttachments({
                 plans: attachmentPlans,
                 operations,
+                expectedZoneInventorySha256: pinnedZoneInventorySha256,
+                expectedZoneRouteInventory,
             });
             plan.invocation = validateDeploymentEvidence(
                 await operations.upload({
@@ -1033,6 +1296,8 @@ export const deployProductionEntries = async ({
             await readAndValidateProductionAttachments({
                 plans: attachmentPlans,
                 operations,
+                expectedZoneInventorySha256: pinnedZoneInventorySha256,
+                expectedZoneRouteInventory,
             });
             if (plan.invocation.workerTag !== plan.baseline.workerTag) {
                 throw new Error(
@@ -1067,6 +1332,8 @@ export const deployProductionEntries = async ({
         await readAndValidateProductionAttachments({
             plans: attachmentPlans,
             operations,
+            expectedZoneInventorySha256: pinnedZoneInventorySha256,
+            expectedZoneRouteInventory,
         });
         for (const plan of plans) {
             await revalidateRollbackBaseline({ ...plan, operations });
@@ -1089,6 +1356,8 @@ export const deployProductionEntries = async ({
             await readAndValidateProductionAttachments({
                 plans: attachmentPlans,
                 operations,
+                expectedZoneInventorySha256: pinnedZoneInventorySha256,
+                expectedZoneRouteInventory,
             });
             validateUploadedVersionOwnership({
                 plan,
@@ -1133,6 +1402,12 @@ export const deployProductionEntries = async ({
                 );
             }
             await confirmInvocationActive({ plan, operations });
+            await readAndValidateProductionAttachments({
+                plans: attachmentPlans,
+                operations,
+                expectedZoneInventorySha256: pinnedZoneInventorySha256,
+                expectedZoneRouteInventory,
+            });
             plan.indeterminateActivation = false;
             activatedPlans.push(plan);
             await operations.verify({
@@ -1155,6 +1430,8 @@ export const deployProductionEntries = async ({
             await readAndValidateProductionAttachments({
                 plans: attachmentPlans,
                 operations,
+                expectedZoneInventorySha256: pinnedZoneInventorySha256,
+                expectedZoneRouteInventory,
             });
             await confirmInvocationActive({ plan, operations });
         }
@@ -1179,6 +1456,8 @@ export const deployProductionEntries = async ({
                         plan,
                         inventoryPlans: attachmentPlans,
                         operations,
+                        expectedZoneInventorySha256: pinnedZoneInventorySha256,
+                        expectedZoneRouteInventory,
                         log,
                     })
                 );
@@ -1637,6 +1916,7 @@ export const main = async (argv = process.argv.slice(2)) => {
     });
     const operations = {
         listWorkerScripts: workersApi.listWorkerScripts,
+        listZoneRouteInventory: workersApi.listZoneRouteInventory,
         listWorkerDomains: workersApi.listWorkerDomains,
         getWorkerSubdomain: workersApi.getWorkerSubdomain,
         status: ({ workerName }) => workersApi.getCurrentDeployment(workerName),
@@ -1713,6 +1993,8 @@ export const main = async (argv = process.argv.slice(2)) => {
         deploymentEntries: entries,
         configs,
         expectedCommit,
+        expectedZoneInventorySha256:
+            deploymentEnvironment.CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256,
         operations,
     });
 };

--- a/scripts/provision-cloudflare-production.mjs
+++ b/scripts/provision-cloudflare-production.mjs
@@ -17,10 +17,11 @@ import {
 import {
     productionWorkerConfig,
     productionSmokeEnvironment,
-    readAndValidateProductionAttachments,
+    readAndValidateZoneRouteInventory,
     readSingleVersionDeployment,
     readWorkerDomainInventory,
     readWorkerScriptMap,
+    requireExpectedAccountZoneInventorySha256,
     runWranglerVersionUpload,
     withoutCloudflareDeploymentCredentials,
 } from "./deploy-cloudflare-production.mjs";
@@ -228,6 +229,7 @@ const validateProvisioningAttachmentInventory = ({
     entries,
     scripts,
     domains,
+    zoneRouteInventory,
 }) => {
     const expectedByHostname = new Map();
     const expectedProductionWorkers = new Set();
@@ -244,6 +246,9 @@ const validateProvisioningAttachmentInventory = ({
         ...expectedProductionWorkers,
         ...expectedPreviewWorkers,
     ]);
+    const zonesById = new Map(
+        zoneRouteInventory.map((zone) => [zone.zoneId, zone])
+    );
 
     for (const [workerName, metadata] of scripts) {
         const inManagedNamespace = workerName.startsWith(
@@ -257,19 +262,6 @@ const validateProvisioningAttachmentInventory = ({
             }
             throw new Error(
                 `Cloudflare has an unreviewed Worker identity ${workerName} inside the managed namespace`
-            );
-        }
-        const managedRoutes = metadata.routes.filter(({ pattern }) =>
-            routeTargetsManagedAppHostname(pattern)
-        );
-        if (
-            metadata.routes.length > 0 &&
-            (inManagedNamespace ||
-                policyWorkers.has(workerName) ||
-                managedRoutes.length > 0)
-        ) {
-            throw new Error(
-                `${workerName} has unreviewed traditional Worker route attachments`
             );
         }
         if (
@@ -290,7 +282,26 @@ const validateProvisioningAttachmentInventory = ({
         }
     }
 
+    for (const zone of zoneRouteInventory) {
+        for (const route of zone.routes) {
+            if (
+                routeTargetsManagedAppHostname(route.pattern) ||
+                (route.script !== null && policyWorkers.has(route.script))
+            ) {
+                throw new Error(
+                    `${route.script ?? "scriptless route"} has an unreviewed traditional Worker route attachment in ${zone.zoneName}`
+                );
+            }
+        }
+    }
+
     for (const domain of domains) {
+        const domainZone = zonesById.get(domain.zoneId);
+        if (!domainZone || domainZone.zoneName !== domain.zoneName) {
+            throw new Error(
+                `Cloudflare custom domain ${domain.hostname} references a zone outside the authoritative account inventory`
+            );
+        }
         const expectedWorker = expectedByHostname.get(domain.hostname);
         const managedHostname = managedAppHostname(domain.hostname);
         const policyWorker = policyWorkers.has(domain.service);
@@ -890,6 +901,7 @@ export const inspectProductionProvisioning = async ({
     configs,
     artifacts,
     expectedCommit,
+    expectedZoneInventorySha256,
     operations,
     invocationNonce,
     invocationCandidates = new Map(),
@@ -898,6 +910,9 @@ export const inspectProductionProvisioning = async ({
     if (!FULL_GIT_COMMIT.test(expectedCommit || "")) {
         throw new Error("Provisioning requires a full Git commit hash");
     }
+    const expectedZoneFingerprint = requireExpectedAccountZoneInventorySha256(
+        expectedZoneInventorySha256
+    );
     if (!(configs instanceof Map) || configs.size !== entries.length) {
         throw new Error(
             "Provisioning requires every rendered production config"
@@ -934,6 +949,7 @@ export const inspectProductionProvisioning = async ({
             policy,
             artifact,
             artifactManifestDigest: artifact.digest,
+            expectedZoneInventorySha256: expectedZoneFingerprint,
             ...productionWorkerConfig({ site, policy, configs }),
         };
         validateRenderedCloudflareConfig({
@@ -946,9 +962,21 @@ export const inspectProductionProvisioning = async ({
         }
         return plan;
     });
-    const scripts = await readWorkerScriptMap(operations);
+    const scripts = await readWorkerScriptMap(operations, {
+        allowMissingInlineRoutes: true,
+    });
+    const zoneRouteInventory = await readAndValidateZoneRouteInventory({
+        scripts,
+        operations,
+        expectedZoneInventorySha256: expectedZoneFingerprint,
+    });
     const domains = await readWorkerDomainInventory(operations);
-    validateProvisioningAttachmentInventory({ entries, scripts, domains });
+    validateProvisioningAttachmentInventory({
+        entries,
+        scripts,
+        domains,
+        zoneRouteInventory,
+    });
     const activeServiceAttachments = await readActiveServiceAttachmentInventory(
         {
             entries,
@@ -1186,6 +1214,8 @@ export const inspectProductionProvisioning = async ({
         plans,
         previewPlans,
         scripts,
+        expectedZoneInventorySha256: expectedZoneFingerprint,
+        zoneRouteInventory,
         domains,
         activeServiceAttachments,
         queueConsumerInventory,
@@ -1198,6 +1228,7 @@ export const productionProvisioningStateDigest = ({
     inspection,
     expectedCommit,
     accountId,
+    expectedZoneInventorySha256,
 }) => {
     if (!FULL_GIT_COMMIT.test(expectedCommit || "")) {
         throw new Error("Provisioning state digest requires a full Git commit");
@@ -1207,23 +1238,31 @@ export const productionProvisioningStateDigest = ({
             "Provisioning state digest requires an exact Cloudflare account ID"
         );
     }
+    const expectedZoneFingerprint = requireExpectedAccountZoneInventorySha256(
+        expectedZoneInventorySha256
+    );
     const state = {
-        schema: 2,
+        schema: 4,
         expectedCommit: expectedCommit.toLowerCase(),
         accountId: accountId.toLowerCase(),
+        expectedZoneInventorySha256: expectedZoneFingerprint,
         scripts: [...inspection.scripts]
             .map(([workerName, metadata]) => ({
                 workerName,
                 workerTag: nullable(metadata.tag),
-                routes: [...metadata.routes].sort((left, right) =>
-                    left.id.localeCompare(right.id)
-                ),
+                inlineRoutes:
+                    metadata.routes === null
+                        ? null
+                        : [...metadata.routes].sort((left, right) =>
+                              left.id.localeCompare(right.id)
+                          ),
                 tailConsumers: metadata.tailConsumers ?? [],
                 logpush: metadata.logpush ?? false,
             }))
             .sort((left, right) =>
                 left.workerName.localeCompare(right.workerName)
             ),
+        zoneRouteInventory: inspection.zoneRouteInventory,
         domains: [...inspection.domains].sort((left, right) =>
             left.id.localeCompare(right.id)
         ),
@@ -1424,6 +1463,19 @@ const assertSameQueueConsumerInventory = (before, after, phase) => {
     }
 };
 
+const assertSameZoneRouteInventory = (before, after, phase) => {
+    if (
+        after.expectedZoneInventorySha256 !==
+            before.expectedZoneInventorySha256 ||
+        JSON.stringify(after.zoneRouteInventory) !==
+            JSON.stringify(before.zoneRouteInventory)
+    ) {
+        throw new Error(
+            `Cloudflare authoritative account zone or Worker route inventory changed ${phase}`
+        );
+    }
+};
+
 const productionLedgerState = (plan) => ({
     siteId: plan.site.id,
     workerName: plan.workerName,
@@ -1434,6 +1486,7 @@ const productionLedgerState = (plan) => ({
     versionId: plan.versionId,
     versionFingerprint: plan.versionFingerprint,
     artifactManifestDigest: plan.artifactManifestDigest,
+    expectedZoneInventorySha256: plan.expectedZoneInventorySha256,
     active: plan.active,
     domainAttached: plan.domainAttached,
 });
@@ -1480,6 +1533,7 @@ const assertProductionLedger = (
             "versionId",
             "versionFingerprint",
             "artifactManifestDigest",
+            "expectedZoneInventorySha256",
             "active",
             "domainAttached",
         ]) {
@@ -1571,16 +1625,11 @@ const finalVerify = async ({
     expectedCommit,
     operations,
     invocationCandidates,
+    readFencedInspection,
 }) => {
-    const attachmentPlans = entries.map(({ site, policy }) => ({
-        site,
-        policy,
-        ...productionWorkerConfig({ site, policy, configs }),
-    }));
-    const initialScripts = await readAndValidateProductionAttachments({
-        plans: attachmentPlans,
-        operations,
-    });
+    const initialScripts = (
+        await readFencedInspection("at the start of final live verification")
+    ).scripts;
     const identities = new Map();
     const versions = new Map();
     for (const { site, policy } of entries) {
@@ -1659,10 +1708,8 @@ const finalVerify = async ({
         }
     }
 
-    const finalScripts = await readAndValidateProductionAttachments({
-        plans: attachmentPlans,
-        operations,
-    });
+    const finalScripts = (await readFencedInspection("after provisioning"))
+        .scripts;
     for (const { site, policy } of entries) {
         if (
             finalScripts.get(policy.productionWorker)?.tag !==
@@ -1726,6 +1773,7 @@ export const provisionProductionEntries = async ({
     configs,
     artifacts,
     expectedCommit,
+    expectedZoneInventorySha256,
     accountId,
     mode,
     plannedStateDigest,
@@ -1740,6 +1788,9 @@ export const provisionProductionEntries = async ({
             "Provisioning requires the exact Cloudflare account identity"
         );
     }
+    const pinnedZoneInventorySha256 = requireExpectedAccountZoneInventorySha256(
+        expectedZoneInventorySha256
+    );
     const invocationNonce =
         mode === "apply" ? randomBytes(16).toString("hex") : undefined;
     const invocationCandidates = new Map();
@@ -1748,6 +1799,7 @@ export const provisionProductionEntries = async ({
         configs,
         artifacts,
         expectedCommit,
+        expectedZoneInventorySha256: pinnedZoneInventorySha256,
         operations,
         invocationNonce,
         invocationCandidates,
@@ -1757,6 +1809,7 @@ export const provisionProductionEntries = async ({
         inspection: initial,
         expectedCommit,
         accountId,
+        expectedZoneInventorySha256: pinnedZoneInventorySha256,
     });
     if (mode === "apply" && plannedStateDigest == null) {
         throw new Error(
@@ -1806,6 +1859,7 @@ export const provisionProductionEntries = async ({
         });
         assertSamePreviewInventory(initial, inspection, phase);
         assertSameQueueConsumerInventory(initial, inspection, phase);
+        assertSameZoneRouteInventory(initial, inspection, phase);
         if (requirePublicFence) {
             assertAllManagedPublicUrlsDisabled(inspection, phase, {
                 allowProductionWorker,
@@ -2234,6 +2288,7 @@ export const provisionProductionEntries = async ({
         expectedCommit,
         operations,
         invocationCandidates,
+        readFencedInspection,
     });
     const finalInspection = await readFencedInspection(
         "after final live verification"
@@ -2423,6 +2478,7 @@ export const main = async (argv = process.argv.slice(2)) => {
     const runtimeSmokeEnvironment = productionSmokeEnvironment(entries);
     const operations = {
         listWorkerScripts: workersApi.listWorkerScripts,
+        listZoneRouteInventory: workersApi.listZoneRouteInventory,
         listWorkerDomains: workersApi.listWorkerDomains,
         getWorkerSubdomain: workersApi.getWorkerSubdomain,
         listWorkerSchedules: workersApi.listWorkerSchedules,
@@ -2467,6 +2523,8 @@ export const main = async (argv = process.argv.slice(2)) => {
         artifacts,
         expectedCommit,
         accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
+        expectedZoneInventorySha256:
+            process.env.CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256,
         mode,
         ...(mode === "apply" ? { plannedStateDigest } : {}),
         operations,


### PR DESCRIPTION
## Summary

- reconcile production Workers against authoritative per-zone route inventory instead of nullable inline route metadata
- require a protected canonical SHA-256 fingerprint of the complete account zone identity set at every plan, upload, activation, verification, rollback, and provisioning fence
- keep planning read-only and fail closed on permission-filtered subsets, hidden routes, inventory drift, or ambiguous custom-domain ownership

## Verification

- 318/318 Cloudflare tests
- full workspace build
- Wrangler 4.110.0 / esbuild 0.28.1 toolchain validation
- production bootstrap validation
- seven exact Wrangler version-upload dry runs
- independent reviewer approval

The protected cloudflare-production inventory fingerprint was derived from two identical exhaustive API snapshots and independently cross-checked against all six dashboard rows before this PR was opened.