### PR TITLE
chore(ci): pin Node 24 actions by commit

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -20,17 +20,17 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                   fetch-depth: 0
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -19,17 +19,17 @@ jobs:
         timeout-minutes: 30
         steps:
             - name: Checkout
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                   persist-credentials: false
 
             - name: Setup Node
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.x
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 

--- a/.github/workflows/cloudflare-production-provision.yml
+++ b/.github/workflows/cloudflare-production-provision.yml
@@ -87,18 +87,18 @@ jobs:
                   fi
 
             - name: Checkout
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                   ref: ${{ github.sha }}
                   persist-credentials: false
 
             - name: Setup Node
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.x
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
@@ -205,18 +205,18 @@ jobs:
                   fi
 
             - name: Checkout
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                   ref: ${{ github.sha }}
                   persist-credentials: false
 
             - name: Setup Node
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.x
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 

--- a/.github/workflows/cloudflare-production.yml
+++ b/.github/workflows/cloudflare-production.yml
@@ -36,17 +36,17 @@ jobs:
         timeout-minutes: 30
         steps:
             - name: Checkout
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                   persist-credentials: false
 
             - name: Setup Node
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.x
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
@@ -92,17 +92,17 @@ jobs:
         environment: cloudflare-production
         steps:
             - name: Checkout
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                   persist-credentials: false
 
             - name: Setup Node
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22.x
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 

--- a/.github/workflows/file-share-benchmarks.yml
+++ b/.github/workflows/file-share-benchmarks.yml
@@ -57,15 +57,15 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm
@@ -222,7 +222,7 @@ jobs:
 
             - name: Upload artifacts
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: file-share-benchmark-${{ github.run_id }}
                   path: bench-results

--- a/.github/workflows/file-share-ci.yml
+++ b/.github/workflows/file-share-ci.yml
@@ -38,15 +38,15 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm
@@ -94,7 +94,7 @@ jobs:
 
             - name: Upload offline-reopen failure artifacts
               if: failure()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: file-share-offline-reopen-${{ github.run_id }}
                   path: ${{ runner.temp }}/file-share-offline-reopen

--- a/.github/workflows/file-share-two-runner-artifact-benchmarks.yml
+++ b/.github/workflows/file-share-two-runner-artifact-benchmarks.yml
@@ -49,15 +49,15 @@ jobs:
             cancel-in-progress: false
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm
@@ -86,7 +86,7 @@ jobs:
 
             - name: Upload writer artifacts
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: file-share-two-runner-writer-${{ github.run_id }}
                   path: bench-results
@@ -100,15 +100,15 @@ jobs:
             cancel-in-progress: false
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm
@@ -138,7 +138,7 @@ jobs:
 
             - name: Upload reader artifacts
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: file-share-two-runner-reader-${{ github.run_id }}
                   path: bench-results
@@ -152,13 +152,13 @@ jobs:
         if: always()
         steps:
             - name: Download writer artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: file-share-two-runner-writer-${{ github.run_id }}
                   path: writer-results
 
             - name: Download reader artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: file-share-two-runner-reader-${{ github.run_id }}
                   path: reader-results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,17 +27,17 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                   fetch-depth: 0
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm
@@ -48,7 +48,7 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Create release PR or publish packages
-              uses: changesets/action@v1
+              uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
               with:
                   version: pnpm version-packages
                   publish: pnpm release:packages

--- a/.github/workflows/shared-fs-ci.yml
+++ b/.github/workflows/shared-fs-ci.yml
@@ -43,15 +43,15 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm
@@ -80,15 +80,15 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm
@@ -114,10 +114,10 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup Go
-              uses: actions/setup-go@v6
+              uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
               with:
                   go-version: "1.24.x"
                   cache-dependency-path: packages/shared-fs/native/go.sum

--- a/.github/workflows/shared-fs-cross-os-interop.yml
+++ b/.github/workflows/shared-fs-cross-os-interop.yml
@@ -84,15 +84,15 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm
@@ -142,7 +142,7 @@ jobs:
                   exit 1
 
             - name: Upload shared filesystem address
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: shared-fs-address
                   path: shared-fs-address/address.txt
@@ -170,15 +170,15 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm

