### PR TITLE
fix(cloudflare): accept complete domain inventory shape

### DIFF
--- a/.github/workflows/cloudflare-production-provision.yml
+++ b/.github/workflows/cloudflare-production-provision.yml
@@ -259,8 +259,8 @@ jobs:
               # never derive it with this possibly permission-filtered token.
               env:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PRODUCTION_API_TOKEN }}
-                  CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-                  CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256: ${{ vars.CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256: ${{ secrets.CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 }}
                   PROVISION_MODE: ${{ inputs.mode }}
                   PROVISION_CONFIRM: ${{ inputs.confirm }}
                   PROVISION_PLANNED_COMMIT: ${{ inputs.planned_commit }}

--- a/.github/workflows/cloudflare-production.yml
+++ b/.github/workflows/cloudflare-production.yml
@@ -135,8 +135,8 @@ jobs:
               # never derive it with this possibly permission-filtered token.
               env:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PRODUCTION_API_TOKEN }}
-                  CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-                  CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256: ${{ vars.CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256: ${{ secrets.CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 }}
                   DEPLOY_TARGET: ${{ inputs.target }}
                   DEPLOY_COMMIT: ${{ github.sha }}
                   PW_CLOUDFLARE_SMOKE: "1"

--- a/README.md
+++ b/README.md
@@ -12,32 +12,37 @@
 ## Examples
 
 ### [Chat room](./packages/one-chat-room/)
+
 [<img src="./packages/one-chat-room/demo.gif" width="600" />](./packages/one-chat-room/)
 
-
 ### [Lobby + chat rooms](./packages/many-chat-rooms/)
+
 [<img src="./packages/many-chat-rooms/demo.gif" width="600" />](./packages/many-chat-rooms/)
 
 ### [Blog platform](./packages/blog-platform/)
+
 [<img src="./packages/blog-platform/demo-cli.gif" width="600" />](./packages/blog-platform/)
 
-
 ### [Collaborative text document](./packages/text-document/)
+
 [<img src="./packages/text-document/demo.gif" width="600" />](./packages/text-document/)
 
-
 ### [Sync files](./packages/file-share/)
+
 #### [React app](./packages/file-share/)
+
 [<img src="./packages/file-share/demo-frontend.gif" width="600" />](./packages/file-share/)
+
 #### [CLI](./packages/file-share/)
+
 [<img src="./packages/file-share/demo-cli.gif" width="600" />](./packages/file-share/)
 
-
 ### [Video streaming](./packages/media-streaming/video-streaming)
+
 [<img src="./packages/media-streaming/video-streaming/demo.gif" width="600" />](./packages/media-streaming/video-streaming/)
 
-
 ### [Collaborative machine learning](./packages/collaborative-learning/)
+
 [<img src="./packages/collaborative-learning/demo.gif" width="600" />](./packages/collaborative-learning/)
 
 ## Requirements
@@ -47,13 +52,13 @@
 ## How to run the examples
 
 1.
+
 ```sh
 yarn
 yarn build
 ```
 
-2.
-Go into an example. If it is a frontend app, you can run it locally (if you have a node running (see below)) with
+2.  Go into an example. If it is a frontend app, you can run it locally (if you have a node running (see below)) with
 
 ```sh
 yarn start
@@ -66,17 +71,19 @@ yarn start-remote
 ```
 
 ## How to setup a local relay node
+
 (This is just a basic libp2p-js node)
 
-1.
-Install Node >= 16
+1.  Install Node >= 16
 
-2.
-Install CLI
+2.  Install CLI
+
 ```sh
 npm install -g @peerbit/server
 ```
+
 3.
+
 ```sh
 peerbit start
 ```
@@ -127,9 +134,12 @@ Production configs are rendered with `--mode production`. First-party demo
 Workers are restricted to `*.apps.peerbit.org` and must exactly match the
 deployment policy. Before any upload or promotion, production reads the
 account's complete zone inventory and each zone's authoritative Worker routes,
-plus every page of its custom-domain inventory. The protected token therefore
-needs `Workers Scripts Read`, `Zone Read`, and `Workers Routes Read` across every
-zone in the account. Zone enumeration explicitly includes `full`, `partial`,
+plus its account-wide custom-domain collection. Cloudflare defines that domain
+endpoint as a single complete collection, so production requests its bare URL,
+validates any optional completeness metadata, and accepts it only after two
+identical canonical reads. The protected token therefore needs `Workers Scripts
+Read`, `Zone Read`, and `Workers Routes Read` across every zone in the account.
+Zone enumeration explicitly includes `full`, `partial`,
 `secondary`, and `internal` zones and accepts the route inventory only after two
 independently read, canonical complete snapshots match. Cloudflare's optional
 inline script-route field is used only as a consistency check when present;
@@ -137,7 +147,8 @@ missing inline routes defer to the authoritative per-zone result. Custom-domain
 zone IDs and names must exist in that same account snapshot. The account-wide
 zone list is permission-filtered, so a successful paginated response is not by
 itself proof that the token can see every zone. The protected environment must
-also define `CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256`, derived independently
+store the account ID and `CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256` as masked
+environment secrets. The fingerprint is derived independently
 from a full dashboard/admin inventory. Its input is the UTF-8 JSON encoding of
 every expected `{zoneId,zoneName}` object, with exactly those keys, lowercase
 values, no extra whitespace or newline, sorted first by `zoneId` and then by

--- a/cloudflare/deployment-safety.test.mjs
+++ b/cloudflare/deployment-safety.test.mjs
@@ -871,7 +871,7 @@ test("Worker subdomain API diagnostics preserve non-workers.dev boundaries", asy
     }
 });
 
