### PR TITLE
fix(media): deliver chunks to live subscribers

### DIFF
--- a/.changeset/fixed-live-stream-targets.md
+++ b/.changeset/fixed-live-stream-targets.md
@@ -1,0 +1,5 @@
+---
+"@peerbit/media-streaming": patch
+---
+
+Deliver newly appended media chunks to current live subscribers when `Track.put` uses its default replicator target.

--- a/packages/media-streaming/streaming-utils/src/__tests__/index.test.ts
+++ b/packages/media-streaming/streaming-utils/src/__tests__/index.test.ts
@@ -462,7 +462,7 @@ describe("MediaStream", () => {
         });
     });
     describe("live", () => {
-        test("one chunk", async () => {
+        test("delivers one chunk with the default target", async () => {
             const track1 = await streamer.open(
                 new Track({
                     sender: streamer.identity.publicKey,
@@ -492,7 +492,9 @@ describe("MediaStream", () => {
                 new Chunk({ time: 0, chunk: new Uint8Array([1, 2, 3]) })
             );
             await waitForResolved(() =>
-                expect(receivedChunks).to.have.length(1)
+                expect(receivedChunks.map((chunk) => chunk.timeBN)).to.deep.eq([
+                    0n,
+                ])
             );
         });
 

--- a/packages/media-streaming/streaming-utils/src/index.ts
+++ b/packages/media-streaming/streaming-utils/src/index.ts
@@ -425,9 +425,11 @@ export abstract class TrackSource {
             });
         } else {
             await this.endPreviousLivestreamSubscription();
+            // Keep the sender's full range fixed so intersecting live
+            // subscriptions participate in chunk leader selection.
             await this.chunks.log.replicate(
                 args === "streamer" || args === "all"
-                    ? { factor: 1 }
+                    ? { factor: 1, strict: true }
                     : (args ?? { factor: 1 })
             );
             return;


### PR DESCRIPTION
Makes the sender full-range replication intent strict so intersecting live subscriber ranges participate in default-target leader selection. This preserves sender retention and avoids delivering to passive non-live peers.\n\nValidation:\n- media streaming package build\n- focused one-chunk and second-chunk live tests, repeated 10 times (20 assertions)\n- independent review with no P0/P1/P2 findings\n\nThe pre-existing explicit target-all/fanout failure is intentionally tracked as a separate release-blocking repair.