--- a/.github/workflows/shared-fs-native-adapter-release.yml
+++ b/.github/workflows/shared-fs-native-adapter-release.yml
@@ -32,7 +32,7 @@ jobs:
             publish_release: ${{ steps.release.outputs.publish_release }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Resolve tag
               id: release
@@ -96,10 +96,10 @@ jobs:
         runs-on: ${{ matrix.runs-on }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup Go
-              uses: actions/setup-go@v6
+              uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
               with:
                   go-version: "1.24.x"
                   cache-dependency-path: packages/shared-fs/native/go.sum
@@ -159,7 +159,7 @@ jobs:
                   Compress-Archive -Path "$env:RUNNER_TEMP\asset\peerbit-shared-fs-native.exe" -DestinationPath "$env:RUNNER_TEMP\$env:ASSET_NAME" -Force
 
             - name: Upload asset artifact
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: peerbit-shared-fs-native-${{ matrix.target }}
                   path: ${{ runner.temp }}/peerbit-shared-fs-native-${{ matrix.target }}.*
@@ -174,10 +174,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Download assets
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   path: dist/native-adapter
                   merge-multiple: true

--- a/.github/workflows/shared-fs-native-cross-os-interop.yml
+++ b/.github/workflows/shared-fs-native-cross-os-interop.yml
@@ -94,7 +94,7 @@ jobs:
             runs_on: ${{ steps.labels.outputs.runs_on }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Compute runner labels
               id: labels
@@ -150,7 +150,7 @@ jobs:
 
             - name: Preserve runner state
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: scaleway-macos-native-interop-state-${{ github.run_id }}-${{ github.run_attempt }}
                   path: tmp/processes/github-scaleway-runner.json
@@ -163,7 +163,7 @@ jobs:
 
             - name: Upload provisioning timing
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: shared-fs-native-macos-provision-timing-${{ github.run_id }}-${{ github.run_attempt }}
                   path: native-interop-metrics/provision-macos.json
@@ -180,7 +180,7 @@ jobs:
             runs_on: ${{ steps.labels.outputs.runs_on }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Compute runner labels
               id: labels
@@ -239,7 +239,7 @@ jobs:
 
             - name: Preserve runner state
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: scaleway-windows-native-interop-state-${{ github.run_id }}-${{ github.run_attempt }}
                   path: tmp/processes/github-scaleway-windows-runner.json
@@ -252,7 +252,7 @@ jobs:
 
             - name: Upload provisioning timing
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: shared-fs-native-provision-timing-${{ github.run_id }}-${{ github.run_attempt }}
                   path: native-interop-metrics/provision-windows.json
@@ -266,22 +266,22 @@ jobs:
         timeout-minutes: 60
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm
                   cache-dependency-path: pnpm-lock.yaml
 
             - name: Setup Go
-              uses: actions/setup-go@v6
+              uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
               with:
                   go-version: "1.24.x"
                   cache-dependency-path: packages/shared-fs/native/go.sum
@@ -366,7 +366,7 @@ jobs:
                   exit 1
 
             - name: Upload shared filesystem address
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: shared-fs-native-address
                   path: shared-fs-native-address/address.txt
@@ -388,7 +388,7 @@ jobs:
 
             - name: Upload Linux timing
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: shared-fs-native-linux-timing-${{ github.run_id }}-${{ github.run_attempt }}
                   path: native-interop-metrics/*.json
@@ -405,22 +405,22 @@ jobs:
         timeout-minutes: 60
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm
                   cache-dependency-path: pnpm-lock.yaml
 
             - name: Setup Go
-              uses: actions/setup-go@v6
+              uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
               with:
                   go-version: "1.24.x"
                   cache: false
@@ -470,7 +470,7 @@ jobs:
                   node scripts/wait-github-artifact.mjs shared-fs-native-address
 
             - name: Download seed address
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: shared-fs-native-address
                   path: shared-fs-native-address
@@ -500,7 +500,7 @@ jobs:
 
             - name: Upload macOS timing
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: shared-fs-native-macos-timing-${{ github.run_id }}-${{ github.run_attempt }}
                   path: native-interop-metrics/*.json
@@ -517,21 +517,21 @@ jobs:
         timeout-minutes: 60
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   package-manager-cache: false
 
             - name: Setup Go
-              uses: actions/setup-go@v6
+              uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
               with:
                   go-version: "1.24.x"
                   cache: false
@@ -639,7 +639,7 @@ jobs:
                   node scripts/wait-github-artifact.mjs shared-fs-native-address
 
             - name: Download seed address
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: shared-fs-native-address
                   path: shared-fs-native-address
@@ -669,7 +669,7 @@ jobs:
 
             - name: Upload Windows timing
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: shared-fs-native-windows-timing-${{ github.run_id }}-${{ github.run_attempt }}
                   path: native-interop-metrics/*.json
@@ -686,10 +686,10 @@ jobs:
         timeout-minutes: 20
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Restore runner state
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               continue-on-error: true
               with:
                   name: scaleway-macos-native-interop-state-${{ github.run_id }}-${{ github.run_attempt }}
@@ -731,7 +731,7 @@ jobs:
 
             - name: Upload cleanup timing
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: shared-fs-native-macos-cleanup-timing-${{ github.run_id }}-${{ github.run_attempt }}
                   path: native-interop-metrics/cleanup-macos.json
@@ -748,10 +748,10 @@ jobs:
         timeout-minutes: 20
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Restore runner state
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               continue-on-error: true
               with:
                   name: scaleway-windows-native-interop-state-${{ github.run_id }}-${{ github.run_attempt }}
@@ -793,7 +793,7 @@ jobs:
 
             - name: Upload cleanup timing
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: shared-fs-native-cleanup-timing-${{ github.run_id }}-${{ github.run_attempt }}
                   path: native-interop-metrics/cleanup-windows.json
@@ -810,7 +810,7 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Check native runner resource limits
               shell: bash
@@ -826,7 +826,7 @@ jobs:
 
             - name: Download native timing artifacts
               if: always()
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               continue-on-error: true
               with:
                   pattern: shared-fs-native-*timing-${{ github.run_id }}-${{ github.run_attempt }}
@@ -843,7 +843,7 @@ jobs:
 
             - name: Upload aggregate native timing
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: shared-fs-native-aggregate-timing-${{ github.run_id }}-${{ github.run_attempt }}
                   path: native-interop-timing/summary.md

--- a/.github/workflows/shared-fs-native-os-smoke.yml
+++ b/.github/workflows/shared-fs-native-os-smoke.yml
@@ -43,7 +43,7 @@ jobs:
         timeout-minutes: 20
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Run janitors
               shell: bash
@@ -75,7 +75,7 @@ jobs:
             runs_on: ${{ steps.labels.outputs.runs_on }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Compute runner labels
               id: labels
@@ -119,7 +119,7 @@ jobs:
 
             - name: Preserve runner state
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: scaleway-macos-state-${{ github.run_id }}-${{ github.run_attempt }}
                   path: tmp/processes/github-scaleway-runner.json
@@ -133,22 +133,22 @@ jobs:
         timeout-minutes: 45
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm
                   cache-dependency-path: pnpm-lock.yaml
 
             - name: Setup Go
-              uses: actions/setup-go@v6
+              uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
               with:
                   go-version: "1.24.x"
                   cache: false
@@ -176,10 +176,10 @@ jobs:
         timeout-minutes: 20
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Restore runner state
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               continue-on-error: true
               with:
                   name: scaleway-macos-state-${{ github.run_id }}-${{ github.run_attempt }}
@@ -210,7 +210,7 @@ jobs:
             runs_on: ${{ steps.labels.outputs.runs_on }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Compute runner labels
               id: labels
@@ -257,7 +257,7 @@ jobs:
 
             - name: Preserve runner state
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: scaleway-windows-state-${{ github.run_id }}-${{ github.run_attempt }}
                   path: tmp/processes/github-scaleway-windows-runner.json
@@ -271,21 +271,21 @@ jobs:
         timeout-minutes: 45
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   package-manager-cache: false
 
             - name: Setup Go
-              uses: actions/setup-go@v6
+              uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
               with:
                   go-version: "1.24.x"
                   cache: false
@@ -366,10 +366,10 @@ jobs:
         timeout-minutes: 20
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Restore runner state
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               continue-on-error: true
               with:
                   name: scaleway-windows-state-${{ github.run_id }}-${{ github.run_attempt }}
@@ -402,7 +402,7 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Check native runner resource limits
               shell: bash

--- a/.github/workflows/shared-fs-native-smoke.yml
+++ b/.github/workflows/shared-fs-native-smoke.yml
@@ -17,22 +17,22 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm
                   cache-dependency-path: pnpm-lock.yaml
 
             - name: Setup Go
-              uses: actions/setup-go@v6
+              uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
               with:
                   go-version: "1.24.x"
                   cache-dependency-path: packages/shared-fs/native/go.sum

--- a/.github/workflows/shared-fs-npm-install-smoke.yml
+++ b/.github/workflows/shared-fs-npm-install-smoke.yml
@@ -35,7 +35,7 @@ jobs:
 
         steps:
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   registry-url: https://registry.npmjs.org

--- a/.github/workflows/shared-fs-package-install.yml
+++ b/.github/workflows/shared-fs-package-install.yml
@@ -39,15 +39,15 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v5
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   run_install: false
 
             - name: Setup Node
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
               with:
                   node-version: 22
                   cache: pnpm

--- a/cloudflare/workflow-safety.test.mjs
+++ b/cloudflare/workflow-safety.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { repoRoot } from "../scripts/cloudflare-deployment-policy.mjs";
@@ -13,6 +13,56 @@ const productionWorkflow = readWorkflow("cloudflare-production.yml");
 const provisioningWorkflow = readWorkflow(
     "cloudflare-production-provision.yml"
 );
+
+const pinnedWorkflowActions = new Map([
+    ["actions/checkout", "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
+    ["actions/setup-node", "820762786026740c76f36085b0efc47a31fe5020"],
+    ["pnpm/action-setup", "0ebf47130e4866e96fce0953f49152a61190b271"],
+    ["actions/download-artifact", "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"],
+    ["actions/upload-artifact", "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"],
+    ["actions/setup-go", "924ae3a1cded613372ab5595356fb5720e22ba16"],
+    ["changesets/action", "a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d"],
+]);
+
+test("every remote workflow action is pinned to its reviewed commit", () => {
+    const workflowsDirectory = path.join(repoRoot, ".github/workflows");
+    const observedActions = new Set();
+
+    for (const name of readdirSync(workflowsDirectory).sort()) {
+        if (!/\.ya?ml$/.test(name)) {
+            continue;
+        }
+        const workflow = readFileSync(
+            path.join(workflowsDirectory, name),
+            "utf8"
+        );
+        for (const [index, line] of workflow.split("\n").entries()) {
+            const match = line.match(/^\s*uses:\s*([^\s#]+)/);
+            if (!match || match[1].startsWith("./")) {
+                continue;
+            }
+            const action = match[1].match(/^([^@]+)@([0-9a-f]{40})$/);
+            assert.ok(
+                action,
+                `${name}:${index + 1} must pin its remote action to an exact 40-character commit SHA`
+            );
+            const expectedCommit = pinnedWorkflowActions.get(action[1]);
+            assert.equal(
+                typeof expectedCommit,
+                "string",
+                `${name}:${index + 1} uses an unreviewed remote action: ${action[1]}`
+            );
+            assert.equal(
+                action[2],
+                expectedCommit,
+                `${name}:${index + 1} does not use the reviewed commit for ${action[1]}`
+            );
+            observedActions.add(action[1]);
+        }
+    }
+
+    assert.deepEqual(observedActions, new Set(pinnedWorkflowActions.keys()));
+});
 
 const receiptValidationScripts = () => {
     const stepMarker =


### PR DESCRIPTION
## Summary
- upgrade every third-party workflow action to its reviewed Node 24 release
- pin all 120 remote action invocations to exact commit SHAs
- add a repository-wide fail-closed allowlist test for workflow actions

## Validation
- all workflow YAML parsed successfully
- `node --test cloudflare/workflow-safety.test.mjs` (12/12)
- locked Wrangler toolchain validation
- `node --test cloudflare/*.test.mjs` (320/320)
- independent review: no P1/P2 findings

Authored and published as `peerbit-org`.