-test("Cloudflare Workers API exhausts read-only custom-domain pagination", async () => {
+test("Cloudflare Workers API reads the complete custom-domain collection without unsupported pagination", async () => {
     const accountId = "c".repeat(32);
     const apiToken = "test-token_123";
     const requests = [];
@@ -898,17 +898,15 @@ test("Cloudflare Workers API exhausts read-only custom-domain pagination", async
         apiToken,
         request: async (url, init) => {
             requests.push({ url, init });
-            const page = Number(new URL(url).searchParams.get("page"));
             return new Response(
                 JSON.stringify({
                     success: true,
-                    result: [rawDomains[page - 1]],
+                    result: rawDomains,
                     result_info: {
-                        count: 1,
-                        page,
-                        per_page: 1,
+                        count: 2,
+                        page: 1,
+                        per_page: 50,
                         total_count: 2,
-                        total_pages: 2,
                     },
                 }),
                 { status: 200 }
@@ -924,19 +922,11 @@ test("Cloudflare Workers API exhausts read-only custom-domain pagination", async
         requests.map(({ url, init }) => [url, init.method]),
         [
             [
-                `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/domains?page=1&per_page=100`,
+                `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/domains`,
                 "GET",
             ],
             [
-                `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/domains?page=2&per_page=100`,
-                "GET",
-            ],
-            [
-                `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/domains?page=1&per_page=100`,
-                "GET",
-            ],
-            [
-                `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/domains?page=2&per_page=100`,
+                `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/domains`,
                 "GET",
             ],
         ]
@@ -947,46 +937,81 @@ test("Cloudflare Workers API exhausts read-only custom-domain pagination", async
     }
 });
 
-test("custom-domain pagination discards a constant-total hybrid snapshot", async () => {
+test("custom-domain inventory accepts omitted and consistent optional completeness metadata", async () => {
+    const rawDomain = rawWorkerDomain("alpha");
+    const fixtures = [
+        { result: [] },
+        { result: [], result_info: { total_pages: 0 } },
+        { result: [], result_info: { total_pages: 1 } },
+        { result: [rawDomain], result_info: {} },
+        { result: [rawDomain], result_info: { count: 1 } },
+        {
+            result: [rawDomain],
+            result_info: {
+                count: 1,
+                page: 1,
+                per_page: 50,
+                total_count: 1,
+            },
+        },
+        {
+            result: [rawDomain],
+            result_info: {
+                count: 1,
+                page: 1,
+                per_page: 50,
+                total_count: 1,
+                total_pages: 1,
+            },
+        },
+    ];
+
+    for (const fixture of fixtures) {
+        let requests = 0;
+        const api = createCloudflareWorkersApi({
+            accountId: "c".repeat(32),
+            apiToken: "test-token_123",
+            request: async () => {
+                requests += 1;
+                return new Response(
+                    JSON.stringify({ success: true, ...fixture }),
+                    { status: 200 }
+                );
+            },
+        });
+        assert.deepEqual(
+            (await api.listWorkerDomains()).map(({ id }) => id),
+            fixture.result.map(({ id }) => id)
+        );
+        assert.equal(requests, 2);
+    }
+});
+
+test("custom-domain inventory discards a changing first snapshot", async () => {
     const accountId = "c".repeat(32);
     const apiToken = "test-token_123";
     const alpha = rawWorkerDomain("alpha");
     const bravo = rawWorkerDomain("bravo");
     const charlie = rawWorkerDomain("charlie");
-    const delta = rawWorkerDomain("delta");
-    const echo = rawWorkerDomain("echo");
     const snapshots = [
-        [
-            [alpha, bravo],
-            [delta, echo],
-        ],
-        [
-            [bravo, charlie],
-            [delta, echo],
-        ],
-        [
-            [bravo, charlie],
-            [delta, echo],
-        ],
+        [alpha, bravo],
+        [bravo, charlie],
+        [bravo, charlie],
     ];
     let requests = 0;
     const api = createCloudflareWorkersApi({
         accountId,
         apiToken,
-        request: async (url) => {
-            const page = Number(new URL(url).searchParams.get("page"));
-            const snapshot = snapshots[Math.floor(requests / 2)];
+        request: async () => {
+            const snapshot = snapshots[requests];
             requests += 1;
             return new Response(
                 JSON.stringify({
                     success: true,
-                    result: snapshot[page - 1],
+                    result: snapshot,
                     result_info: {
                         count: 2,
-                        page,
-                        per_page: 2,
-                        total_count: 4,
-                        total_pages: 2,
+                        total_count: 2,
                     },
                 }),
                 { status: 200 }
@@ -996,47 +1021,35 @@ test("custom-domain pagination discards a constant-total hybrid snapshot", async
 
     assert.deepEqual(
         (await api.listWorkerDomains()).map(({ id }) => id),
-        ["domain-bravo", "domain-charlie", "domain-delta", "domain-echo"]
+        ["domain-bravo", "domain-charlie"]
     );
-    assert.equal(requests, 6);
+    assert.equal(requests, 3);
 });
 
-test("custom-domain pagination fails closed when complete snapshots keep churning", async () => {
+test("custom-domain inventory fails closed when complete snapshots keep churning", async () => {
     const accountId = "c".repeat(32);
     const apiToken = "test-token_123";
     const alpha = rawWorkerDomain("alpha");
     const bravo = rawWorkerDomain("bravo");
     const charlie = rawWorkerDomain("charlie");
-    const delta = rawWorkerDomain("delta");
-    const echo = rawWorkerDomain("echo");
     const snapshots = [
-        [
-            [alpha, bravo],
-            [delta, echo],
-        ],
-        [
-            [bravo, charlie],
-            [delta, echo],
-        ],
+        [alpha, bravo],
+        [bravo, charlie],
     ];
     let requests = 0;
     const api = createCloudflareWorkersApi({
         accountId,
         apiToken,
-        request: async (url) => {
-            const page = Number(new URL(url).searchParams.get("page"));
-            const snapshot = snapshots[Math.floor(requests / 2) % 2];
+        request: async () => {
+            const snapshot = snapshots[requests % 2];
             requests += 1;
             return new Response(
                 JSON.stringify({
                     success: true,
-                    result: snapshot[page - 1],
+                    result: snapshot,
                     result_info: {
                         count: 2,
-                        page,
-                        per_page: 2,
-                        total_count: 4,
-                        total_pages: 2,
+                        total_count: 2,
                     },
                 }),
                 { status: 200 }
@@ -1048,12 +1061,59 @@ test("custom-domain pagination fails closed when complete snapshots keep churnin
         api.listWorkerDomains(),
         /did not remain stable across complete snapshots/
     );
-    assert.equal(requests, 6);
+    assert.equal(requests, 3);
 });
 
-test("custom-domain pagination and API ambiguity fail closed", async () => {
+test("custom-domain API and completeness ambiguity fail closed", async () => {
     const accountId = "c".repeat(32);
     const apiToken = "test-token_123";
+    const rawDomain = rawWorkerDomain("alpha");
+    const payloads = [
+        { success: true, result: {} },
+        { success: true, result: [rawDomain], result_info: null },
+        {
+            success: true,
+            result: [rawDomain],
+            result_info: { cursor: "unexpected-continuation" },
+        },
+        {
+            success: true,
+            result: [rawDomain],
+            result_info: { count: 2 },
+        },
+        {
+            success: true,
+            result: [rawDomain],
+            result_info: { page: 2 },
+        },
+        {
+            success: true,
+            result: [rawDomain, rawWorkerDomain("bravo")],
+            result_info: { per_page: 1 },
+        },
+        {
+            success: true,
+            result: [rawDomain],
+            result_info: { total_count: 2 },
+        },
+        {
+            success: true,
+            result: [rawDomain],
+            result_info: { total_pages: 2 },
+        },
+        {
+            success: true,
+            result: [rawDomain, rawDomain],
+        },
+        {
+            success: true,
+            result: [
+                rawWorkerDomain("retired", {
+                    hostname: "retired.apps.peerbit.org.",
+                }),
+            ],
+        },
+    ];
     const responses = [
         () =>
             new Response(
@@ -1063,55 +1123,10 @@ test("custom-domain pagination and API ambiguity fail closed", async () => {
                 }),
                 { status: 403 }
             ),
-        () =>
-            new Response(JSON.stringify({ success: true, result: [] }), {
-                status: 200,
-            }),
-        (url) => {
-            const page = Number(new URL(url).searchParams.get("page"));
-            return new Response(
-                JSON.stringify({
-                    success: true,
-                    result: [
-                        {
-                            id: "domain-" + page,
-                            hostname: "duplicate.apps.peerbit.org",
-                            service: "peerbit-examples-files",
-                            environment: "production",
-                            zone_id: ZONE_ID,
-                            zone_name: "peerbit.org",
-                        },
-                    ],
-                    result_info: {
-                        count: 1,
-                        page,
-                        per_page: 1,
-                        total_count: 2,
-                        total_pages: 2,
-                    },
-                }),
-                { status: 200 }
-            );
-        },
-        () =>
-            new Response(
-                JSON.stringify({
-                    success: true,
-                    result: [
-                        rawWorkerDomain("retired", {
-                            hostname: "retired.apps.peerbit.org.",
-                        }),
-                    ],
-                    result_info: {
-                        count: 1,
-                        page: 1,
-                        per_page: 100,
-                        total_count: 1,
-                        total_pages: 1,
-                    },
-                }),
-                { status: 200 }
-            ),
+        ...payloads.map(
+            (payload) => () =>
+                new Response(JSON.stringify(payload), { status: 200 })
+        ),
     ];
 
     for (const request of responses) {
@@ -1140,13 +1155,14 @@ test("attachment inventory source contract uses account-scoped domains and autho
     );
     const domainsStart = source.indexOf("listWorkerDomains: async");
     const domainsEnd = source.indexOf(
-        "getCurrentDeployment: async",
+        "getWorkerSubdomain: async",
         domainsStart
     );
     const domainInventory = source.slice(domainsStart, domainsEnd);
     assert.ok(domainsStart >= 0 && domainsEnd > domainsStart);
-    assert.match(domainInventory, /domainsUrl/);
+    assert.match(domainInventory, /url:\s*domainsUrl/);
     assert.doesNotMatch(domainInventory, /method\s*:|body\s*:/);
+    assert.doesNotMatch(domainInventory, /url:\s*`\$\{domainsUrl\}\?/);
     const subdomainStart = source.indexOf("getWorkerSubdomain: async");
     const subdomainEnd = source.indexOf(
         "getCurrentDeployment: async",

--- a/cloudflare/production-provisioning.md
+++ b/cloudflare/production-provisioning.md
@@ -44,9 +44,11 @@ These are the relevant official references:
    Read** for **every zone in the account**, not merely `peerbit.org`: the
    safety fence enumerates the complete account and reads each zone's
    authoritative traditional-Worker routes. Its existing
-   `CLOUDFLARE_ACCOUNT_ID` variable must identify the reviewed account.
-   The protected environment must also define the exact lowercase 64-hex
-   `CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256` variable. Establish it from an
+   `CLOUDFLARE_ACCOUNT_ID` secret must identify the reviewed account. The
+   protected environment must also define the exact lowercase 64-hex
+   `CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256` secret. Keeping both as
+   environment secrets prevents the Actions runner from printing their raw
+   values in its initial environment header. Establish the fingerprint from an
    independently verified full dashboard/admin zone inventory, never from the
    deployment token's permission-filtered `/zones` response. Canonical input is
    UTF-8 JSON with no trailing newline: an array of exactly
@@ -54,7 +56,7 @@ These are the relevant official references:
    sorted first by `zoneId` and then by `zoneName` using ascending code-point
    order. Hash that byte sequence with SHA-256. If the full inventory has not
    yet been independently established, leave production workflows blocked
-   until this variable is reviewed and set.
+   until this secret is reviewed and set.
 3. Confirm that the `peerbit.org` zone is active in that account. Cloudflare
    cannot attach a Custom Domain over a conflicting CNAME, so resolve any such
    conflict manually before applying.

--- a/cloudflare/workflow-safety.test.mjs
+++ b/cloudflare/workflow-safety.test.mjs
@@ -46,7 +46,15 @@ test("credentialed production shell receives target and commit through env", () 
     assert.match(productionWorkflow, /DEPLOY_COMMIT: \$\{\{ github\.sha \}\}/);
     assert.match(
         productionWorkflow,
-        /CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256: \$\{\{ vars\.CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 \}\}/
+        /CLOUDFLARE_ACCOUNT_ID: \$\{\{ secrets\.CLOUDFLARE_ACCOUNT_ID \}\}/
+    );
+    assert.match(
+        productionWorkflow,
+        /CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256: \$\{\{ secrets\.CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 \}\}/
+    );
+    assert.doesNotMatch(
+        productionWorkflow,
+        /vars\.(?:CLOUDFLARE_ACCOUNT_ID|CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256)/
     );
     assert.match(productionWorkflow, /--target "\$DEPLOY_TARGET"/);
     assert.match(productionWorkflow, /--commit "\$DEPLOY_COMMIT"/);
@@ -186,11 +194,15 @@ test("one-time provisioning is protected, explicit, and serialized with routine 
     );
     assert.match(
         provisioningWorkflow,
-        /CLOUDFLARE_ACCOUNT_ID: \$\{\{ vars\.CLOUDFLARE_ACCOUNT_ID \}\}/
+        /CLOUDFLARE_ACCOUNT_ID: \$\{\{ secrets\.CLOUDFLARE_ACCOUNT_ID \}\}/
     );
     assert.match(
         provisioningWorkflow,
-        /CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256: \$\{\{ vars\.CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 \}\}/
+        /CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256: \$\{\{ secrets\.CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256 \}\}/
+    );
+    assert.doesNotMatch(
+        provisioningWorkflow,
+        /vars\.(?:CLOUDFLARE_ACCOUNT_ID|CLOUDFLARE_ACCOUNT_ZONE_INVENTORY_SHA256)/
     );
     assert.match(provisioningWorkflow, /--mode "\$PROVISION_MODE"/);
     assert.match(provisioningWorkflow, /--commit "\$PROVISION_COMMIT"/);

--- a/scripts/cloudflare-workers-api.mjs
+++ b/scripts/cloudflare-workers-api.mjs
@@ -7,8 +7,6 @@ const DNS_HOSTNAME =
 const VERSION_ID =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const CLOUDFLARE_API_BASE_URL = "https://api.cloudflare.com/client/v4";
-const CUSTOM_DOMAIN_PAGE_SIZE = 100;
-const MAX_CUSTOM_DOMAIN_PAGES = 1_000;
 const MAX_CUSTOM_DOMAIN_SNAPSHOT_ATTEMPTS = 3;
 const ZONE_PAGE_SIZE = 50;
 const MAX_ZONE_PAGES = 1_000;
@@ -594,112 +592,103 @@ export const createCloudflareWorkersApi = ({
                 const domains = [];
                 const domainIds = new Set();
                 const hostnames = new Set();
-                let expectedTotalCount;
-                let expectedTotalPages;
-                let expectedPerPage;
-
-                for (let page = 1; page <= MAX_CUSTOM_DOMAIN_PAGES; page += 1) {
-                    const payload = await call({
+                const payload = await call({
+                    operation,
+                    url: domainsUrl,
+                });
+                const result = payload.result;
+                const info = payload.result_info;
+                if (!Array.isArray(result)) {
+                    invalidResult({
                         operation,
-                        url: `${domainsUrl}?page=${page}&per_page=${CUSTOM_DOMAIN_PAGE_SIZE}`,
+                        message:
+                            "Cloudflare returned an invalid custom-domain inventory",
                     });
-                    const result = payload.result;
-                    const info = payload.result_info;
-                    const validInfo =
-                        Array.isArray(result) &&
-                        info &&
-                        typeof info === "object" &&
-                        Number.isSafeInteger(info.count) &&
-                        info.count >= 0 &&
-                        info.count === result.length &&
-                        Number.isSafeInteger(info.page) &&
-                        info.page === page &&
-                        Number.isSafeInteger(info.per_page) &&
-                        info.per_page > 0 &&
-                        info.count <= info.per_page &&
-                        Number.isSafeInteger(info.total_count) &&
-                        info.total_count >= 0 &&
-                        Number.isSafeInteger(info.total_pages) &&
-                        info.total_pages >= 0 &&
-                        info.total_pages <= MAX_CUSTOM_DOMAIN_PAGES &&
-                        (info.total_count === 0
-                            ? info.total_pages === 0 || info.total_pages === 1
-                            : info.total_pages ===
-                              Math.ceil(info.total_count / info.per_page)) &&
-                        page <= Math.max(info.total_pages, 1);
-                    if (!validInfo) {
-                        invalidResult({
-                            operation,
-                            message:
-                                "Cloudflare returned invalid or ambiguous custom-domain pagination",
-                        });
-                    }
+                }
 
-                    expectedTotalCount ??= info.total_count;
-                    expectedTotalPages ??= info.total_pages;
-                    expectedPerPage ??= info.per_page;
+                if (info !== undefined) {
+                    const allowedInfoKeys = new Set([
+                        "count",
+                        "page",
+                        "per_page",
+                        "total_count",
+                        "total_pages",
+                    ]);
+                    const validInfoObject =
+                        info !== null &&
+                        typeof info === "object" &&
+                        !Array.isArray(info) &&
+                        Object.keys(info).every((key) =>
+                            allowedInfoKeys.has(key)
+                        );
+                    const validOptionalInteger = (key, predicate) =>
+                        !(key in info) ||
+                        (Number.isSafeInteger(info[key]) &&
+                            predicate(info[key]));
                     if (
-                        info.total_count !== expectedTotalCount ||
-                        info.total_pages !== expectedTotalPages ||
-                        info.per_page !== expectedPerPage
+                        !validInfoObject ||
+                        !validOptionalInteger(
+                            "count",
+                            (value) => value === result.length
+                        ) ||
+                        !validOptionalInteger("page", (value) => value === 1) ||
+                        !validOptionalInteger(
+                            "per_page",
+                            (value) => value > 0 && value >= result.length
+                        ) ||
+                        !validOptionalInteger(
+                            "total_count",
+                            (value) => value === result.length
+                        ) ||
+                        !validOptionalInteger("total_pages", (value) =>
+                            result.length === 0
+                                ? value === 0 || value === 1
+                                : value === 1
+                        )
                     ) {
                         invalidResult({
                             operation,
                             message:
-                                "Cloudflare custom-domain pagination changed while it was being read",
+                                "Cloudflare returned invalid or ambiguous custom-domain completeness metadata",
                         });
                     }
-
-                    for (const domain of result) {
-                        const hostname =
-                            typeof domain?.hostname === "string"
-                                ? domain.hostname.toLowerCase()
-                                : undefined;
-                        if (
-                            typeof domain?.id !== "string" ||
-                            domain.id.length === 0 ||
-                            domainIds.has(domain.id) ||
-                            !hostname ||
-                            !DNS_HOSTNAME.test(hostname) ||
-                            domain.hostname.trim() !== domain.hostname ||
-                            hostnames.has(hostname) ||
-                            !WORKER_NAME.test(domain.service || "") ||
-                            typeof domain.environment !== "string" ||
-                            domain.environment.length === 0 ||
-                            !CLOUDFLARE_ACCOUNT_ID.test(domain.zone_id || "") ||
-                            typeof domain.zone_name !== "string" ||
-                            domain.zone_name.length === 0
-                        ) {
-                            invalidResult({
-                                operation,
-                                message:
-                                    "Cloudflare returned an invalid or ambiguous custom-domain attachment",
-                            });
-                        }
-                        domainIds.add(domain.id);
-                        hostnames.add(hostname);
-                        domains.push({
-                            id: domain.id,
-                            hostname,
-                            service: domain.service,
-                            environment: domain.environment,
-                            zoneId: domain.zone_id,
-                            zoneName: domain.zone_name.toLowerCase(),
-                        });
-                    }
-
-                    if (page >= info.total_pages) break;
                 }
 
-                if (
-                    expectedTotalCount == null ||
-                    expectedTotalPages == null ||
-                    domains.length !== expectedTotalCount
-                ) {
-                    invalidResult({
-                        operation,
-                        message:
-                            "Cloudflare returned an incomplete custom-domain inventory",
+                for (const domain of result) {
+                    const hostname =
+                        typeof domain?.hostname === "string"
+                            ? domain.hostname.toLowerCase()
+                            : undefined;
+                    if (
+                        typeof domain?.id !== "string" ||
+                        domain.id.length === 0 ||
+                        domainIds.has(domain.id) ||
+                        !hostname ||
+                        !DNS_HOSTNAME.test(hostname) ||
+                        domain.hostname.trim() !== domain.hostname ||
+                        hostnames.has(hostname) ||
+                        !WORKER_NAME.test(domain.service || "") ||
+                        typeof domain.environment !== "string" ||
+                        domain.environment.length === 0 ||
+                        !CLOUDFLARE_ACCOUNT_ID.test(domain.zone_id || "") ||
+                        typeof domain.zone_name !== "string" ||
+                        domain.zone_name.length === 0
+                    ) {
+                        invalidResult({
+                            operation,
+                            message:
+                                "Cloudflare returned an invalid or ambiguous custom-domain attachment",
+                        });
+                    }
+                    domainIds.add(domain.id);
+                    hostnames.add(hostname);
+                    domains.push({
+                        id: domain.id,
+                        hostname,
+                        service: domain.service,
+                        environment: domain.environment,
+                        zoneId: domain.zone_id,
+                        zoneName: domain.zone_name.toLowerCase(),
                     });
                 }
                 return domains.sort((left, right) =>


### PR DESCRIPTION
## Summary
- follow Cloudflare's single-page Worker custom-domain list contract while validating any optional completeness metadata fail-closed
- retain repeated canonical inventory snapshots and reject continuation, truncation, duplicate, or inconsistent evidence
- move the account identity and authoritative zone fingerprint to masked protected-environment secrets

## Validation
- `node --test cloudflare/*.test.mjs` (319/319)
- `pnpm run build`
- 7 preview Wrangler `versions upload --dry-run` bundles
- 7 production Wrangler `versions upload --dry-run` bundles
- independent P1/P2 review: clean